### PR TITLE
M2 #29: Transaction list with filters and pagination

### DIFF
--- a/backend/internal/handler/transaction_handler.go
+++ b/backend/internal/handler/transaction_handler.go
@@ -3,11 +3,13 @@ package handler
 import (
 	"errors"
 	"net/http"
+	"strconv"
 	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/shopspring/decimal"
 
+	"github.com/gregwym/offbook/backend/internal/repository"
 	"github.com/gregwym/offbook/backend/internal/service"
 )
 
@@ -21,9 +23,88 @@ func NewTransactionHandler(s *service.TransactionService) *TransactionHandler {
 
 func (h *TransactionHandler) Register(g *gin.RouterGroup) {
 	g.POST("/transactions", h.Create)
+	g.GET("/transactions", h.List)
 	g.GET("/transactions/:id", h.Get)
 	g.PATCH("/transactions/:id", h.Update)
 	g.DELETE("/transactions/:id", h.Delete)
+}
+
+// List returns a paginated, filtered slice of transactions.
+//
+// Query params:
+//
+//	account_id   — exact match (positive int64)
+//	category_id  — exact match OR the literal "null" to find uncategorized rows
+//	from, to     — inclusive date range on transaction_date, YYYY-MM-DD or RFC3339
+//	search       — case-insensitive substring match on description + merchant_name
+//	limit        — default 50, clamped to [1, 200]
+//	offset       — default 0, must be non-negative
+func (h *TransactionHandler) List(c *gin.Context) {
+	f := repository.TransactionFilter{}
+
+	if v := c.Query("account_id"); v != "" {
+		id, err := strconv.ParseInt(v, 10, 64)
+		if err != nil || id <= 0 {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "account_id must be a positive integer", "code": "INVALID_REQUEST"})
+			return
+		}
+		f.AccountID = &id
+	}
+	if v := c.Query("category_id"); v != "" {
+		if v == "null" {
+			f.UncategorizedOnly = true
+		} else {
+			id, err := strconv.ParseInt(v, 10, 64)
+			if err != nil || id <= 0 {
+				c.JSON(http.StatusBadRequest, gin.H{"error": "category_id must be a positive integer or 'null'", "code": "INVALID_REQUEST"})
+				return
+			}
+			f.CategoryID = &id
+		}
+	}
+	if v := c.Query("from"); v != "" {
+		t, ok := parseFlexibleDate(c, v, "from")
+		if !ok {
+			return
+		}
+		f.From = &t
+	}
+	if v := c.Query("to"); v != "" {
+		t, ok := parseFlexibleDate(c, v, "to")
+		if !ok {
+			return
+		}
+		f.To = &t
+	}
+	f.Search = c.Query("search")
+	if v := c.Query("limit"); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil || n < 0 {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "limit must be a non-negative integer", "code": "INVALID_REQUEST"})
+			return
+		}
+		f.Limit = n
+	}
+	if v := c.Query("offset"); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil || n < 0 {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "offset must be a non-negative integer", "code": "INVALID_REQUEST"})
+			return
+		}
+		f.Offset = n
+	}
+
+	transactions, total, err := h.svc.List(c.Request.Context(), f)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error(), "code": "INTERNAL"})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{
+		"data":   transactions,
+		"total":  total,
+		"limit":  resolvedLimit(f.Limit),
+		"offset": f.Offset,
+	})
 }
 
 // JSON shape for POST /transactions.

--- a/backend/internal/repository/transaction_repo.go
+++ b/backend/internal/repository/transaction_repo.go
@@ -3,18 +3,32 @@ package repository
 import (
 	"context"
 	"errors"
+	"time"
 
 	"gorm.io/gorm"
 
 	"github.com/gregwym/offbook/backend/internal/model"
 )
 
+// TransactionFilter narrows the set of transactions returned by List.
+// Zero values mean "no filter on that dimension"; nil pointers mean the same.
+// UncategorizedOnly takes precedence over CategoryID — set at most one.
+type TransactionFilter struct {
+	AccountID         *int64
+	CategoryID        *int64
+	UncategorizedOnly bool       // matches rows where category_id IS NULL
+	From              *time.Time // inclusive lower bound on transaction_date
+	To                *time.Time // inclusive upper bound on transaction_date
+	Search            string     // ILIKE %term% across description + merchant_name
+	Limit             int
+	Offset            int
+}
+
 // TransactionRepository is the data-access contract for transactions.
