### PR TITLE
feat(backend): seed 20 system categories

### DIFF
--- a/backend/migrations/000002_seed_categories.down.sql
+++ b/backend/migrations/000002_seed_categories.down.sql
@@ -1,0 +1,5 @@
+-- Remove only system-seeded rows. User-created categories (is_system = FALSE)
+-- are preserved.
+DELETE FROM categories
+WHERE is_system = TRUE
+  AND deleted_at IS NULL;

--- a/backend/migrations/000002_seed_categories.up.sql
+++ b/backend/migrations/000002_seed_categories.up.sql
@@ -1,0 +1,26 @@
+-- Seed system categories. Re-runnable: ON CONFLICT on the partial unique
+-- index (slug WHERE deleted_at IS NULL) makes this a no-op on a populated DB.
+-- Icons are Lucide React names (lucide.dev/icons). Colors are 6-digit hex.
+
+INSERT INTO categories (name, slug, icon, color, is_system) VALUES
+    ('Food & Dining',     'food-and-dining',    'utensils',         '#F59E0B', TRUE),
+    ('Groceries',         'groceries',          'shopping-cart',    '#84CC16', TRUE),
+    ('Transportation',    'transportation',     'car',              '#3B82F6', TRUE),
+    ('Gas',               'gas',                'fuel',             '#F97316', TRUE),
+    ('Housing',           'housing',            'home',             '#6366F1', TRUE),
+    ('Rent/Mortgage',     'rent-mortgage',      'building',         '#8B5CF6', TRUE),
+    ('Utilities',         'utilities',          'zap',              '#EAB308', TRUE),
+    ('Healthcare',        'healthcare',         'heart-pulse',      '#EC4899', TRUE),
+    ('Insurance',         'insurance',          'shield',           '#14B8A6', TRUE),
+    ('Entertainment',     'entertainment',      'film',             '#A855F7', TRUE),
+    ('Shopping',          'shopping',           'shopping-bag',     '#06B6D4', TRUE),
+    ('Clothing',          'clothing',           'shirt',            '#D946EF', TRUE),
+    ('Education',         'education',          'graduation-cap',   '#0EA5E9', TRUE),
+    ('Personal Care',     'personal-care',      'sparkles',         '#F43F5E', TRUE),
+    ('Gifts & Donations', 'gifts-and-donations','gift',             '#10B981', TRUE),
+    ('Travel',            'travel',             'plane',            '#22D3EE', TRUE),
+    ('Subscriptions',     'subscriptions',      'repeat',           '#6B7280', TRUE),
+    ('Fees & Charges',    'fees-and-charges',   'receipt',          '#EF4444', TRUE),
+    ('Income',            'income',             'dollar-sign',      '#16A34A', TRUE),
+    ('Transfer',          'transfer',           'arrow-left-right', '#64748B', TRUE)
+ON CONFLICT (slug) WHERE deleted_at IS NULL DO NOTHING;


### PR DESCRIPTION
Closes #4

## Summary
- `migrations/000002_seed_categories.up.sql` inserts the 20 system categories from issue #4 with `is_system = TRUE`, each carrying a Lucide React icon name and a 6-digit hex color.
- Re-runnable via `ON CONFLICT (slug) WHERE deleted_at IS NULL DO NOTHING` (matches the partial unique index from #3).
- Down migration deletes only `is_system = TRUE` rows — user-created categories survive a `down` + `up` cycle.

## Categories (slug, icon, color)
food-and-dining (utensils, #F59E0B), groceries (shopping-cart, #84CC16), transportation (car, #3B82F6), gas (fuel, #F97316), housing (home, #6366F1), rent-mortgage (building, #8B5CF6), utilities (zap, #EAB308), healthcare (heart-pulse, #EC4899), insurance (shield, #14B8A6), entertainment (film, #A855F7), shopping (shopping-bag, #06B6D4), clothing (shirt, #D946EF), education (graduation-cap, #0EA5E9), personal-care (sparkles, #F43F5E), gifts-and-donations (gift, #10B981), travel (plane, #22D3EE), subscriptions (repeat, #6B7280), fees-and-charges (receipt, #EF4444), income (dollar-sign, #16A34A), transfer (arrow-left-right, #64748B).

## Test plan
- [x] `go run ./cmd/migrate up` → 20 rows where `is_system = TRUE`
- [x] Re-running the seed SQL by hand → still 20 (ON CONFLICT works)
- [x] Insert a user category (`is_system = FALSE`), `go run ./cmd/migrate down` → 0 system rows, user row preserved
- [x] `go run ./cmd/migrate up` again → 20 system rows back
- [ ] Reviewer: `go run ./cmd/migrate up`, query `SELECT slug, icon, color FROM categories WHERE is_system`