### PR TITLE
Configure golangci-lint v2 (run via Docker)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,7 +3,7 @@
 ## Commands
 - Backend: `cd backend && go run cmd/server/main.go`
 - Tests: `cd backend && go test ./...`
-- Lint: `cd backend && golangci-lint run`
+- Lint: `cd backend && docker run --rm -v "$PWD":/app -w /app golangci/golangci-lint:latest-alpine golangci-lint run ./...`
 - Frontend: `cd frontend && pnpm dev`
 - Full stack: `docker compose up`
 - Migrations: `cd backend && go run ./cmd/migrate {up|down|down-all|version|force <ver>}` (uses `.env`)

--- a/backend/.golangci.yml
+++ b/backend/.golangci.yml
@@ -1,0 +1,23 @@
+version: "2"
+
+run:
+  timeout: 5m
+  tests: true
+
+linters:
+  default: none
+  enable:
+    - errcheck       # unhandled errors
+    - govet          # shadowing, struct tags, suspicious constructs
+    - ineffassign    # ineffective assignments
+    - staticcheck    # bugs + simplifications (subsumes gosimple in v2)
+    - unused         # dead code
+
+  exclusions:
+    paths:
+      - migrations
+    rules:
+      # Test files often deliberately ignore Close() / Delete() return values
+      # during cleanup; muting errcheck there keeps the noise out.
+      - path: _test\.go
+        linters: [errcheck]

--- a/backend/cmd/migrate/main.go
+++ b/backend/cmd/migrate/main.go
@@ -96,15 +96,15 @@ func newMigrator(databaseURL, path string) (*migrate.Migrate, func(), error) {
 	}
 	driver, err := migratepg.WithInstance(sqlDB, &migratepg.Config{})
 	if err != nil {
-		sqlDB.Close()
+		_ = sqlDB.Close()
 		return nil, nil, fmt.Errorf("migrate driver: %w", err)
 	}
 	m, err := migrate.NewWithDatabaseInstance("file://"+path, "postgres", driver)
 	if err != nil {
-		sqlDB.Close()
+		_ = sqlDB.Close()
 		return nil, nil, fmt.Errorf("migrate.New: %w", err)
 	}
-	return m, func() { sqlDB.Close() }, nil
+	return m, func() { _ = sqlDB.Close() }, nil
 }
 
 func usage() {

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -34,7 +34,7 @@ func loadDotenv(path string) {
 	if err := godotenv.Load(path); err != nil && !errors.Is(err, fs.ErrNotExist) {
 		// Real parse error — surface via stderr so the user notices, but don't crash.
 		// (Most callers want to keep going if the file is malformed.)
-		os.Stderr.WriteString("dotenv load " + path + ": " + err.Error() + "\n")
+		_, _ = os.Stderr.WriteString("dotenv load " + path + ": " + err.Error() + "\n")
 	}
 }
 

--- a/backend/internal/db/migrate.go
+++ b/backend/internal/db/migrate.go
@@ -26,7 +26,7 @@ func RunMigrations(databaseURL, migrationsPath string) error {
 	if err != nil {
 		return fmt.Errorf("sql.Open: %w", err)
 	}
-	defer sqlDB.Close()
+	defer func() { _ = sqlDB.Close() }()
 
 	driver, err := migratepg.WithInstance(sqlDB, &migratepg.Config{})
 	if err != nil {


### PR DESCRIPTION
## Summary
- `backend/.golangci.yml` (v2 config) enabling `errcheck`, `govet`, `staticcheck`, `ineffassign`, `unused` — the high-value set from the issue. `migrations/` excluded; `errcheck` muted in `_test.go` so cleanup unscoped deletes can ignore returns.
- Lint runs via the official `golangci/golangci-lint:latest-alpine` Docker image, matching the project policy of keeping dev dependencies portable rather than `go install`-ing or `brew install`-ing tools.
- Fixed four pre-existing `errcheck` findings: unchecked `sql.DB.Close()` calls in `cmd/migrate/main.go` and `internal/db/migrate.go`, plus an unchecked `os.Stderr.WriteString` in `internal/config/config.go`.
- Updated `CLAUDE.md` lint command to the Docker invocation.

## Test plan
- [x] `docker run --rm -v "$PWD":/app -w /app golangci/golangci-lint:latest-alpine golangci-lint run ./...` → `0 issues`
- [x] `go test ./...` still passes
- [x] `go vet ./...` still passes (pre-commit hook unaffected)

Closes #8