### PR TITLE
M2 #26: Accounts CRUD backend (handler/service/repo)

### DIFF
--- a/backend/internal/handler/account_handler.go
+++ b/backend/internal/handler/account_handler.go
@@ -1,0 +1,202 @@
+package handler
+
+import (
+	"errors"
+	"net/http"
+	"strconv"
+
+	"github.com/gin-gonic/gin"
+	"github.com/shopspring/decimal"
+
+	"github.com/gregwym/offbook/backend/internal/repository"
+	"github.com/gregwym/offbook/backend/internal/service"
+)
+
+type AccountHandler struct {
+	svc *service.AccountService
+}
+
+func NewAccountHandler(s *service.AccountService) *AccountHandler {
+	return &AccountHandler{svc: s}
+}
+
+// Register attaches account routes to the given /api/v1 group.
+func (h *AccountHandler) Register(g *gin.RouterGroup) {
+	g.POST("/accounts", h.Create)
+	g.GET("/accounts", h.List)
+	g.GET("/accounts/:id", h.Get)
+	g.PATCH("/accounts/:id", h.Update)
+	g.DELETE("/accounts/:id", h.Delete)
+}
+
+// JSON request shape for POST /accounts.
+type createAccountRequest struct {
+	Name            string           `json:"name"`
+	InstitutionSlug string           `json:"institution_slug"`
+	AccountType     string           `json:"account_type"`
+	Currency        string           `json:"currency"`
+	Balance         *decimal.Decimal `json:"balance"`
+	LastFour        *string          `json:"last_four"`
+	IsActive        *bool            `json:"is_active"`
+}
+
+func (h *AccountHandler) Create(c *gin.Context) {
+	var req createAccountRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error(), "code": "INVALID_REQUEST"})
+		return
+	}
+	in := service.CreateAccountInput{
+		Name:            req.Name,
+		InstitutionSlug: req.InstitutionSlug,
+		AccountType:     req.AccountType,
+		Currency:        req.Currency,
+		LastFour:        req.LastFour,
+		IsActive:        req.IsActive,
+	}
+	if req.Balance != nil {
+		in.Balance = *req.Balance
+	}
+	a, err := h.svc.Create(c.Request.Context(), in)
+	if err != nil {
+		h.writeServiceError(c, err)
+		return
+	}
+	c.JSON(http.StatusCreated, gin.H{"data": a})
+}
+
+func (h *AccountHandler) Get(c *gin.Context) {
+	id, ok := parseID(c)
+	if !ok {
+		return
+	}
+	a, err := h.svc.Get(c.Request.Context(), id)
+	if err != nil {
+		h.writeServiceError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"data": a})
+}
+
+func (h *AccountHandler) List(c *gin.Context) {
+	f := repository.AccountFilter{
+		InstitutionSlug: c.Query("institution_slug"),
+		AccountType:     c.Query("account_type"),
+	}
+	if v := c.Query("is_active"); v != "" {
+		switch v {
+		case "true":
+			t := true
+			f.IsActive = &t
+		case "false":
+			fv := false
+			f.IsActive = &fv
+		default:
+			c.JSON(http.StatusBadRequest, gin.H{"error": "is_active must be true or false", "code": "INVALID_REQUEST"})
+			return
+		}
+	}
+	if v := c.Query("limit"); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil || n < 0 {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "limit must be a non-negative integer", "code": "INVALID_REQUEST"})
+			return
+		}
+		f.Limit = n
+	}
+	if v := c.Query("offset"); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil || n < 0 {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "offset must be a non-negative integer", "code": "INVALID_REQUEST"})
+			return
+		}
+		f.Offset = n
+	}
+
+	accounts, total, err := h.svc.List(c.Request.Context(), f)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error(), "code": "INTERNAL"})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{
+		"data":   accounts,
+		"total":  total,
+		"limit":  resolvedLimit(f.Limit),
+		"offset": f.Offset,
+	})
+}
+
+type updateAccountRequest struct {
+	Name            *string          `json:"name"`
+	InstitutionSlug *string          `json:"institution_slug"`
+	AccountType     *string          `json:"account_type"`
+	Currency        *string          `json:"currency"`
+	Balance         *decimal.Decimal `json:"balance"`
+	LastFour        *string          `json:"last_four"`
+	IsActive        *bool            `json:"is_active"`
+}
+
+func (h *AccountHandler) Update(c *gin.Context) {
+	id, ok := parseID(c)
+	if !ok {
+		return
+	}
+	var req updateAccountRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error(), "code": "INVALID_REQUEST"})
+		return
+	}
+	a, err := h.svc.Update(c.Request.Context(), id, service.UpdateAccountInput(req))
+	if err != nil {
+		h.writeServiceError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"data": a})
+}
+
+func (h *AccountHandler) Delete(c *gin.Context) {
+	id, ok := parseID(c)
+	if !ok {
+		return
+	}
+	if err := h.svc.SoftDelete(c.Request.Context(), id); err != nil {
+		h.writeServiceError(c, err)
+		return
+	}
+	c.Status(http.StatusNoContent)
+}
+
+func (h *AccountHandler) writeServiceError(c *gin.Context, err error) {
+	switch {
+	case errors.Is(err, service.ErrAccountNotFound):
+		c.JSON(http.StatusNotFound, gin.H{"error": err.Error(), "code": "ACCOUNT_NOT_FOUND"})
+	case errors.Is(err, service.ErrEmptyName),
+		errors.Is(err, service.ErrEmptyInstitution),
+		errors.Is(err, service.ErrInvalidType),
+		errors.Is(err, service.ErrInvalidCurrency),
+		errors.Is(err, service.ErrInvalidLastFour),
+		errors.Is(err, service.ErrInvalidAccount):
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error(), "code": "INVALID_ACCOUNT"})
+	default:
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error(), "code": "INTERNAL"})
+	}
+}
+
+func parseID(c *gin.Context) (int64, bool) {
+	id, err := strconv.ParseInt(c.Param("id"), 10, 64)
+	if err != nil || id <= 0 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "id must be a positive integer", "code": "INVALID_REQUEST"})
+		return 0, false
+	}
+	return id, true
+}
+
+func resolvedLimit(requested int) int {
+	if requested <= 0 {
+		return 50
+	}
+	if requested > 200 {
+		return 200
+	}
+	return requested
+}

