### PR TITLE
M2 #27: Account PII via isolated pii_store

### DIFF
--- a/backend/internal/handler/pii_handler.go
+++ b/backend/internal/handler/pii_handler.go
@@ -1,0 +1,93 @@
+package handler
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/gregwym/offbook/backend/internal/service"
+)
+
+// PIIHandler exposes the deliberate, auditable PII access points.
+// Kept in its own file so a reviewer can see every place PII crosses the API
+// boundary at a glance.
+type PIIHandler struct {
+	svc *service.PIIService
+}
+
+func NewPIIHandler(s *service.PIIService) *PIIHandler {
+	return &PIIHandler{svc: s}
+}
+
+// RegisterAccountRoutes mounts the account PII endpoints. These are the ONLY
+// way PII leaves the backend — see ARCHITECTURE.md.
+func (h *PIIHandler) RegisterAccountRoutes(g *gin.RouterGroup) {
+	g.GET("/accounts/:id/pii", h.GetForAccount)
+	g.PUT("/accounts/:id/pii", h.SetForAccount)
+}
+
+func (h *PIIHandler) GetForAccount(c *gin.Context) {
+	id, ok := parseID(c)
+	if !ok {
+		return
+	}
+	pii, err := h.svc.GetAccountPII(c.Request.Context(), id)
+	if err != nil {
+		h.writeError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"data": pii})
+}
+
+func (h *PIIHandler) SetForAccount(c *gin.Context) {
+	id, ok := parseID(c)
+	if !ok {
+		return
+	}
+	var req map[string]string
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error(), "code": "INVALID_REQUEST"})
+		return
+	}
+	if len(req) == 0 {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error":   "body must be a non-empty object of {field_name: value}",
+			"code":    "INVALID_REQUEST",
+			"allowed": service.AllowedAccountPIIFields(),
+		})
+		return
+	}
+	if err := h.svc.SetAccountPII(c.Request.Context(), id, req); err != nil {
+		h.writeError(c, err)
+		return
+	}
+	// Read back so the client sees the full current state after the upsert.
+	pii, err := h.svc.GetAccountPII(c.Request.Context(), id)
+	if err != nil {
+		h.writeError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"data": pii})
+}
+
+func (h *PIIHandler) writeError(c *gin.Context, err error) {
+	switch {
+	case errors.Is(err, service.ErrAccountNotFound):
+		c.JSON(http.StatusNotFound, gin.H{"error": err.Error(), "code": "ACCOUNT_NOT_FOUND"})
+	case errors.Is(err, service.ErrInvalidPIIField):
+		// Include the allowlist so the caller can fix the request without guessing.
+		msg := err.Error()
+		// Strip the "invalid pii field: " prefix for the user-facing message? Keep as-is —
+		// the wrapped field name is useful and the code disambiguates programmatically.
+		_ = strings.TrimSpace(msg)
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error":   msg,
+			"code":    "INVALID_PII_FIELD",
+			"allowed": service.AllowedAccountPIIFields(),
+		})
+	default:
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error(), "code": "INTERNAL"})
+	}
+}

