### PR TITLE
M2 #28: Manual transaction entry backend

### DIFF
--- a/backend/internal/handler/transaction_handler.go
+++ b/backend/internal/handler/transaction_handler.go
@@ -1,0 +1,199 @@
+package handler
+
+import (
+	"errors"
+	"net/http"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/shopspring/decimal"
+
+	"github.com/gregwym/offbook/backend/internal/service"
+)
+
+type TransactionHandler struct {
+	svc *service.TransactionService
+}
+
+func NewTransactionHandler(s *service.TransactionService) *TransactionHandler {
+	return &TransactionHandler{svc: s}
+}
+
+func (h *TransactionHandler) Register(g *gin.RouterGroup) {
+	g.POST("/transactions", h.Create)
+	g.GET("/transactions/:id", h.Get)
+	g.PATCH("/transactions/:id", h.Update)
+	g.DELETE("/transactions/:id", h.Delete)
+}
+
+// JSON shape for POST /transactions.
+// transaction_date accepts either RFC3339 ("2026-05-16T00:00:00Z") or
+// a plain date ("2026-05-16"). We decode as string and parse explicitly so
+// we can reject ambiguous input early.
+type createTransactionRequest struct {
+	AccountID       int64            `json:"account_id"`
+	CategoryID      *int64           `json:"category_id"`
+	Amount          *decimal.Decimal `json:"amount"`
+	Currency        string           `json:"currency"`
+	Description     *string          `json:"description"`
+	MerchantName    *string          `json:"merchant_name"`
+	TransactionDate string           `json:"transaction_date"`
+	PostedDate      *string          `json:"posted_date"`
+	Source          string           `json:"source"`
+	Notes           *string          `json:"notes"`
+}
+
+func (h *TransactionHandler) Create(c *gin.Context) {
+	var req createTransactionRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error(), "code": "INVALID_REQUEST"})
+		return
+	}
+	if req.Amount == nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "amount is required", "code": "INVALID_REQUEST"})
+		return
+	}
+	txDate, ok := parseFlexibleDate(c, req.TransactionDate, "transaction_date")
+	if !ok {
+		return
+	}
+	in := service.CreateTransactionInput{
+		AccountID:       req.AccountID,
+		CategoryID:      req.CategoryID,
+		Amount:          *req.Amount,
+		Currency:        req.Currency,
+		Description:     req.Description,
+		MerchantName:    req.MerchantName,
+		TransactionDate: txDate,
+		Source:          req.Source,
+		Notes:           req.Notes,
+	}
+	if req.PostedDate != nil {
+		pd, ok := parseFlexibleDate(c, *req.PostedDate, "posted_date")
+		if !ok {
+			return
+		}
+		in.PostedDate = &pd
+	}
+	t, err := h.svc.Create(c.Request.Context(), in)
+	if err != nil {
+		h.writeServiceError(c, err)
+		return
+	}
+	c.JSON(http.StatusCreated, gin.H{"data": t})
+}
+
+func (h *TransactionHandler) Get(c *gin.Context) {
+	id, ok := parseID(c)
+	if !ok {
+		return
+	}
+	t, err := h.svc.Get(c.Request.Context(), id)
+	if err != nil {
+		h.writeServiceError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"data": t})
+}
+
+// updateTransactionRequest mirrors the sparse-patch service input. A null
+// category_id with clear_category=true uncategorizes; sending a non-null
+// category_id sets it. clear_category=false (default) + null category_id = leave alone.
+type updateTransactionRequest struct {
+	CategoryID      *int64           `json:"category_id"`
+	ClearCategory   bool             `json:"clear_category"`
+	Amount          *decimal.Decimal `json:"amount"`
+	Currency        *string          `json:"currency"`
+	Description     *string          `json:"description"`
+	MerchantName    *string          `json:"merchant_name"`
+	TransactionDate *string          `json:"transaction_date"`
+	PostedDate      *string          `json:"posted_date"`
+	Notes           *string          `json:"notes"`
+}
+
+func (h *TransactionHandler) Update(c *gin.Context) {
+	id, ok := parseID(c)
+	if !ok {
+		return
+	}
+	var req updateTransactionRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error(), "code": "INVALID_REQUEST"})
+		return
+	}
+	in := service.UpdateTransactionInput{
+		CategoryID:    req.CategoryID,
+		ClearCategory: req.ClearCategory,
+		Amount:        req.Amount,
+		Currency:      req.Currency,
+		Description:   req.Description,
+		MerchantName:  req.MerchantName,
+		Notes:         req.Notes,
+	}
+	if req.TransactionDate != nil {
+		td, ok := parseFlexibleDate(c, *req.TransactionDate, "transaction_date")
+		if !ok {
+			return
+		}
+		in.TransactionDate = &td
+	}
+	if req.PostedDate != nil {
+		pd, ok := parseFlexibleDate(c, *req.PostedDate, "posted_date")
+		if !ok {
+			return
+		}
+		in.PostedDate = &pd
+	}
+	t, err := h.svc.Update(c.Request.Context(), id, in)
+	if err != nil {
+		h.writeServiceError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"data": t})
+}
+
+func (h *TransactionHandler) Delete(c *gin.Context) {
+	id, ok := parseID(c)
+	if !ok {
+		return
+	}
+	if err := h.svc.SoftDelete(c.Request.Context(), id); err != nil {
+		h.writeServiceError(c, err)
+		return
+	}
+	c.Status(http.StatusNoContent)
+}
+
+func (h *TransactionHandler) writeServiceError(c *gin.Context, err error) {
+	switch {
+	case errors.Is(err, service.ErrTransactionNotFound):
+		c.JSON(http.StatusNotFound, gin.H{"error": err.Error(), "code": "TRANSACTION_NOT_FOUND"})
+	case errors.Is(err, service.ErrAccountNotFound):
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error(), "code": "ACCOUNT_NOT_FOUND"})
+	case errors.Is(err, service.ErrInvalidCategory):
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error(), "code": "INVALID_CATEGORY"})
+	case errors.Is(err, service.ErrInvalidAmount),
+		errors.Is(err, service.ErrInvalidSource),
+		errors.Is(err, service.ErrMissingDate),
+		errors.Is(err, service.ErrInvalidCurrency):
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error(), "code": "INVALID_TRANSACTION"})
+	default:
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error(), "code": "INTERNAL"})
+	}
+}
+
+// parseFlexibleDate accepts "2026-05-16" or RFC3339. On failure it writes a
+// 400 response and returns ok=false so callers can early-return.
+func parseFlexibleDate(c *gin.Context, raw, field string) (time.Time, bool) {
+	if t, err := time.Parse("2006-01-02", raw); err == nil {
+		return t, true
+	}
+	if t, err := time.Parse(time.RFC3339, raw); err == nil {
+		return t, true
+	}
+	c.JSON(http.StatusBadRequest, gin.H{
+		"error": field + " must be YYYY-MM-DD or RFC3339",
+		"code":  "INVALID_REQUEST",
+	})
+	return time.Time{}, false
+}