--- a/backend/internal/repository/account_repo.go
+++ b/backend/internal/repository/account_repo.go
@@ -1,0 +1,115 @@
+package repository
+
+import (
+	"context"
+	"errors"
+
+	"gorm.io/gorm"
+
+	"github.com/gregwym/offbook/backend/internal/model"
+)
+
+// AccountFilter narrows the set of accounts returned by List.
+// Zero values mean "no filter on that dimension".
+type AccountFilter struct {
+	InstitutionSlug string
+	AccountType     string
+	IsActive        *bool
+	Limit           int
+	Offset          int
+}
+
+// AccountRepository is the data-access contract for accounts. PII fields
+// (holder name, account number, etc.) live in pii_store and are NOT exposed
+// here — see pii_repo for that.
+type AccountRepository interface {
+	Create(ctx context.Context, a *model.Account) error
+	GetByID(ctx context.Context, id int64) (*model.Account, error)
+	List(ctx context.Context, f AccountFilter) ([]model.Account, int64, error)
+	Update(ctx context.Context, a *model.Account) error
+	SoftDelete(ctx context.Context, id int64) error
+}
+
+// ErrNotFound is returned by repository methods when no matching row exists.
+// Services translate this into domain-specific errors (e.g. ErrAccountNotFound).
+var ErrNotFound = errors.New("not found")
+
+type accountRepo struct {
+	db *gorm.DB
+}
+
+func NewAccountRepository(db *gorm.DB) AccountRepository {
+	return &accountRepo{db: db}
+}
+
+func (r *accountRepo) Create(ctx context.Context, a *model.Account) error {
+	return r.db.WithContext(ctx).Create(a).Error
+}
+
+func (r *accountRepo) GetByID(ctx context.Context, id int64) (*model.Account, error) {
+	var a model.Account
+	if err := r.db.WithContext(ctx).First(&a, id).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, ErrNotFound
+		}
+		return nil, err
+	}
+	return &a, nil
+}
+
+func (r *accountRepo) List(ctx context.Context, f AccountFilter) ([]model.Account, int64, error) {
+	q := r.db.WithContext(ctx).Model(&model.Account{})
+	if f.InstitutionSlug != "" {
+		q = q.Where("institution_slug = ?", f.InstitutionSlug)
+	}
+	if f.AccountType != "" {
+		q = q.Where("account_type = ?", f.AccountType)
+	}
+	if f.IsActive != nil {
+		q = q.Where("is_active = ?", *f.IsActive)
+	}
+
+	var total int64
+	if err := q.Count(&total).Error; err != nil {
+		return nil, 0, err
+	}
+
+	limit := f.Limit
+	if limit <= 0 {
+		limit = 50
+	}
+	if limit > 200 {
+		limit = 200
+	}
+
+	var out []model.Account
+	if err := q.Order("id DESC").Limit(limit).Offset(f.Offset).Find(&out).Error; err != nil {
+		return nil, 0, err
+	}
+	return out, total, nil
+}
+
+func (r *accountRepo) Update(ctx context.Context, a *model.Account) error {
+	// Save updates all fields, including the zero values that PATCH explicitly cleared
+	// (e.g. unsetting LastFour). The handler is responsible for loading-then-patching
+	// so we never blow away fields the caller didn't intend to change.
+	res := r.db.WithContext(ctx).Save(a)
+	if res.Error != nil {
+		return res.Error
+	}
+	if res.RowsAffected == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+func (r *accountRepo) SoftDelete(ctx context.Context, id int64) error {
+	res := r.db.WithContext(ctx).Delete(&model.Account{}, id)
+	if res.Error != nil {
+		return res.Error
+	}
+	if res.RowsAffected == 0 {
+		return ErrNotFound
+	}
+	return nil
+}

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/gregwym/offbook/backend/internal/config"
 	"github.com/gregwym/offbook/backend/internal/handler"
+	"github.com/gregwym/offbook/backend/internal/repository"
+	"github.com/gregwym/offbook/backend/internal/service"
 )
 
 func New(cfg config.Config, gormDB *gorm.DB) *gin.Engine {
@@ -14,9 +16,14 @@ func New(cfg config.Config, gormDB *gorm.DB) *gin.Engine {
 
 	health := handler.NewHealthHandler(gormDB)
 
+	accountRepo := repository.NewAccountRepository(gormDB)
+	accountSvc := service.NewAccountService(accountRepo)
+	accountHandler := handler.NewAccountHandler(accountSvc)
+
 	v1 := r.Group("/api/v1")
 	{
 		v1.GET("/health", health.Get)
+		accountHandler.Register(v1)
 	}
 
 	return r

--- a/backend/internal/service/account_service.go
+++ b/backend/internal/service/account_service.go
@@ -1,0 +1,196 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/shopspring/decimal"
+
+	"github.com/gregwym/offbook/backend/internal/model"
+	"github.com/gregwym/offbook/backend/internal/repository"
+)
+
+// Domain errors. Handlers map these to HTTP status codes.
+var (
+	ErrAccountNotFound  = errors.New("account not found")
+	ErrInvalidAccount   = errors.New("invalid account")
+	ErrInvalidType      = errors.New("invalid account_type")
+	ErrInvalidCurrency  = errors.New("invalid currency")
+	ErrInvalidLastFour  = errors.New("last_four must be exactly 4 digits")
+	ErrEmptyName        = errors.New("name must not be empty")
+	ErrEmptyInstitution = errors.New("institution_slug must not be empty")
+)
+
+// validAccountTypes mirrors the CHECK constraint in migration 000001.
+var validAccountTypes = map[string]struct{}{
+	"checking":    {},
+	"savings":     {},
+	"credit_card": {},
+	"loan":        {},
+	"investment":  {},
+	"crypto":      {},
+	"cash":        {},
+	"other":       {},
+}
+
+// CreateAccountInput is the validated, decoded request payload for account creation.
+type CreateAccountInput struct {
+	Name            string
+	InstitutionSlug string
+	AccountType     string
+	Currency        string
+	Balance         decimal.Decimal
+	LastFour        *string
+	IsActive        *bool
+}
+
+// UpdateAccountInput is a sparse patch. Pointer fields distinguish "not provided"
+// from "set to zero value". Balance lives in the main accounts table per the
+// architecture (it's not PII).
+type UpdateAccountInput struct {
+	Name            *string
+	InstitutionSlug *string
+	AccountType     *string
+	Currency        *string
+	Balance         *decimal.Decimal
+	LastFour        *string
+	IsActive        *bool
+}
+
+// AccountService owns business rules for accounts. It deliberately does NOT
+// receive pii_repo or pii_service — PII is set via the separate pii endpoints.
+type AccountService struct {
+	repo repository.AccountRepository
+}
+
+func NewAccountService(repo repository.AccountRepository) *AccountService {
+	return &AccountService{repo: repo}
+}
+
+func (s *AccountService) Create(ctx context.Context, in CreateAccountInput) (*model.Account, error) {
+	if in.Currency == "" {
+		in.Currency = "USD"
+	}
+	a := &model.Account{
+		Name:            strings.TrimSpace(in.Name),
+		InstitutionSlug: strings.TrimSpace(in.InstitutionSlug),
+		AccountType:     strings.TrimSpace(in.AccountType),
+		Currency:        strings.ToUpper(strings.TrimSpace(in.Currency)),
+		Balance:         in.Balance,
+		LastFour:        in.LastFour,
+		IsActive:        true,
+	}
+	if in.IsActive != nil {
+		a.IsActive = *in.IsActive
+	}
+	if err := validate(a); err != nil {
+		return nil, err
+	}
+	if err := s.repo.Create(ctx, a); err != nil {
+		return nil, fmt.Errorf("create account: %w", err)
+	}
+	return a, nil
+}
+
+func (s *AccountService) Get(ctx context.Context, id int64) (*model.Account, error) {
+	a, err := s.repo.GetByID(ctx, id)
+	if err != nil {
+		if errors.Is(err, repository.ErrNotFound) {
+			return nil, ErrAccountNotFound
+		}
+		return nil, err
+	}
+	return a, nil
+}
+
+func (s *AccountService) List(ctx context.Context, f repository.AccountFilter) ([]model.Account, int64, error) {
+	return s.repo.List(ctx, f)
+}
+
+func (s *AccountService) Update(ctx context.Context, id int64, in UpdateAccountInput) (*model.Account, error) {
+	a, err := s.repo.GetByID(ctx, id)
+	if err != nil {
+		if errors.Is(err, repository.ErrNotFound) {
+			return nil, ErrAccountNotFound
+		}
+		return nil, err
+	}
+
+	if in.Name != nil {
+		a.Name = strings.TrimSpace(*in.Name)
+	}
+	if in.InstitutionSlug != nil {
+		a.InstitutionSlug = strings.TrimSpace(*in.InstitutionSlug)
+	}
+	if in.AccountType != nil {
+		a.AccountType = strings.TrimSpace(*in.AccountType)
+	}
+	if in.Currency != nil {
+		a.Currency = strings.ToUpper(strings.TrimSpace(*in.Currency))
+	}
+	if in.Balance != nil {
+		a.Balance = *in.Balance
+	}
+	if in.LastFour != nil {
+		// Pointer to empty string means "clear it"; pass null pointer to leave alone.
+		if *in.LastFour == "" {
+			a.LastFour = nil
+		} else {
+			lf := *in.LastFour
+			a.LastFour = &lf
+		}
+	}
+	if in.IsActive != nil {
+		a.IsActive = *in.IsActive
+	}
+
+	if err := validate(a); err != nil {
+		return nil, err
+	}
+	if err := s.repo.Update(ctx, a); err != nil {
+		if errors.Is(err, repository.ErrNotFound) {
+			return nil, ErrAccountNotFound
+		}
+		return nil, fmt.Errorf("update account: %w", err)
+	}
+	return a, nil
+}
+
+func (s *AccountService) SoftDelete(ctx context.Context, id int64) error {
+	if err := s.repo.SoftDelete(ctx, id); err != nil {
+		if errors.Is(err, repository.ErrNotFound) {
+			return ErrAccountNotFound
+		}
+		return fmt.Errorf("soft delete account: %w", err)
+	}
+	return nil
+}
+
+func validate(a *model.Account) error {
+	if a.Name == "" {
+		return ErrEmptyName
+	}
+	if a.InstitutionSlug == "" {
+		return ErrEmptyInstitution
+	}
+	if _, ok := validAccountTypes[a.AccountType]; !ok {
+		return ErrInvalidType
+	}
+	if len(a.Currency) != 3 {
+		return ErrInvalidCurrency
+	}
+	if a.LastFour != nil {
+		v := *a.LastFour
+		if len(v) != 4 {
+			return ErrInvalidLastFour
+		}
+		for _, r := range v {
+			if r < '0' || r > '9' {
+				return ErrInvalidLastFour
+			}
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary
- AccountRepository, AccountService, AccountHandler under `/api/v1/accounts` (POST, GET list, GET id, PATCH, DELETE).
- Validates account_type/currency/last_four/name; sparse PATCH that doesn't clobber unrelated fields; GORM soft-delete excludes rows from list.
- No PII dependency — holder name / account number ship in #27.

## Test plan
- [x] `go test ./...` passes
- [x] `golangci-lint run` reports 0 issues
- [x] Smoke-tested all 5 endpoints against running Postgres
- [x] Verified NUMERIC(30,18) balance round-trips (`1234.567890123456789`, `9999.999999999999999999`)
- [x] Verified soft-delete returns 204, subsequent GET returns 404, deleted row excluded from list

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)