### PR TITLE
Wire up Docker Compose for backend + frontend + postgres

### DIFF
--- a/backend/.air.toml
+++ b/backend/.air.toml
@@ -1,0 +1,17 @@
+root = "."
+tmp_dir = "tmp"
+
+[build]
+  cmd = "go build -o ./tmp/server ./cmd/server"
+  bin = "tmp/server"
+  full_bin = "/app/tmp/server"
+  include_ext = ["go"]
+  exclude_dir = ["tmp", "data", "migrations"]
+  delay = 500
+  stop_on_error = true
+
+[log]
+  time = true
+
+[misc]
+  clean_on_exit = true

--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,7 @@
+.git
+.gitignore
+.env
+.env.*
+*.md
+tmp/
+data/

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,19 @@
+# syntax=docker/dockerfile:1.7
+FROM golang:1.26-alpine AS build
+WORKDIR /src
+RUN apk add --no-cache git ca-certificates
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 GOOS=linux go build -trimpath -ldflags="-s -w" -o /out/server ./cmd/server
+
+FROM alpine:3.19
+RUN apk add --no-cache ca-certificates tzdata && adduser -D -u 10001 app
+WORKDIR /app
+COPY --from=build /out/server /app/server
+COPY migrations /app/migrations
+ENV MIGRATIONS_PATH=/app/migrations \
+    PORT=8000
+USER app
+EXPOSE 8000
+ENTRYPOINT ["/app/server"]

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,41 @@
+# Dev override: live reload for backend (air) and Vite dev server for frontend.
+# Usage:  docker compose -f docker-compose.yml -f docker-compose.dev.yml up
+services:
+  backend:
+    image: cosmtrek/air:latest
+    build: !reset null
+    working_dir: /app
+    entrypoint: ["air", "-c", ".air.toml"]
+    volumes:
+      - ./backend:/app
+      - backend_go_mod:/go/pkg/mod
+    environment:
+      DATABASE_URL: postgres://offbook:offbook@postgres:5432/offbook?sslmode=disable
+      PORT: "8000"
+      FRONTEND_URL: http://localhost:5173
+      MIGRATIONS_PATH: /app/migrations
+    healthcheck:
+      disable: true
+
+  frontend:
+    image: node:22-alpine
+    build: !reset null
+    working_dir: /app
+    entrypoint: ["sh", "-c"]
+    command:
+      - |
+        corepack enable
+        pnpm install --frozen-lockfile
+        pnpm dev --host 0.0.0.0 --port 5173
+    ports: !override
+      - "5173:5173"
+    volumes:
+      - ./frontend:/app
+      - frontend_node_modules:/app/node_modules
+    environment:
+      VITE_API_BASE_URL: ""
+      VITE_PROXY_TARGET: http://backend:8000
+
+volumes:
+  backend_go_mod:
+  frontend_node_modules:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,10 +10,10 @@ services:
     volumes:
       - ./data/postgres:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U offbook"]
+      test: ["CMD-SHELL", "pg_isready -U offbook -d offbook"]
       interval: 5s
       timeout: 5s
-      retries: 5
+      retries: 10
 
   backend:
     build:
@@ -25,18 +25,26 @@ services:
       DATABASE_URL: postgres://offbook:offbook@postgres:5432/offbook?sslmode=disable
       PORT: "8000"
       FRONTEND_URL: http://localhost:5173
+      MIGRATIONS_PATH: /app/migrations
     env_file:
       - path: .env
         required: false
     depends_on:
       postgres:
         condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost:8000/api/v1/health || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
 
   frontend:
     build:
       context: ./frontend
       dockerfile: Dockerfile
     ports:
-      - "5173:5173"
+      - "5173:80"
     depends_on:
-      - backend
+      backend:
+        condition: service_started

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,7 @@
+.git
+.gitignore
+.env
+.env.*
+node_modules
+dist
+*.md

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -11,6 +11,7 @@ node_modules
 dist
 dist-ssr
 *.local
+.pnpm-store/
 
 # Editor directories and files
 .vscode/*

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,13 @@
+# syntax=docker/dockerfile:1.7
+FROM node:22-alpine AS build
+WORKDIR /src
+RUN corepack enable
+COPY package.json pnpm-lock.yaml ./
+RUN pnpm install --frozen-lockfile
+COPY . .
+RUN pnpm build
+
+FROM nginx:alpine
+COPY --from=build /src/dist /usr/share/nginx/html
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+EXPOSE 80

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,0 +1,28 @@
+server {
+    listen 80;
+    server_name _;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # SPA fallback — all unknown routes serve index.html for client-side routing.
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    # Proxy API calls to the backend service on the compose network.
+    location /api/ {
+        proxy_pass http://backend:8000;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # Long cache for hashed asset files.
+    location /assets/ {
+        expires 1y;
+        access_log off;
+        add_header Cache-Control "public, immutable";
+    }
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,17 +1,23 @@
-import { defineConfig } from 'vite'
+import { defineConfig, loadEnv } from 'vite'
 import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
 
 // https://vite.dev/config/
-export default defineConfig({
-  plugins: [react(), tailwindcss()],
-  server: {
-    port: 5173,
-    proxy: {
-      '/api': {
-        target: 'http://localhost:8000',
-        changeOrigin: true,
+export default defineConfig(({ mode }) => {
+  // VITE_PROXY_TARGET points at the backend host. On the host it's localhost;
+  // inside docker-compose.dev it's set to http://backend:8000.
+  const env = loadEnv(mode, process.cwd(), '')
+  const proxyTarget = env.VITE_PROXY_TARGET || 'http://localhost:8000'
+  return {
+    plugins: [react(), tailwindcss()],
+    server: {
+      port: 5173,
+      proxy: {
+        '/api': {
+          target: proxyTarget,
+          changeOrigin: true,
+        },
       },
     },
-  },
+  }
 })


### PR DESCRIPTION
## Summary
- Multi-stage `backend/Dockerfile` (golang:1.26-alpine → alpine:3.19) shipping the migrate-on-startup binary and migrations dir
- `frontend/Dockerfile` (node:22-alpine build → nginx:alpine) with SPA fallback + `/api/` reverse proxy to the `backend` service
- `docker-compose.yml`: postgres healthcheck gates backend, backend healthcheck via `wget`, frontend port 5173→80
- `docker-compose.dev.yml` override: `cosmtrek/air` for Go hot reload, `node:22-alpine` running `vite dev` with bind-mounts; `VITE_PROXY_TARGET=http://backend:8000` so the in-container Vite proxy reaches the backend service
- `vite.config.ts` reads `VITE_PROXY_TARGET` (defaults to `http://localhost:8000` on the host)
- Postgres data persisted at `./data/postgres/`

## Test plan
- [x] `docker compose build` succeeds for backend + frontend
- [x] `docker compose up -d` → all three services report healthy
- [x] `curl http://localhost:8000/api/v1/health` → `{"status":"ok"}`
- [x] `curl http://localhost:5173/` → 200, SPA routes (`/accounts`) → 200
- [x] `curl http://localhost:5173/api/v1/health` → `{"status":"ok"}` (nginx → backend)
- [x] Migrations + seed (20 system categories) applied automatically on first boot
- [x] `docker compose down && docker compose up -d` → seeded data survives via `./data/postgres/` volume
- [x] `docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d` → air builds, vite dev serves, `/api` proxies to backend service

Closes #6