--- a/backend/internal/repository/category_repo.go
+++ b/backend/internal/repository/category_repo.go
@@ -1,0 +1,45 @@
+package repository
+
+import (
+	"context"
+	"errors"
+
+	"gorm.io/gorm"
+
+	"github.com/gregwym/offbook/backend/internal/model"
+)
+
+// CategoryRepository is read-only for now. M4 will add CRUD when rules ship;
+// for M2 we only need existence checks during transaction validation and a
+// future read for the frontend dropdown (#32).
+type CategoryRepository interface {
+	GetByID(ctx context.Context, id int64) (*model.Category, error)
+	List(ctx context.Context) ([]model.Category, error)
+}
+
+type categoryRepo struct {
+	db *gorm.DB
+}
+
+func NewCategoryRepository(db *gorm.DB) CategoryRepository {
+	return &categoryRepo{db: db}
+}
+
+func (r *categoryRepo) GetByID(ctx context.Context, id int64) (*model.Category, error) {
+	var c model.Category
+	if err := r.db.WithContext(ctx).First(&c, id).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, ErrNotFound
+		}
+		return nil, err
+	}
+	return &c, nil
+}
+
+func (r *categoryRepo) List(ctx context.Context) ([]model.Category, error) {
+	var out []model.Category
+	if err := r.db.WithContext(ctx).Order("name ASC").Find(&out).Error; err != nil {
+		return nil, err
+	}
+	return out, nil
+}