--- a/backend/internal/repository/pii_repo.go
+++ b/backend/internal/repository/pii_repo.go
@@ -1,0 +1,80 @@
+// Package repository — pii_repo is the ONLY repository that touches pii_store.
+// See ARCHITECTURE.md "PII Isolation". Other services and the AI layer MUST NOT
+// depend on this type.
+package repository
+
+import (
+	"context"
+	"errors"
+
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+
+	"github.com/gregwym/offbook/backend/internal/model"
+)
+
+// PIIRepository is the data-access contract for pii_store. The interface is
+// deliberately narrow — there is no List, no search, no cross-entity queries.
+// PII lookups are always scoped to a specific (entity_type, entity_id).
+type PIIRepository interface {
+	Set(ctx context.Context, entityType string, entityID int64, field, value string) error
+	Get(ctx context.Context, entityType string, entityID int64, field string) (string, error)
+	GetAll(ctx context.Context, entityType string, entityID int64) (map[string]string, error)
+	DeleteAll(ctx context.Context, entityType string, entityID int64) error
+}
+
+type piiRepo struct {
+	db *gorm.DB
+}
+
+func NewPIIRepository(db *gorm.DB) PIIRepository {
+	return &piiRepo{db: db}
+}
+
+func (r *piiRepo) Set(ctx context.Context, entityType string, entityID int64, field, value string) error {
+	rec := model.PIIRecord{
+		EntityType: entityType,
+		EntityID:   entityID,
+		FieldName:  field,
+		Value:      value,
+	}
+	// Upsert on the (entity_type, entity_id, field_name) unique constraint.
+	return r.db.WithContext(ctx).Clauses(clause.OnConflict{
+		Columns:   []clause.Column{{Name: "entity_type"}, {Name: "entity_id"}, {Name: "field_name"}},
+		DoUpdates: clause.AssignmentColumns([]string{"value", "updated_at"}),
+	}).Create(&rec).Error
+}
+
+func (r *piiRepo) Get(ctx context.Context, entityType string, entityID int64, field string) (string, error) {
+	var rec model.PIIRecord
+	err := r.db.WithContext(ctx).
+		Where("entity_type = ? AND entity_id = ? AND field_name = ?", entityType, entityID, field).
+		First(&rec).Error
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return "", ErrNotFound
+		}
+		return "", err
+	}
+	return rec.Value, nil
+}
+
+func (r *piiRepo) GetAll(ctx context.Context, entityType string, entityID int64) (map[string]string, error) {
+	var recs []model.PIIRecord
+	if err := r.db.WithContext(ctx).
+		Where("entity_type = ? AND entity_id = ?", entityType, entityID).
+		Find(&recs).Error; err != nil {
+		return nil, err
+	}
+	out := make(map[string]string, len(recs))
+	for _, rec := range recs {
+		out[rec.FieldName] = rec.Value
+	}
+	return out, nil
+}
+
+func (r *piiRepo) DeleteAll(ctx context.Context, entityType string, entityID int64) error {
+	return r.db.WithContext(ctx).
+		Where("entity_type = ? AND entity_id = ?", entityType, entityID).
+		Delete(&model.PIIRecord{}).Error
+}

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -20,10 +20,17 @@ func New(cfg config.Config, gormDB *gorm.DB) *gin.Engine {
 	accountSvc := service.NewAccountService(accountRepo)
 	accountHandler := handler.NewAccountHandler(accountSvc)
 
+	// PII flow: pii_repo is wired ONLY into pii_service, which is wired ONLY
+	// into pii_handler. account_service / account_handler never see it.
+	piiRepo := repository.NewPIIRepository(gormDB)
+	piiSvc := service.NewPIIService(piiRepo, accountSvc)
+	piiHandler := handler.NewPIIHandler(piiSvc)
+
 	v1 := r.Group("/api/v1")
 	{
 		v1.GET("/health", health.Get)
 		accountHandler.Register(v1)
+		piiHandler.RegisterAccountRoutes(v1)
 	}
 
 	return r

--- a/backend/internal/service/pii_service.go
+++ b/backend/internal/service/pii_service.go
@@ -1,0 +1,86 @@
+// pii_service is the ONLY service that receives a PIIRepository.
+// See ARCHITECTURE.md "PII Isolation" — the AI layer and all other domain
+// services MUST NOT depend on pii_repo or this service.
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/gregwym/offbook/backend/internal/repository"
+)
+
+const (
+	piiEntityAccount = "account"
+)
+
+// Account PII field allowlist. Mirrors ARCHITECTURE.md's "What goes in pii_store"
+// table. Anything outside this set is rejected so callers can't smuggle
+// arbitrary blobs into the PII table.
+var allowedAccountPIIFields = map[string]struct{}{
+	"holder_name":    {},
+	"account_number": {},
+	"routing_number": {},
+	"address":        {},
+}
+
+// Domain errors.
+var (
+	ErrInvalidPIIField = errors.New("invalid pii field")
+	ErrEmptyPIIValue   = errors.New("pii value must not be empty")
+)
+
+// PIIService is the only place that wires pii_repo. It depends on
+// AccountService only to check existence — never to mutate accounts.
+type PIIService struct {
+	repo    repository.PIIRepository
+	accSvc  *AccountService
+}
+
+func NewPIIService(repo repository.PIIRepository, accSvc *AccountService) *PIIService {
+	return &PIIService{repo: repo, accSvc: accSvc}
+}
+
+// GetAccountPII returns all stored PII fields for the account.
+// Returns ErrAccountNotFound if the account doesn't exist (or is soft-deleted).
+func (s *PIIService) GetAccountPII(ctx context.Context, accountID int64) (map[string]string, error) {
+	if _, err := s.accSvc.Get(ctx, accountID); err != nil {
+		return nil, err
+	}
+	return s.repo.GetAll(ctx, piiEntityAccount, accountID)
+}
+
+// SetAccountPII upserts the provided fields. Fields not in the map are left
+// untouched; pass an empty string value to clear a field's stored value
+// (we still write the row — explicit "" beats silent loss).
+//
+// NOTE: per ADR #21 (backlog) the orphan-cleanup policy for PII on account
+// soft-delete is not yet decided. Today, soft-deleting an account leaves
+// PII rows behind. Revisit once #21 lands.
+func (s *PIIService) SetAccountPII(ctx context.Context, accountID int64, fields map[string]string) error {
+	if _, err := s.accSvc.Get(ctx, accountID); err != nil {
+		return err
+	}
+	for field, value := range fields {
+		field = strings.TrimSpace(field)
+		if _, ok := allowedAccountPIIFields[field]; !ok {
+			return fmt.Errorf("%w: %s", ErrInvalidPIIField, field)
+		}
+		if err := s.repo.Set(ctx, piiEntityAccount, accountID, field, value); err != nil {
+			return fmt.Errorf("set pii %s: %w", field, err)
+		}
+	}
+	return nil
+}
+
+// AllowedAccountPIIFields returns the canonical field allowlist. Exported for
+// handler-side documentation/error messages.
+func AllowedAccountPIIFields() []string {
+	out := make([]string, 0, len(allowedAccountPIIFields))
+	for k := range allowedAccountPIIFields {
+		out = append(out, k)
+	}
+	return out
+}


### PR DESCRIPTION
## Summary
- New `pii_repo` (the only repository touching `pii_store`), `pii_service` (the only consumer of `pii_repo`), and `pii_handler` exposing `GET`/`PUT /api/v1/accounts/:id/pii`.
- Field allowlist (`holder_name`, `account_number`, `routing_number`, `address`) prevents arbitrary blobs.
- Orphan-cleanup policy on soft-delete deferred to ADR backlog #21 — TODO in service references it.

## Test plan
- [x] `go test ./...` passes
- [x] `golangci-lint run` reports 0 issues
- [x] Smoke-tested PUT/GET/upsert/invalid-field/empty-body/missing-account paths
- [x] **SQL-level isolation**: after `PUT /accounts/6/pii`, `accounts` row contains no PII values; `pii_store` has the three rows
- [x] **Grep audit**: `PIIRepository` referenced only by `pii_service`; `PIIService` only by `pii_handler` + router wiring

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)