-// List + filtering ship separately in #29 — keep this interface minimal so
-// the next PR can extend it without breaking callers.
 type TransactionRepository interface {
 	Create(ctx context.Context, t *model.Transaction) error
 	GetByID(ctx context.Context, id int64) (*model.Transaction, error)
+	List(ctx context.Context, f TransactionFilter) ([]model.Transaction, int64, error)
 	Update(ctx context.Context, t *model.Transaction) error
 	SoftDelete(ctx context.Context, id int64) error
 }
@@ -40,6 +54,54 @@ func (r *transactionRepo) GetByID(ctx context.Context, id int64) (*model.Transac
 		return nil, err
 	}
 	return &t, nil
+}
+
+func (r *transactionRepo) List(ctx context.Context, f TransactionFilter) ([]model.Transaction, int64, error) {
+	q := r.db.WithContext(ctx).Model(&model.Transaction{})
+
+	if f.AccountID != nil {
+		q = q.Where("account_id = ?", *f.AccountID)
+	}
+	switch {
+	case f.UncategorizedOnly:
+		q = q.Where("category_id IS NULL")
+	case f.CategoryID != nil:
+		q = q.Where("category_id = ?", *f.CategoryID)
+	}
+	if f.From != nil {
+		q = q.Where("transaction_date >= ?", *f.From)
+	}
+	if f.To != nil {
+		q = q.Where("transaction_date <= ?", *f.To)
+	}
+	if s := f.Search; s != "" {
+		// ILIKE %term% — no full-text index in M2.
+		pattern := "%" + s + "%"
+		q = q.Where("description ILIKE ? OR merchant_name ILIKE ?", pattern, pattern)
+	}
+
+	var total int64
+	if err := q.Count(&total).Error; err != nil {
+		return nil, 0, err
+	}
+
+	limit := f.Limit
+	if limit <= 0 {
+		limit = 50
+	}
+	if limit > 200 {
+		limit = 200
+	}
+
+	var out []model.Transaction
+	if err := q.
+		Order("transaction_date DESC, id DESC").
+		Limit(limit).
+		Offset(f.Offset).
+		Find(&out).Error; err != nil {
+		return nil, 0, err
+	}
+	return out, total, nil
 }
 
 func (r *transactionRepo) Update(ctx context.Context, t *model.Transaction) error {

--- a/backend/internal/repository/transaction_repo_test.go
+++ b/backend/internal/repository/transaction_repo_test.go
@@ -1,0 +1,324 @@
+package repository_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/joho/godotenv"
+	"github.com/shopspring/decimal"
+	"gorm.io/gorm"
+
+	"github.com/gregwym/offbook/backend/internal/db"
+	"github.com/gregwym/offbook/backend/internal/model"
+	"github.com/gregwym/offbook/backend/internal/repository"
+)
+
+// loadRepoDotenv mirrors the helper in model/decimal_precision_test.go.
+// `go test` sets cwd to the package dir, so config.Load()'s default
+// search of ./.env and ../.env won't find the repo-root .env.
+func loadRepoDotenv() {
+	dir, err := os.Getwd()
+	if err != nil {
+		return
+	}
+	for i := 0; i < 8; i++ {
+		envPath := filepath.Join(dir, ".env")
+		if _, err := os.Stat(envPath); err == nil {
+			_ = godotenv.Load(envPath)
+			return
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return
+		}
+		dir = parent
+	}
+}
+
+func openTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	loadRepoDotenv()
+	url := os.Getenv("TEST_DATABASE_URL")
+	if url == "" {
+		url = os.Getenv("DATABASE_URL")
+	}
+	if url == "" {
+		t.Skip("no DATABASE_URL set; skipping integration test")
+	}
+	g, err := db.Open(url)
+	if err != nil {
+		t.Fatalf("db.Open: %v", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := db.Ping(ctx, g); err != nil {
+		t.Skipf("db.Ping: %v; skipping integration test", err)
+	}
+	return g
+}
+
+// seedTxFixture builds a small, deterministic transaction set spanning two
+// accounts and two categories so that filter dimensions are independent.
+//
+// Returns (accountA, accountB, categoryX, categoryY, [tx ids]) so tests can
+// reference the IDs directly. All fixture rows are registered with t.Cleanup
+// for hard deletion at end-of-test (these are integration rows, not domain
+// data — soft-delete would just clutter the test DB).
+func seedTxFixture(t *testing.T, g *gorm.DB) (int64, int64, int64, int64, []int64) {
+	t.Helper()
+	ctx := context.Background()
+
+	accA := &model.Account{Name: "fixture-A", InstitutionSlug: "fixture", AccountType: "checking", Currency: "USD"}
+	accB := &model.Account{Name: "fixture-B", InstitutionSlug: "fixture", AccountType: "credit_card", Currency: "USD"}
+	if err := g.WithContext(ctx).Create(accA).Error; err != nil {
+		t.Fatalf("seed account A: %v", err)
+	}
+	if err := g.WithContext(ctx).Create(accB).Error; err != nil {
+		t.Fatalf("seed account B: %v", err)
+	}
+	t.Cleanup(func() {
+		g.Unscoped().Delete(&model.Account{}, accA.ID)
+		g.Unscoped().Delete(&model.Account{}, accB.ID)
+	})
+
+	catX := &model.Category{Name: "FixtureX", Slug: "fixture-x-" + time.Now().Format("150405.000000"), IsSystem: false}
+	catY := &model.Category{Name: "FixtureY", Slug: "fixture-y-" + time.Now().Format("150405.000000"), IsSystem: false}
+	if err := g.WithContext(ctx).Create(catX).Error; err != nil {
+		t.Fatalf("seed cat X: %v", err)
+	}
+	if err := g.WithContext(ctx).Create(catY).Error; err != nil {
+		t.Fatalf("seed cat Y: %v", err)
+	}
+	t.Cleanup(func() {
+		g.Unscoped().Delete(&model.Category{}, catX.ID)
+		g.Unscoped().Delete(&model.Category{}, catY.ID)
+	})
+
+	d := func(s string) time.Time {
+		v, _ := time.Parse("2006-01-02", s)
+		return v
+	}
+	desc := func(s string) *string { return &s }
+
+	rows := []model.Transaction{
+		// account A, cat X, date 2026-05-10, "Whole Foods market"
+		{AccountID: accA.ID, CategoryID: &catX.ID, Amount: decimal.NewFromInt(-100), Currency: "USD",
+			Description: desc("Whole Foods market"), MerchantName: desc("Whole Foods"),
+			TransactionDate: d("2026-05-10"), Source: "manual"},
+		// account A, cat Y, date 2026-05-12, "Shell gas"
+		{AccountID: accA.ID, CategoryID: &catY.ID, Amount: decimal.NewFromInt(-40), Currency: "USD",
+			Description: desc("Shell gas"), MerchantName: desc("Shell"),
+			TransactionDate: d("2026-05-12"), Source: "manual"},
+		// account B, no category, date 2026-05-15, "Coffee shop"
+		{AccountID: accB.ID, Amount: decimal.NewFromInt(-5), Currency: "USD",
+			Description: desc("Coffee shop"), MerchantName: desc("Blue Bottle"),
+			TransactionDate: d("2026-05-15"), Source: "manual"},
+		// account B, cat X, date 2026-05-20, "Whole Foods returns"
+		{AccountID: accB.ID, CategoryID: &catX.ID, Amount: decimal.NewFromInt(25), Currency: "USD",
+			Description: desc("Whole Foods returns"), MerchantName: desc("Whole Foods"),
+			TransactionDate: d("2026-05-20"), Source: "manual"},
+		// account A, no category, date 2026-04-01, "Old transaction"
+		{AccountID: accA.ID, Amount: decimal.NewFromInt(-1), Currency: "USD",
+			Description: desc("Old transaction"), MerchantName: desc("Misc"),
+			TransactionDate: d("2026-04-01"), Source: "manual"},
+	}
+	ids := make([]int64, 0, len(rows))
+	for i := range rows {
+		if err := g.WithContext(ctx).Create(&rows[i]).Error; err != nil {
+			t.Fatalf("seed tx %d: %v", i, err)
+		}
+		ids = append(ids, rows[i].ID)
+	}
+	t.Cleanup(func() {
+		for _, id := range ids {
+			g.Unscoped().Delete(&model.Transaction{}, id)
+		}
+	})
+
+	return accA.ID, accB.ID, catX.ID, catY.ID, ids
+}
+
+func TestTransactionRepository_List_Filters(t *testing.T) {
+	g := openTestDB(t)
+	repo := repository.NewTransactionRepository(g)
+	accA, accB, catX, _, ids := seedTxFixture(t, g)
+
+	// Helper: assert that the returned rows are EXACTLY the expected fixture indices.
+	// idsByIndex maps fixture row index (0..4) → tx id. Tests reference indices so
+	// the assertions stay readable when fixtures are reordered.
+	want := func(indices ...int) map[int64]struct{} {
+		m := make(map[int64]struct{}, len(indices))
+		for _, i := range indices {
+			m[ids[i]] = struct{}{}
+		}
+		return m
+	}
+
+	cases := []struct {
+		name       string
+		filter     repository.TransactionFilter
+		wantIDs    map[int64]struct{}
+		wantTotal  int64
+		wantOrder  []int // expected (newest-first) order by fixture index, optional
+	}{
+		{
+			name:      "by account_id A",
+			filter:    repository.TransactionFilter{AccountID: int64Ptr(accA)},
+			wantIDs:   want(0, 1, 4),
+			wantTotal: 3,
+			wantOrder: []int{1, 0, 4}, // 2026-05-12, 2026-05-10, 2026-04-01
+		},
+		{
+			name:      "by account_id B",
+			filter:    repository.TransactionFilter{AccountID: int64Ptr(accB)},
+			wantIDs:   want(2, 3),
+			wantTotal: 2,
+		},
+		{
+			name:      "by category_id X",
+			filter:    repository.TransactionFilter{CategoryID: int64Ptr(catX)},
+			wantIDs:   want(0, 3),
+			wantTotal: 2,
+		},
+		{
+			name:      "uncategorized only",
+			filter:    repository.TransactionFilter{UncategorizedOnly: true, AccountID: nil},
+			wantIDs:   nil, // checked below — we don't assert global count because other fixtures may exist
+			wantTotal: -1,
+		},
+		{
+			// Scoped to accB so other tests' rows in this date window don't pollute counts.
+			// accB has rows on 5/15 (idx 2) and 5/20 (idx 3); only 5/15 falls in [5/11, 5/16].
+			name:      "date range from 2026-05-11 to 2026-05-16 (scoped to accB)",
+			filter:    repository.TransactionFilter{AccountID: int64Ptr(accB), From: timePtr("2026-05-11"), To: timePtr("2026-05-16")},
+			wantIDs:   want(2),
+			wantTotal: 1,
+		},
+		{
+			// "Whole Foods returns" is a fixture-unique phrase, isolating us from
+			// other smoke-test rows that may also use "Whole Foods".
+			name:      "search exact 'Whole Foods returns' (fixture-unique)",
+			filter:    repository.TransactionFilter{Search: "Whole Foods returns"},
+			wantIDs:   want(3),
+			wantTotal: 1,
+		},
+		{
+			name:      "search via merchant_name 'blue bottle'",
+			filter:    repository.TransactionFilter{Search: "Blue Bottle"},
+			wantIDs:   want(2),
+			wantTotal: 1,
+		},
+		{
+			name:      "combined: account A + cat X",
+			filter:    repository.TransactionFilter{AccountID: int64Ptr(accA), CategoryID: int64Ptr(catX)},
+			wantIDs:   want(0),
+			wantTotal: 1,
+		},
+		{
+			name:      "limit clamped (-1 → default 50)",
+			filter:    repository.TransactionFilter{AccountID: int64Ptr(accA), Limit: -1},
+			wantIDs:   want(0, 1, 4),
+			wantTotal: 3,
+		},
+		{
+			name:      "limit clamped (300 → max 200)",
+			filter:    repository.TransactionFilter{AccountID: int64Ptr(accA), Limit: 300},
+			wantIDs:   want(0, 1, 4),
+			wantTotal: 3,
+		},
+		{
+			name:      "pagination: limit 1 offset 1 on accountA returns the middle row by date DESC",
+			filter:    repository.TransactionFilter{AccountID: int64Ptr(accA), Limit: 1, Offset: 1},
+			wantIDs:   want(0), // 2nd-newest of A is fixture index 0 (2026-05-10)
+			wantTotal: 3,       // total ignores limit/offset
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, total, err := repo.List(context.Background(), tc.filter)
+			if err != nil {
+				t.Fatalf("List: %v", err)
+			}
+
+			// Special-case: "uncategorized only" can pick up rows from other tests
+			// in the same DB. Just assert OUR uncategorized rows are present.
+			if tc.filter.UncategorizedOnly {
+				gotIDs := txIDSet(got)
+				for _, idx := range []int{2, 4} {
+					if _, ok := gotIDs[ids[idx]]; !ok {
+						t.Errorf("expected uncategorized fixture row index %d (id %d) in results", idx, ids[idx])
+					}
+				}
+				return
+			}
+
+			if tc.wantTotal >= 0 && total != tc.wantTotal {
+				t.Errorf("total = %d, want %d", total, tc.wantTotal)
+			}
+			if tc.wantIDs != nil {
+				gotIDs := txIDSet(got)
+				if len(gotIDs) != len(tc.wantIDs) {
+					t.Errorf("len(results) = %d, want %d (got ids %v, want %v)",
+						len(gotIDs), len(tc.wantIDs), gotIDs, tc.wantIDs)
+				}
+				for id := range tc.wantIDs {
+					if _, ok := gotIDs[id]; !ok {
+						t.Errorf("missing expected id %d", id)
+					}
+				}
+			}
+			if tc.wantOrder != nil {
+				if len(got) != len(tc.wantOrder) {
+					t.Fatalf("ordering check: len(got)=%d, want %d", len(got), len(tc.wantOrder))
+				}
+				for i, idx := range tc.wantOrder {
+					if got[i].ID != ids[idx] {
+						t.Errorf("position %d: id %d, want %d (fixture index %d)",
+							i, got[i].ID, ids[idx], idx)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestTransactionRepository_List_ExcludesSoftDeleted(t *testing.T) {
+	g := openTestDB(t)
+	repo := repository.NewTransactionRepository(g)
+	accA, _, _, _, ids := seedTxFixture(t, g)
+
+	// Soft-delete fixture row index 1 (account A, 2026-05-12).
+	if err := repo.SoftDelete(context.Background(), ids[1]); err != nil {
+		t.Fatalf("soft delete: %v", err)
+	}
+	got, total, err := repo.List(context.Background(), repository.TransactionFilter{AccountID: int64Ptr(accA)})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if total != 2 {
+		t.Errorf("total = %d, want 2 (one soft-deleted should be excluded)", total)
+	}
+	gotIDs := txIDSet(got)
+	if _, ok := gotIDs[ids[1]]; ok {
+		t.Errorf("soft-deleted id %d appeared in list", ids[1])
+	}
+}
+
+func int64Ptr(v int64) *int64 { return &v }
+
+func timePtr(s string) *time.Time {
+	t, _ := time.Parse("2006-01-02", s)
+	return &t
+}
+
+func txIDSet(ts []model.Transaction) map[int64]struct{} {
+	out := make(map[int64]struct{}, len(ts))
+	for _, t := range ts {
+		out[t.ID] = struct{}{}
+	}
+	return out
+}

--- a/backend/internal/service/transaction_service.go
+++ b/backend/internal/service/transaction_service.go
@@ -128,6 +128,13 @@ func (s *TransactionService) Create(ctx context.Context, in CreateTransactionInp
 	return t, nil
 }
 
+// List returns transactions matching the filter, plus the total count
+// (count uses the same WHERE clause sans limit/offset so the UI can render
+// pagination controls).
+func (s *TransactionService) List(ctx context.Context, f repository.TransactionFilter) ([]model.Transaction, int64, error) {
+	return s.repo.List(ctx, f)
+}
+
 func (s *TransactionService) Get(ctx context.Context, id int64) (*model.Transaction, error) {
 	t, err := s.repo.GetByID(ctx, id)
 	if err != nil {


### PR DESCRIPTION
## Summary
- `GET /api/v1/transactions` with `account_id`, `category_id` (or `null` for uncategorized), `from`/`to` date range, `search` (ILIKE on description + merchant_name), and `limit`/`offset` pagination.
- Response: `{data, total, limit, offset}`. `total` uses the same WHERE clause without limit/offset.
- Stable sort: `transaction_date DESC, id DESC`.

## Test plan
- [x] `go test ./...` passes (12 table-driven cases for filter dimensions + soft-delete exclusion test)
- [x] `golangci-lint run` reports 0 issues
- [x] Smoke-tested against running server: filter by account, uncategorized via `null`, search, limit clamp, validation errors

## Index notes
- Existing indexes from migration 000001 cover `account_id`, `transaction_date DESC`, and `category_id`. Search hits a seq scan on `description`/`merchant_name`; if that becomes a problem on realistic data it's a follow-up.

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)