### PR TITLE
docs #38: Document Claude session tips in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,12 @@
 
 When running via Claude's Bash tool, prefix `make` with `command` (`command make dev`) — a zsh autoload stub in the shell snapshot shadows the binary. Interactive shells are unaffected.
 
+## Working in Claude Sessions
+- Use `command make` (not raw `make`) — a zsh autoload stub in claude-code's shell snapshot shadows the binary in Claude's Bash tool. Interactive terminals are unaffected.
+- Bash tool cwd persists across calls. Stay in the repo root for `git` (so it matches the allowlist's plain `git <verb>` patterns); `cd backend` only when running `make`/`go`/etc.
+- Don't put a `cd` and a dependent command in the same tool turn as parallel calls — parallel Bash invocations have no defined order. Either chain them with `&&` (loses allowlist match) or send them as separate sequential calls (preferred).
+- For port-bound dev servers, always stop *by port* (`make stop` does this) — `go run` spawns a supervisor + child binary, so killing the saved PID isn't sufficient.
+
 ## Autonomous Workflow
 1. Read @docs/ROADMAP.md → find current milestone
 2. `gh issue list --state open --milestone "<current milestone>"`


### PR DESCRIPTION
## Summary
Moves the dev-workflow lessons from M2 (`command make`, cwd persistence, parallel-cd, kill-by-port) into CLAUDE.md so they travel with the repo instead of living in one user's personal Claude memory.

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)