--- a/backend/internal/repository/transaction_repo.go
+++ b/backend/internal/repository/transaction_repo.go
@@ -1,0 +1,65 @@
+package repository
+
+import (
+	"context"
+	"errors"
+
+	"gorm.io/gorm"
+
+	"github.com/gregwym/offbook/backend/internal/model"
+)
+
+// TransactionRepository is the data-access contract for transactions.
+// List + filtering ship separately in #29 — keep this interface minimal so
+// the next PR can extend it without breaking callers.
+type TransactionRepository interface {
+	Create(ctx context.Context, t *model.Transaction) error
+	GetByID(ctx context.Context, id int64) (*model.Transaction, error)
+	Update(ctx context.Context, t *model.Transaction) error
+	SoftDelete(ctx context.Context, id int64) error
+}
+
+type transactionRepo struct {
+	db *gorm.DB
+}
+
+func NewTransactionRepository(db *gorm.DB) TransactionRepository {
+	return &transactionRepo{db: db}
+}
+
+func (r *transactionRepo) Create(ctx context.Context, t *model.Transaction) error {
+	return r.db.WithContext(ctx).Create(t).Error
+}
+
+func (r *transactionRepo) GetByID(ctx context.Context, id int64) (*model.Transaction, error) {
+	var t model.Transaction
+	if err := r.db.WithContext(ctx).First(&t, id).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, ErrNotFound
+		}
+		return nil, err
+	}
+	return &t, nil
+}
+
+func (r *transactionRepo) Update(ctx context.Context, t *model.Transaction) error {
+	res := r.db.WithContext(ctx).Save(t)
+	if res.Error != nil {
+		return res.Error
+	}
+	if res.RowsAffected == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+func (r *transactionRepo) SoftDelete(ctx context.Context, id int64) error {
+	res := r.db.WithContext(ctx).Delete(&model.Transaction{}, id)
+	if res.Error != nil {
+		return res.Error
+	}
+	if res.RowsAffected == 0 {
+		return ErrNotFound
+	}
+	return nil
+}

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -26,11 +26,17 @@ func New(cfg config.Config, gormDB *gorm.DB) *gin.Engine {
 	piiSvc := service.NewPIIService(piiRepo, accountSvc)
 	piiHandler := handler.NewPIIHandler(piiSvc)
 
+	transactionRepo := repository.NewTransactionRepository(gormDB)
+	categoryRepo := repository.NewCategoryRepository(gormDB)
+	transactionSvc := service.NewTransactionService(transactionRepo, accountRepo, categoryRepo)
+	transactionHandler := handler.NewTransactionHandler(transactionSvc)
+
 	v1 := r.Group("/api/v1")
 	{
 		v1.GET("/health", health.Get)
 		accountHandler.Register(v1)
 		piiHandler.RegisterAccountRoutes(v1)
+		transactionHandler.Register(v1)
 	}
 
 	return r

--- a/backend/internal/service/transaction_service.go
+++ b/backend/internal/service/transaction_service.go
@@ -1,0 +1,249 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/shopspring/decimal"
+
+	"github.com/gregwym/offbook/backend/internal/model"
+	"github.com/gregwym/offbook/backend/internal/repository"
+)
+
+// Domain errors for transactions.
+var (
+	ErrTransactionNotFound = errors.New("transaction not found")
+	ErrInvalidCategory     = errors.New("invalid category")
+	ErrInvalidAmount       = errors.New("amount must not be zero")
+	ErrInvalidSource       = errors.New("invalid source")
+	ErrMissingDate         = errors.New("transaction_date is required")
+)
+
+// validSources mirrors the CHECK constraint in migration 000001.
+// Manual entry uses 'manual'; the other values exist for future ingestion paths.
+var validSources = map[string]struct{}{
+	"manual": {},
+	"plaid":  {},
+	"csv":    {},
+	"pdf":    {},
+}
+
+// CreateTransactionInput is the validated, decoded create payload.
+// Source defaults to "manual" if empty.
+type CreateTransactionInput struct {
+	AccountID       int64
+	CategoryID      *int64
+	Amount          decimal.Decimal
+	Currency        string
+	Description     *string
+	MerchantName    *string
+	TransactionDate time.Time
+	PostedDate      *time.Time
+	Source          string
+	Notes           *string
+}
+
+// UpdateTransactionInput is a sparse patch. Pointer fields distinguish
+// "not provided" from "set to zero value".
+type UpdateTransactionInput struct {
+	CategoryID      *int64           // pointer-to-pointer omitted; pass *id to set, nil-but-Provided not supported in this minimal patch — see ClearCategory
+	ClearCategory   bool             // true uncategorizes the row
+	Amount          *decimal.Decimal
+	Currency        *string
+	Description     *string
+	MerchantName    *string
+	TransactionDate *time.Time
+	PostedDate      *time.Time
+	Notes           *string
+}
+
+// TransactionService owns business rules for transactions. It depends on the
+// account and category repos only for existence checks — it never reads PII.
+type TransactionService struct {
+	repo        repository.TransactionRepository
+	accountRepo repository.AccountRepository
+	categoryRepo repository.CategoryRepository
+}
+
+func NewTransactionService(
+	repo repository.TransactionRepository,
+	accountRepo repository.AccountRepository,
+	categoryRepo repository.CategoryRepository,
+) *TransactionService {
+	return &TransactionService{repo: repo, accountRepo: accountRepo, categoryRepo: categoryRepo}
+}
+
+func (s *TransactionService) Create(ctx context.Context, in CreateTransactionInput) (*model.Transaction, error) {
+	// Source defaulting + validation. Empty == manual per the issue's "manual entry" framing.
+	src := strings.TrimSpace(in.Source)
+	if src == "" {
+		src = "manual"
+	}
+	if _, ok := validSources[src]; !ok {
+		return nil, ErrInvalidSource
+	}
+	if in.Amount.IsZero() {
+		return nil, ErrInvalidAmount
+	}
+	if in.TransactionDate.IsZero() {
+		return nil, ErrMissingDate
+	}
+	if err := s.assertAccountExists(ctx, in.AccountID); err != nil {
+		return nil, err
+	}
+	if in.CategoryID != nil {
+		if err := s.assertCategoryExists(ctx, *in.CategoryID); err != nil {
+			return nil, err
+		}
+	}
+
+	currency := strings.ToUpper(strings.TrimSpace(in.Currency))
+	if currency == "" {
+		currency = "USD"
+	}
+
+	t := &model.Transaction{
+		AccountID:       in.AccountID,
+		CategoryID:      in.CategoryID,
+		Amount:          in.Amount,
+		Currency:        currency,
+		Description:     trimPtr(in.Description),
+		MerchantName:    trimPtr(in.MerchantName),
+		TransactionDate: in.TransactionDate,
+		PostedDate:      in.PostedDate,
+		Source:          src,
+		Notes:           in.Notes,
+	}
+	if in.CategoryID != nil {
+		method := "manual"
+		t.CategorizationMethod = &method
+	}
+
+	if err := s.repo.Create(ctx, t); err != nil {
+		return nil, fmt.Errorf("create transaction: %w", err)
+	}
+	return t, nil
+}
+
+func (s *TransactionService) Get(ctx context.Context, id int64) (*model.Transaction, error) {
+	t, err := s.repo.GetByID(ctx, id)
+	if err != nil {
+		if errors.Is(err, repository.ErrNotFound) {
+			return nil, ErrTransactionNotFound
+		}
+		return nil, err
+	}
+	return t, nil
+}
+
+func (s *TransactionService) Update(ctx context.Context, id int64, in UpdateTransactionInput) (*model.Transaction, error) {
+	t, err := s.repo.GetByID(ctx, id)
+	if err != nil {
+		if errors.Is(err, repository.ErrNotFound) {
+			return nil, ErrTransactionNotFound
+		}
+		return nil, err
+	}
+
+	// Category handling: caller can either set (CategoryID != nil) or clear (ClearCategory = true).
+	// Setting + clearing in the same patch is contradictory — clear wins.
+	switch {
+	case in.ClearCategory:
+		t.CategoryID = nil
+		t.CategorizationMethod = nil
+	case in.CategoryID != nil:
+		if err := s.assertCategoryExists(ctx, *in.CategoryID); err != nil {
+			return nil, err
+		}
+		t.CategoryID = in.CategoryID
+		method := "manual"
+		t.CategorizationMethod = &method
+	}
+
+	if in.Amount != nil {
+		if in.Amount.IsZero() {
+			return nil, ErrInvalidAmount
+		}
+		t.Amount = *in.Amount
+	}
+	if in.Currency != nil {
+		c := strings.ToUpper(strings.TrimSpace(*in.Currency))
+		if len(c) != 3 {
+			return nil, ErrInvalidCurrency
+		}
+		t.Currency = c
+	}
+	if in.Description != nil {
+		t.Description = trimPtr(in.Description)
+	}
+	if in.MerchantName != nil {
+		t.MerchantName = trimPtr(in.MerchantName)
+	}
+	if in.TransactionDate != nil {
+		if in.TransactionDate.IsZero() {
+			return nil, ErrMissingDate
+		}
+		t.TransactionDate = *in.TransactionDate
+	}
+	if in.PostedDate != nil {
+		// Empty time means "clear" so the caller can unset a previously-set posted_date.
+		if in.PostedDate.IsZero() {
+			t.PostedDate = nil
+		} else {
+			pd := *in.PostedDate
+			t.PostedDate = &pd
+		}
+	}
+	if in.Notes != nil {
+		t.Notes = in.Notes
+	}
+
+	if err := s.repo.Update(ctx, t); err != nil {
+		if errors.Is(err, repository.ErrNotFound) {
+			return nil, ErrTransactionNotFound
+		}
+		return nil, fmt.Errorf("update transaction: %w", err)
+	}
+	return t, nil
+}
+
+func (s *TransactionService) SoftDelete(ctx context.Context, id int64) error {
+	if err := s.repo.SoftDelete(ctx, id); err != nil {
+		if errors.Is(err, repository.ErrNotFound) {
+			return ErrTransactionNotFound
+		}
+		return fmt.Errorf("soft delete transaction: %w", err)
+	}
+	return nil
+}
+
+func (s *TransactionService) assertAccountExists(ctx context.Context, id int64) error {
+	if _, err := s.accountRepo.GetByID(ctx, id); err != nil {
+		if errors.Is(err, repository.ErrNotFound) {
+			return ErrAccountNotFound
+		}
+		return err
+	}
+	return nil
+}
+
+func (s *TransactionService) assertCategoryExists(ctx context.Context, id int64) error {
+	if _, err := s.categoryRepo.GetByID(ctx, id); err != nil {
+		if errors.Is(err, repository.ErrNotFound) {
+			return ErrInvalidCategory
+		}
+		return err
+	}
+	return nil
+}
+
+func trimPtr(s *string) *string {
+	if s == nil {
+		return nil
+	}
+	v := strings.TrimSpace(*s)
+	return &v
+}


### PR DESCRIPTION
## Summary
- POST/GET/PATCH/DELETE `/api/v1/transactions` backed by TransactionRepository + TransactionService + read-only CategoryRepository.
- Source defaults to `manual`; categorization_method auto-sets when a category is provided.
- Date parser accepts plain `YYYY-MM-DD` and RFC3339.

## Test plan
- [x] `go test ./...` passes
- [x] `golangci-lint run` reports 0 issues
- [x] Smoke-tested create / get / patch / delete + 5 error paths against running Postgres
- [x] 18-decimal precision verified (`0.000000000000000001` round-trips)
- [x] PATCH with `clear_category` uncategorizes and clears `categorization_method`

## Out of scope (per issue body)
- List + filters: ships in #29
- Transfers: `is_transfer`/`transfer_pair_id` stay null
- Service tests: ship with dashboard issue #30 per ROADMAP

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)