### PR TITLE
feat(backend): initial schema migration + GORM models + migrate CLI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,7 @@ DATABASE_URL=postgres://offbook:offbook@localhost:5432/offbook?sslmode=disable
 # Backend
 PORT=8000
 FRONTEND_URL=http://localhost:5173
+MIGRATIONS_PATH=migrations
 
 # Plaid (optional — get keys at https://dashboard.plaid.com)
 PLAID_CLIENT_ID=

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,8 +6,8 @@
 - Lint: `cd backend && golangci-lint run`
 - Frontend: `cd frontend && pnpm dev`
 - Full stack: `docker compose up`
-- Migrations up: `cd backend && migrate -path migrations -database "$DATABASE_URL" up`
-- Migrations new: `migrate create -ext sql -dir backend/migrations -seq <name>`
+- Migrations: `cd backend && go run ./cmd/migrate {up|down|down-all|version|force <ver>}` (uses `.env`)
+- Migration files: name as `migrations/{NNNNNN}_{slug}.{up|down}.sql`, 6-digit zero-padded sequence
 
 ## Autonomous Workflow
 1. Read @docs/ROADMAP.md → find current milestone

--- a/backend/cmd/migrate/main.go
+++ b/backend/cmd/migrate/main.go
@@ -1,0 +1,112 @@
+// Migration CLI built into the repo. Use instead of a system `migrate` install.
+//
+//	go run ./cmd/migrate up             # apply all pending migrations
+//	go run ./cmd/migrate down           # roll back one step
+//	go run ./cmd/migrate down-all       # drop everything (dev only)
+//	go run ./cmd/migrate version        # print current version
+//	go run ./cmd/migrate force <ver>    # mark version <ver> as clean (recovery)
+package main
+
+import (
+	"database/sql"
+	"errors"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"strconv"
+
+	"github.com/golang-migrate/migrate/v4"
+	migratepg "github.com/golang-migrate/migrate/v4/database/postgres"
+	_ "github.com/golang-migrate/migrate/v4/source/file"
+	_ "github.com/lib/pq"
+
+	"github.com/gregwym/offbook/backend/internal/config"
+)
+
+func main() {
+	path := flag.String("path", "migrations", "migrations directory")
+	flag.Parse()
+
+	args := flag.Args()
+	if len(args) == 0 {
+		usage()
+		os.Exit(2)
+	}
+
+	cfg := config.Load()
+	if cfg.DatabaseURL == "" {
+		log.Fatal("DATABASE_URL is empty")
+	}
+
+	m, closeFn, err := newMigrator(cfg.DatabaseURL, *path)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer closeFn()
+
+	switch args[0] {
+	case "up":
+		if err := m.Up(); err != nil && !errors.Is(err, migrate.ErrNoChange) {
+			log.Fatalf("up: %v", err)
+		}
+		log.Println("up: OK")
+	case "down":
+		if err := m.Steps(-1); err != nil && !errors.Is(err, migrate.ErrNoChange) {
+			log.Fatalf("down: %v", err)
+		}
+		log.Println("down: OK")
+	case "down-all":
+		if err := m.Down(); err != nil && !errors.Is(err, migrate.ErrNoChange) {
+			log.Fatalf("down-all: %v", err)
+		}
+		log.Println("down-all: OK")
+	case "version":
+		v, dirty, err := m.Version()
+		if errors.Is(err, migrate.ErrNilVersion) {
+			fmt.Println("no migrations applied")
+			return
+		}
+		if err != nil {
+			log.Fatalf("version: %v", err)
+		}
+		fmt.Printf("version=%d dirty=%v\n", v, dirty)
+	case "force":
+		if len(args) < 2 {
+			log.Fatal("force requires a version argument")
+		}
+		v, err := strconv.Atoi(args[1])
+		if err != nil {
+			log.Fatalf("invalid version: %v", err)
+		}
+		if err := m.Force(v); err != nil {
+			log.Fatalf("force: %v", err)
+		}
+		log.Printf("force %d: OK", v)
+	default:
+		usage()
+		os.Exit(2)
+	}
+}
+
+func newMigrator(databaseURL, path string) (*migrate.Migrate, func(), error) {
+	sqlDB, err := sql.Open("postgres", databaseURL)
+	if err != nil {
+		return nil, nil, fmt.Errorf("sql.Open: %w", err)
+	}
+	driver, err := migratepg.WithInstance(sqlDB, &migratepg.Config{})
+	if err != nil {
+		sqlDB.Close()
+		return nil, nil, fmt.Errorf("migrate driver: %w", err)
+	}
+	m, err := migrate.NewWithDatabaseInstance("file://"+path, "postgres", driver)
+	if err != nil {
+		sqlDB.Close()
+		return nil, nil, fmt.Errorf("migrate.New: %w", err)
+	}
+	return m, func() { sqlDB.Close() }, nil
+}
+
+func usage() {
+	fmt.Fprintln(os.Stderr, "usage: migrate [-path <dir>] {up|down|down-all|version|force <ver>}")
+}

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -1,6 +1,8 @@
 package config
 
 import (
+	"errors"
+	"io/fs"
 	"os"
 
 	"github.com/joho/godotenv"
@@ -14,13 +16,25 @@ type Config struct {
 }
 
 func Load() Config {
-	_ = godotenv.Load()
+	// Load .env from cwd, then repo root (one level up), so commands work
+	// whether run from backend/ or the repo root. godotenv stops on the first
+	// missing file, so call once per candidate and ignore not-found errors.
+	loadDotenv(".env")
+	loadDotenv("../.env")
 
 	return Config{
 		Port:           getenv("PORT", "8000"),
 		DatabaseURL:    os.Getenv("DATABASE_URL"),
 		FrontendURL:    getenv("FRONTEND_URL", "http://localhost:5173"),
 		MigrationsPath: getenv("MIGRATIONS_PATH", "migrations"),
+	}
+}
+
+func loadDotenv(path string) {
+	if err := godotenv.Load(path); err != nil && !errors.Is(err, fs.ErrNotExist) {
+		// Real parse error — surface via stderr so the user notices, but don't crash.
+		// (Most callers want to keep going if the file is malformed.)
+		os.Stderr.WriteString("dotenv load " + path + ": " + err.Error() + "\n")
 	}
 }
 

--- a/backend/internal/model/account.go
+++ b/backend/internal/model/account.go
@@ -1,0 +1,26 @@
+package model
+
+import (
+	"time"
+
+	"github.com/shopspring/decimal"
+	"gorm.io/gorm"
+)
+
+type Account struct {
+	ID               int64           `gorm:"primaryKey" json:"id"`
+	Name             string          `gorm:"not null" json:"name"`
+	InstitutionSlug  string          `gorm:"not null" json:"institution_slug"`
+	AccountType      string          `gorm:"not null" json:"account_type"`
+	Currency         string          `gorm:"not null;default:USD" json:"currency"`
+	Balance          decimal.Decimal `gorm:"type:numeric(30,18);not null;default:0" json:"balance"`
+	LastFour         *string         `json:"last_four,omitempty"`
+	PlaidAccountID   *string         `gorm:"column:plaid_account_id" json:"plaid_account_id,omitempty"`
+	PlaidItemID      *string         `gorm:"column:plaid_item_id" json:"plaid_item_id,omitempty"`
+	IsActive         bool            `gorm:"not null;default:true" json:"is_active"`
+	CreatedAt        time.Time       `json:"created_at"`
+	UpdatedAt        time.Time       `json:"updated_at"`
+	DeletedAt        gorm.DeletedAt  `gorm:"index" json:"-"`
+}
+
+func (Account) TableName() string { return "accounts" }

--- a/backend/internal/model/ai_conversation.go
+++ b/backend/internal/model/ai_conversation.go
@@ -1,0 +1,19 @@
+package model
+
+import (
+	"time"
+
+	"gorm.io/gorm"
+)
+
+type AIConversation struct {
+	ID        int64          `gorm:"primaryKey" json:"id"`
+	Title     *string        `json:"title,omitempty"`
+	CreatedAt time.Time      `json:"created_at"`
+	UpdatedAt time.Time      `json:"updated_at"`
+	DeletedAt gorm.DeletedAt `gorm:"index" json:"-"`
+
+	Messages []AIMessage `gorm:"foreignKey:ConversationID" json:"-"`
+}
+
+func (AIConversation) TableName() string { return "ai_conversations" }

--- a/backend/internal/model/ai_message.go
+++ b/backend/internal/model/ai_message.go
@@ -1,0 +1,19 @@
+package model
+
+import (
+	"encoding/json"
+	"time"
+)
+
+type AIMessage struct {
+	ID              int64           `gorm:"primaryKey" json:"id"`
+	ConversationID  int64           `gorm:"not null" json:"conversation_id"`
+	Role            string          `gorm:"not null" json:"role"`
+	Content         string          `gorm:"not null" json:"content"`
+	ContextSnapshot json.RawMessage `gorm:"type:jsonb" json:"context_snapshot,omitempty"`
+	Provider        *string         `json:"provider,omitempty"`
+	ModelName       *string         `json:"model_name,omitempty"`
+	CreatedAt       time.Time       `json:"created_at"`
+}
+
+func (AIMessage) TableName() string { return "ai_messages" }

--- a/backend/internal/model/budget.go
+++ b/backend/internal/model/budget.go
@@ -1,0 +1,24 @@
+package model
+
+import (
+	"time"
+
+	"github.com/shopspring/decimal"
+	"gorm.io/gorm"
+)
+
+type Budget struct {
+	ID         int64           `gorm:"primaryKey" json:"id"`
+	CategoryID int64           `gorm:"not null" json:"category_id"`
+	Period     string          `gorm:"not null" json:"period"`
+	Amount     decimal.Decimal `gorm:"type:numeric(30,18);not null" json:"amount"`
+	Rollover   bool            `gorm:"not null;default:false" json:"rollover"`
+	IsActive   bool            `gorm:"not null;default:true" json:"is_active"`
+	CreatedAt  time.Time       `json:"created_at"`
+	UpdatedAt  time.Time       `json:"updated_at"`
+	DeletedAt  gorm.DeletedAt  `gorm:"index" json:"-"`
+
+	Category *Category `gorm:"foreignKey:CategoryID" json:"-"`
+}
+
+func (Budget) TableName() string { return "budgets" }

--- a/backend/internal/model/categorization_rule.go
+++ b/backend/internal/model/categorization_rule.go
@@ -1,0 +1,23 @@
+package model
+
+import (
+	"time"
+
+	"gorm.io/gorm"
+)
+
+type CategorizationRule struct {
+	ID         int64          `gorm:"primaryKey" json:"id"`
+	Pattern    string         `gorm:"not null" json:"pattern"`
+	CategoryID int64          `gorm:"not null" json:"category_id"`
+	MatchType  string         `gorm:"not null" json:"match_type"`
+	Priority   int            `gorm:"not null;default:0" json:"priority"`
+	IsActive   bool           `gorm:"not null;default:true" json:"is_active"`
+	CreatedAt  time.Time      `json:"created_at"`
+	UpdatedAt  time.Time      `json:"updated_at"`
+	DeletedAt  gorm.DeletedAt `gorm:"index" json:"-"`
+
+	Category *Category `gorm:"foreignKey:CategoryID" json:"-"`
+}
+
+func (CategorizationRule) TableName() string { return "categorization_rules" }

--- a/backend/internal/model/category.go
+++ b/backend/internal/model/category.go
@@ -1,0 +1,25 @@
+package model
+
+import (
+	"time"
+
+	"gorm.io/gorm"
+)
+
+type Category struct {
+	ID        int64          `gorm:"primaryKey" json:"id"`
+	ParentID  *int64         `json:"parent_id,omitempty"`
+	Name      string         `gorm:"not null" json:"name"`
+	Slug      string         `gorm:"not null" json:"slug"`
+	Icon      *string        `json:"icon,omitempty"`
+	Color     *string        `json:"color,omitempty"`
+	IsSystem  bool           `gorm:"not null;default:false" json:"is_system"`
+	CreatedAt time.Time      `json:"created_at"`
+	UpdatedAt time.Time      `json:"updated_at"`
+	DeletedAt gorm.DeletedAt `gorm:"index" json:"-"`
+
+	Parent   *Category  `gorm:"foreignKey:ParentID" json:"-"`
+	Children []Category `gorm:"foreignKey:ParentID" json:"-"`
+}
+
+func (Category) TableName() string { return "categories" }

--- a/backend/internal/model/ingestion_job.go
+++ b/backend/internal/model/ingestion_job.go
@@ -1,0 +1,21 @@
+package model
+
+import "time"
+
+type IngestionJob struct {
+	ID           int64      `gorm:"primaryKey" json:"id"`
+	Source       string     `gorm:"not null" json:"source"`
+	AccountID    *int64     `json:"account_id,omitempty"`
+	FileName     *string    `json:"file_name,omitempty"`
+	Status       string     `gorm:"not null;default:pending" json:"status"`
+	RowsTotal    *int       `json:"rows_total,omitempty"`
+	RowsImported *int       `json:"rows_imported,omitempty"`
+	ErrorMessage *string    `json:"error_message,omitempty"`
+	CreatedAt    time.Time  `json:"created_at"`
+	UpdatedAt    time.Time  `json:"updated_at"`
+	CompletedAt  *time.Time `json:"completed_at,omitempty"`
+
+	Account *Account `gorm:"foreignKey:AccountID" json:"-"`
+}
+
+func (IngestionJob) TableName() string { return "ingestion_jobs" }

--- a/backend/internal/model/investment.go
+++ b/backend/internal/model/investment.go
@@ -1,0 +1,25 @@
+package model
+
+import (
+	"time"
+
+	"github.com/shopspring/decimal"
+)
+
+type Investment struct {
+	ID           int64            `gorm:"primaryKey" json:"id"`
+	AccountID    int64            `gorm:"not null" json:"account_id"`
+	Ticker       string           `gorm:"not null" json:"ticker"`
+	Name         *string          `json:"name,omitempty"`
+	AssetClass   *string          `json:"asset_class,omitempty"`
+	Quantity     decimal.Decimal  `gorm:"type:numeric(30,18);not null" json:"quantity"`
+	CostBasis    *decimal.Decimal `gorm:"type:numeric(30,18)" json:"cost_basis,omitempty"`
+	MarketValue  *decimal.Decimal `gorm:"type:numeric(30,18)" json:"market_value,omitempty"`
+	SnapshotDate time.Time        `gorm:"type:date;not null" json:"snapshot_date"`
+	Source       string           `gorm:"not null" json:"source"`
+	CreatedAt    time.Time        `json:"created_at"`
+
+	Account *Account `gorm:"foreignKey:AccountID" json:"-"`
+}
+
+func (Investment) TableName() string { return "investments" }

--- a/backend/internal/model/pii_record.go
+++ b/backend/internal/model/pii_record.go
@@ -1,0 +1,17 @@
+package model
+
+import "time"
+
+// PIIRecord is a row in pii_store — the ONLY table that holds PII.
+// Only pii_repo may read/write this model (see ARCHITECTURE.md "PII Isolation").
+type PIIRecord struct {
+	ID         int64     `gorm:"primaryKey" json:"id"`
+	EntityType string    `gorm:"not null" json:"entity_type"`
+	EntityID   int64     `gorm:"not null" json:"entity_id"`
+	FieldName  string    `gorm:"not null" json:"field_name"`
+	Value      string    `gorm:"not null" json:"value"`
+	CreatedAt  time.Time `json:"created_at"`
+	UpdatedAt  time.Time `json:"updated_at"`
+}
+
+func (PIIRecord) TableName() string { return "pii_store" }

--- a/backend/internal/model/savings_goal.go
+++ b/backend/internal/model/savings_goal.go
@@ -1,0 +1,24 @@
+package model
+
+import (
+	"time"
+
+	"github.com/shopspring/decimal"
+	"gorm.io/gorm"
+)
+
+type SavingsGoal struct {
+	ID            int64           `gorm:"primaryKey" json:"id"`
+	Name          string          `gorm:"not null" json:"name"`
+	TargetAmount  decimal.Decimal `gorm:"type:numeric(30,18);not null" json:"target_amount"`
+	CurrentAmount decimal.Decimal `gorm:"type:numeric(30,18);not null;default:0" json:"current_amount"`
+	TargetDate    *time.Time      `gorm:"type:date" json:"target_date,omitempty"`
+	AccountID     *int64          `json:"account_id,omitempty"`
+	CreatedAt     time.Time       `json:"created_at"`
+	UpdatedAt     time.Time       `json:"updated_at"`
+	DeletedAt     gorm.DeletedAt  `gorm:"index" json:"-"`
+
+	Account *Account `gorm:"foreignKey:AccountID" json:"-"`
+}
+
+func (SavingsGoal) TableName() string { return "savings_goals" }

--- a/backend/internal/model/transaction.go
+++ b/backend/internal/model/transaction.go
@@ -1,0 +1,37 @@
+package model
+
+import (
+	"time"
+
+	"github.com/shopspring/decimal"
+	"gorm.io/gorm"
+)
+
+type Transaction struct {
+	ID                    int64           `gorm:"primaryKey" json:"id"`
+	AccountID             int64           `gorm:"not null" json:"account_id"`
+	CategoryID            *int64          `json:"category_id,omitempty"`
+	Amount                decimal.Decimal `gorm:"type:numeric(30,18);not null" json:"amount"`
+	Currency              string          `gorm:"not null;default:USD" json:"currency"`
+	Description           *string         `json:"description,omitempty"`
+	DescriptionClean      *string         `json:"description_clean,omitempty"`
+	MerchantName          *string         `json:"merchant_name,omitempty"`
+	TransactionDate       time.Time       `gorm:"type:date;not null" json:"transaction_date"`
+	PostedDate            *time.Time      `gorm:"type:date" json:"posted_date,omitempty"`
+	Source                string          `gorm:"not null" json:"source"`
+	ExternalID            *string         `gorm:"column:external_id" json:"external_id,omitempty"`
+	PlaidTransactionID    *string         `gorm:"column:plaid_transaction_id" json:"plaid_transaction_id,omitempty"`
+	CategorizationMethod  *string         `json:"categorization_method,omitempty"`
+	IsTransfer            bool            `gorm:"not null;default:false" json:"is_transfer"`
+	TransferPairID        *int64          `json:"transfer_pair_id,omitempty"`
+	Notes                 *string         `json:"notes,omitempty"`
+	CreatedAt             time.Time       `json:"created_at"`
+	UpdatedAt             time.Time       `json:"updated_at"`
+	DeletedAt             gorm.DeletedAt  `gorm:"index" json:"-"`
+
+	Account      *Account     `gorm:"foreignKey:AccountID" json:"-"`
+	Category     *Category    `gorm:"foreignKey:CategoryID" json:"-"`
+	TransferPair *Transaction `gorm:"foreignKey:TransferPairID" json:"-"`
+}
+
+func (Transaction) TableName() string { return "transactions" }

--- a/backend/migrations/000001_init.down.sql
+++ b/backend/migrations/000001_init.down.sql
@@ -1,0 +1,15 @@
+BEGIN;
+
+DROP TABLE IF EXISTS ingestion_jobs;
+DROP TABLE IF EXISTS pii_store;
+DROP TABLE IF EXISTS ai_messages;
+DROP TABLE IF EXISTS ai_conversations;
+DROP TABLE IF EXISTS investments;
+DROP TABLE IF EXISTS savings_goals;
+DROP TABLE IF EXISTS budgets;
+DROP TABLE IF EXISTS categorization_rules;
+DROP TABLE IF EXISTS transactions;
+DROP TABLE IF EXISTS accounts;
+DROP TABLE IF EXISTS categories;
+
+COMMIT;

--- a/backend/migrations/000001_init.up.sql
+++ b/backend/migrations/000001_init.up.sql
@@ -1,0 +1,202 @@
+BEGIN;
+
+-- categories: hierarchical, system-seeded + user-added
+CREATE TABLE categories (
+    id          BIGSERIAL PRIMARY KEY,
+    parent_id   BIGINT REFERENCES categories(id) ON DELETE SET NULL,
+    name        TEXT NOT NULL,
+    slug        TEXT NOT NULL,
+    icon        TEXT,
+    color       TEXT,
+    is_system   BOOLEAN NOT NULL DEFAULT FALSE,
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    deleted_at  TIMESTAMPTZ
+);
+CREATE UNIQUE INDEX uq_categories_slug ON categories (slug) WHERE deleted_at IS NULL;
+CREATE INDEX ix_categories_parent_id ON categories (parent_id) WHERE deleted_at IS NULL;
+
+-- accounts: user-labeled financial accounts. PII (holder name, account number) lives in pii_store.
+CREATE TABLE accounts (
+    id                  BIGSERIAL PRIMARY KEY,
+    name                TEXT NOT NULL,
+    institution_slug    TEXT NOT NULL,
+    account_type        TEXT NOT NULL CHECK (account_type IN ('checking','savings','credit_card','loan','investment','crypto','cash','other')),
+    currency            TEXT NOT NULL DEFAULT 'USD',
+    balance             NUMERIC(30, 18) NOT NULL DEFAULT 0,
+    last_four           TEXT,
+    plaid_account_id    TEXT,
+    plaid_item_id       TEXT,
+    is_active           BOOLEAN NOT NULL DEFAULT TRUE,
+    created_at          TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at          TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    deleted_at          TIMESTAMPTZ
+);
+CREATE UNIQUE INDEX uq_accounts_plaid_account_id
+    ON accounts (plaid_account_id)
+    WHERE deleted_at IS NULL AND plaid_account_id IS NOT NULL;
+CREATE INDEX ix_accounts_institution_slug ON accounts (institution_slug) WHERE deleted_at IS NULL;
+CREATE INDEX ix_accounts_plaid_item_id ON accounts (plaid_item_id) WHERE deleted_at IS NULL AND plaid_item_id IS NOT NULL;
+
+-- transactions: source of truth for all line items. transfer_pair_id links matched transfers.
+CREATE TABLE transactions (
+    id                      BIGSERIAL PRIMARY KEY,
+    account_id              BIGINT NOT NULL REFERENCES accounts(id),
+    category_id             BIGINT REFERENCES categories(id) ON DELETE SET NULL,
+    amount                  NUMERIC(30, 18) NOT NULL,
+    currency                TEXT NOT NULL DEFAULT 'USD',
+    description             TEXT,
+    description_clean       TEXT,
+    merchant_name           TEXT,
+    transaction_date        DATE NOT NULL,
+    posted_date             DATE,
+    source                  TEXT NOT NULL CHECK (source IN ('plaid','csv','pdf','manual')),
+    external_id             TEXT,
+    plaid_transaction_id    TEXT,
+    categorization_method   TEXT,
+    is_transfer             BOOLEAN NOT NULL DEFAULT FALSE,
+    transfer_pair_id        BIGINT REFERENCES transactions(id) ON DELETE SET NULL,
+    notes                   TEXT,
+    created_at              TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at              TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    deleted_at              TIMESTAMPTZ
+);
+CREATE UNIQUE INDEX uq_transactions_external
+    ON transactions (account_id, external_id)
+    WHERE deleted_at IS NULL AND external_id IS NOT NULL;
+CREATE UNIQUE INDEX uq_transactions_plaid
+    ON transactions (plaid_transaction_id)
+    WHERE deleted_at IS NULL AND plaid_transaction_id IS NOT NULL;
+CREATE INDEX ix_transactions_account_date
+    ON transactions (account_id, transaction_date DESC)
+    WHERE deleted_at IS NULL;
+CREATE INDEX ix_transactions_category_id
+    ON transactions (category_id)
+    WHERE deleted_at IS NULL AND category_id IS NOT NULL;
+CREATE INDEX ix_transactions_transfer_pair_id
+    ON transactions (transfer_pair_id)
+    WHERE deleted_at IS NULL AND transfer_pair_id IS NOT NULL;
+
+-- categorization_rules: ordered by priority; first match wins
+CREATE TABLE categorization_rules (
+    id          BIGSERIAL PRIMARY KEY,
+    pattern     TEXT NOT NULL,
+    category_id BIGINT NOT NULL REFERENCES categories(id),
+    match_type  TEXT NOT NULL CHECK (match_type IN ('contains','regex','exact')),
+    priority    INTEGER NOT NULL DEFAULT 0,
+    is_active   BOOLEAN NOT NULL DEFAULT TRUE,
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    deleted_at  TIMESTAMPTZ
+);
+CREATE INDEX ix_categorization_rules_priority
+    ON categorization_rules (priority DESC, id)
+    WHERE deleted_at IS NULL AND is_active = TRUE;
+CREATE INDEX ix_categorization_rules_category_id
+    ON categorization_rules (category_id)
+    WHERE deleted_at IS NULL;
+
+-- budgets: per-category spend limits per period
+CREATE TABLE budgets (
+    id          BIGSERIAL PRIMARY KEY,
+    category_id BIGINT NOT NULL REFERENCES categories(id),
+    period      TEXT NOT NULL CHECK (period IN ('monthly','weekly','annual')),
+    amount      NUMERIC(30, 18) NOT NULL,
+    rollover    BOOLEAN NOT NULL DEFAULT FALSE,
+    is_active   BOOLEAN NOT NULL DEFAULT TRUE,
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    deleted_at  TIMESTAMPTZ
+);
+CREATE UNIQUE INDEX uq_budgets_category_period
+    ON budgets (category_id, period)
+    WHERE deleted_at IS NULL AND is_active = TRUE;
+
+-- savings_goals: named targets, optionally linked to an account
+CREATE TABLE savings_goals (
+    id              BIGSERIAL PRIMARY KEY,
+    name            TEXT NOT NULL,
+    target_amount   NUMERIC(30, 18) NOT NULL,
+    current_amount  NUMERIC(30, 18) NOT NULL DEFAULT 0,
+    target_date     DATE,
+    account_id      BIGINT REFERENCES accounts(id) ON DELETE SET NULL,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    deleted_at      TIMESTAMPTZ
+);
+CREATE INDEX ix_savings_goals_account_id
+    ON savings_goals (account_id)
+    WHERE deleted_at IS NULL AND account_id IS NOT NULL;
+
+-- investments: append-only snapshots. NUMERIC(30,18) supports crypto precision.
+CREATE TABLE investments (
+    id              BIGSERIAL PRIMARY KEY,
+    account_id      BIGINT NOT NULL REFERENCES accounts(id),
+    ticker          TEXT NOT NULL,
+    name            TEXT,
+    asset_class     TEXT,
+    quantity        NUMERIC(30, 18) NOT NULL,
+    cost_basis      NUMERIC(30, 18),
+    market_value    NUMERIC(30, 18),
+    snapshot_date   DATE NOT NULL,
+    source          TEXT NOT NULL CHECK (source IN ('plaid','csv','manual')),
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX ix_investments_account_snapshot
+    ON investments (account_id, snapshot_date DESC);
+CREATE INDEX ix_investments_ticker
+    ON investments (ticker, snapshot_date DESC);
+
+-- ai_conversations: a chat thread with the AI advisor
+CREATE TABLE ai_conversations (
+    id          BIGSERIAL PRIMARY KEY,
+    title       TEXT,
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    deleted_at  TIMESTAMPTZ
+);
+
+-- ai_messages: individual turns. context_snapshot records the anonymized DB context passed to the LLM.
+CREATE TABLE ai_messages (
+    id                  BIGSERIAL PRIMARY KEY,
+    conversation_id     BIGINT NOT NULL REFERENCES ai_conversations(id) ON DELETE CASCADE,
+    role                TEXT NOT NULL CHECK (role IN ('user','assistant','system')),
+    content             TEXT NOT NULL,
+    context_snapshot    JSONB,
+    provider            TEXT,
+    model_name          TEXT,
+    created_at          TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX ix_ai_messages_conversation_created
+    ON ai_messages (conversation_id, created_at);
+
+-- pii_store: the ONLY table that holds PII. No FK to other tables (PII isolation).
+CREATE TABLE pii_store (
+    id          BIGSERIAL PRIMARY KEY,
+    entity_type TEXT NOT NULL,
+    entity_id   BIGINT NOT NULL,
+    field_name  TEXT NOT NULL,
+    value       TEXT NOT NULL,
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (entity_type, entity_id, field_name)
+);
+
+-- ingestion_jobs: tracks CSV/PDF upload jobs. Append-only audit trail.
+CREATE TABLE ingestion_jobs (
+    id              BIGSERIAL PRIMARY KEY,
+    source          TEXT NOT NULL CHECK (source IN ('csv','pdf')),
+    account_id      BIGINT REFERENCES accounts(id) ON DELETE SET NULL,
+    file_name       TEXT,
+    status          TEXT NOT NULL CHECK (status IN ('pending','processing','completed','failed')) DEFAULT 'pending',
+    rows_total      INTEGER,
+    rows_imported   INTEGER,
+    error_message   TEXT,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    completed_at    TIMESTAMPTZ
+);
+CREATE INDEX ix_ingestion_jobs_status_created
+    ON ingestion_jobs (status, created_at DESC);
+
+COMMIT;


### PR DESCRIPTION
Closes #3

## Summary
- `migrations/000001_init.{up,down}.sql` — 11 tables matching `docs/ARCHITECTURE.md`. All money columns `NUMERIC(30,18)`, all timestamps `TIMESTAMPTZ`, all PKs `BIGSERIAL`/`BIGINT`. Soft-delete-safe UNIQUE constraints implemented as **partial indexes WHERE deleted_at IS NULL**.
- `internal/model/` — one GORM model per table. `shopspring/decimal` for money, `gorm.DeletedAt` for soft delete, `json.RawMessage` for `ai_messages.context_snapshot` (JSONB). `PIIRecord` has a doc comment flagging it as `pii_repo`-only.
- `cmd/migrate/` — in-repo migration CLI (`go run ./cmd/migrate {up|down|down-all|version|force}`). Wraps `golang-migrate` so operators don't need a system `migrate` binary.
- Config now loads `.env` from `cwd` then `../.env`, so commands work from `backend/` or repo root.
- CLAUDE.md updated to reference the in-repo `cmd/migrate` instead of a system binary; documents migration file naming convention.

## Schema highlights
- `transactions`: composite index `(account_id, transaction_date DESC)`, partial-unique `(account_id, external_id)` and `(plaid_transaction_id)`, self-ref `transfer_pair_id`.
- `pii_store`: BIGSERIAL PK, BIGINT `entity_id`, `UNIQUE(entity_type, entity_id, field_name)`, **no FK by design** — PII isolation.
- `investments`: append-only (no `deleted_at`), index `(account_id, snapshot_date DESC)`.
- `categorization_rules`: index `(priority DESC, id)` for first-match-wins lookup.
- `ai_messages`: `ON DELETE CASCADE` from `ai_conversations`.

## New table not in ARCHITECTURE.md
- `ingestion_jobs` (was in issue #3 scope but missing from docs): tracks CSV/PDF upload jobs (`source`, `status`, `rows_total`, `rows_imported`, `error_message`). Append-only. ARCHITECTURE.md can be updated separately if desired.

## Test plan
- [x] `go build ./...` + `go vet ./...` clean
- [x] `go run ./cmd/migrate up` → all 11 tables present (`\dt`)
- [x] `\d transactions` confirms `NUMERIC(30,18)`, `TIMESTAMPTZ`, partial unique indexes, self-ref FK, CHECK on `source`
- [x] `\d pii_store` confirms `UNIQUE(entity_type, entity_id, field_name)`, `BIGINT entity_id`, no FKs
- [x] `go run ./cmd/migrate down` drops tables; `up` rebuilds cleanly. Idempotent.
- [x] `go run ./cmd/migrate version` reports `version=1 dirty=false`
- [ ] Reviewer: `cd backend && go run ./cmd/migrate up` against a fresh Postgres; verify schema.