### PR TITLE
M2.5 #45: Households + lifecycle + account_shares APIs

### DIFF
--- a/backend/internal/handler/household_handler.go
+++ b/backend/internal/handler/household_handler.go
@@ -1,0 +1,244 @@
+package handler
+
+import (
+	"errors"
+	"net/http"
+	"strconv"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/gregwym/offbook/backend/internal/service/auth"
+	"github.com/gregwym/offbook/backend/internal/service/household"
+)
+
+type HouseholdHandler struct {
+	svc *household.Service
+}
+
+func NewHouseholdHandler(s *household.Service) *HouseholdHandler {
+	return &HouseholdHandler{svc: s}
+}
+
+// Register attaches routes to the authenticated /api/v1 group.
+//   POST   /households                        create
+//   GET    /households/:id                    detail (member-only)
+//   PATCH  /households/:id                    update name / grace (owner)
+//   DELETE /households/:id                    dissolve (owner)
+//   POST   /households/:id/invites            mint invite token (owner)
+//   POST   /invites/:token/accept             consume token
+//   DELETE /households/:id/members/me         self-leave
+//
+//   GET    /accounts/:id/shares                       list visibility per household
+//   PUT    /accounts/:id/shares/:householdID          set/clear visibility
+func (h *HouseholdHandler) Register(g *gin.RouterGroup) {
+	g.POST("/households", h.Create)
+	g.GET("/households/:id", h.Get)
+	g.PATCH("/households/:id", h.Update)
+	g.DELETE("/households/:id", h.Dissolve)
+	g.POST("/households/:id/invites", h.CreateInvite)
+	g.POST("/invites/:token/accept", h.AcceptInvite)
+	g.DELETE("/households/:id/members/me", h.LeaveSelf)
+
+	g.GET("/accounts/:id/shares", h.ListShares)
+	g.PUT("/accounts/:id/shares/:householdID", h.SetShare)
+}
+
+// --- request shapes ---
+
+type createHouseholdRequest struct {
+	Name            string `json:"name"`
+	GracePeriodDays *int   `json:"grace_period_days"`
+}
+
+type updateHouseholdRequest struct {
+	Name            *string `json:"name"`
+	GracePeriodDays *int    `json:"grace_period_days"`
+}
+
+type createInviteRequest struct {
+	Role string `json:"role"`
+}
+
+type setShareRequest struct {
+	Visibility string `json:"visibility"`
+}
+
+// --- handlers ---
+
+func (h *HouseholdHandler) Create(c *gin.Context) {
+	var req createHouseholdRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error(), "code": "INVALID_REQUEST"})
+		return
+	}
+	hh, err := h.svc.Create(c.Request.Context(), auth.MustUserID(c.Request.Context()), household.CreateInput{
+		Name:            req.Name,
+		GracePeriodDays: req.GracePeriodDays,
+	})
+	if err != nil {
+		h.writeError(c, err)
+		return
+	}
+	c.JSON(http.StatusCreated, gin.H{"data": hh})
+}
+
+func (h *HouseholdHandler) Get(c *gin.Context) {
+	id, ok := parseID(c)
+	if !ok {
+		return
+	}
+	detail, err := h.svc.Get(c.Request.Context(), auth.MustUserID(c.Request.Context()), id)
+	if err != nil {
+		h.writeError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"data": detail})
+}
+
+func (h *HouseholdHandler) Update(c *gin.Context) {
+	id, ok := parseID(c)
+	if !ok {
+		return
+	}
+	var req updateHouseholdRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error(), "code": "INVALID_REQUEST"})
+		return
+	}
+	hh, err := h.svc.Update(c.Request.Context(), auth.MustUserID(c.Request.Context()), id, household.UpdateInput{
+		Name:            req.Name,
+		GracePeriodDays: req.GracePeriodDays,
+	})
+	if err != nil {
+		h.writeError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"data": hh})
+}
+
+func (h *HouseholdHandler) Dissolve(c *gin.Context) {
+	id, ok := parseID(c)
+	if !ok {
+		return
+	}
+	if err := h.svc.Dissolve(c.Request.Context(), auth.MustUserID(c.Request.Context()), id); err != nil {
+		h.writeError(c, err)
+		return
+	}
+	c.Status(http.StatusNoContent)
+}
+
+func (h *HouseholdHandler) CreateInvite(c *gin.Context) {
+	id, ok := parseID(c)
+	if !ok {
+		return
+	}
+	var req createInviteRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		// Empty body is allowed — role defaults to contributor.
+		req = createInviteRequest{}
+	}
+	res, err := h.svc.CreateInvite(c.Request.Context(), auth.MustUserID(c.Request.Context()), id, household.CreateInviteInput{
+		Role: req.Role,
+	})
+	if err != nil {
+		h.writeError(c, err)
+		return
+	}
+	c.JSON(http.StatusCreated, gin.H{"data": res})
+}
+
+func (h *HouseholdHandler) AcceptInvite(c *gin.Context) {
+	token := c.Param("token")
+	res, err := h.svc.AcceptInvite(c.Request.Context(), auth.MustUserID(c.Request.Context()), token)
+	if err != nil {
+		h.writeError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"data": res})
+}
+
+func (h *HouseholdHandler) LeaveSelf(c *gin.Context) {
+	id, ok := parseID(c)
+	if !ok {
+		return
+	}
+	if err := h.svc.Leave(c.Request.Context(), auth.MustUserID(c.Request.Context()), id); err != nil {
+		h.writeError(c, err)
+		return
+	}
+	c.Status(http.StatusNoContent)
+}
+
+func (h *HouseholdHandler) ListShares(c *gin.Context) {
+	id, ok := parseID(c)
+	if !ok {
+		return
+	}
+	shares, err := h.svc.ListShares(c.Request.Context(), auth.MustUserID(c.Request.Context()), id)
+	if err != nil {
+		h.writeError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"data": shares, "total": int64(len(shares))})
+}
+
+func (h *HouseholdHandler) SetShare(c *gin.Context) {
+	accountID, ok := parseID(c)
+	if !ok {
+		return
+	}
+	householdID, err := strconv.ParseInt(c.Param("householdID"), 10, 64)
+	if err != nil || householdID <= 0 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "householdID must be a positive integer", "code": "INVALID_REQUEST"})
+		return
+	}
+	var req setShareRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error(), "code": "INVALID_REQUEST"})
+		return
+	}
+	share, err := h.svc.SetShare(c.Request.Context(), auth.MustUserID(c.Request.Context()), accountID, householdID, req.Visibility)
+	if err != nil {
+		h.writeError(c, err)
+		return
+	}
+	if share == nil {
+		// Visibility==private → row cleared (idempotent).
+		c.Status(http.StatusNoContent)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"data": share})
+}
+
+// writeError maps household domain errors to HTTP status codes.
+func (h *HouseholdHandler) writeError(c *gin.Context, err error) {
+	switch {
+	case errors.Is(err, household.ErrHouseholdNotFound),
+		errors.Is(err, household.ErrInviteNotFound):
+		c.JSON(http.StatusNotFound, gin.H{"error": err.Error(), "code": "NOT_FOUND"})
+	case errors.Is(err, household.ErrNotMember),
+		errors.Is(err, household.ErrAccountNotOwned):
+		// Treat as 404 so non-members can't fingerprint existence.
+		c.JSON(http.StatusNotFound, gin.H{"error": "not found", "code": "NOT_FOUND"})
+	case errors.Is(err, household.ErrForbidden):
+		c.JSON(http.StatusForbidden, gin.H{"error": err.Error(), "code": "FORBIDDEN"})
+	case errors.Is(err, household.ErrLastOwner):
+		c.JSON(http.StatusConflict, gin.H{"error": err.Error(), "code": "LAST_OWNER"})
+	case errors.Is(err, household.ErrAlreadyMember):
+		c.JSON(http.StatusConflict, gin.H{"error": err.Error(), "code": "ALREADY_MEMBER"})
+	case errors.Is(err, household.ErrInviteAlreadyAccepted):
+		c.JSON(http.StatusConflict, gin.H{"error": err.Error(), "code": "INVITE_ACCEPTED"})
+	case errors.Is(err, household.ErrInviteExpired):
+		c.JSON(http.StatusGone, gin.H{"error": err.Error(), "code": "INVITE_EXPIRED"})
+	case errors.Is(err, household.ErrEmptyName),
+		errors.Is(err, household.ErrInvalidRole),
+		errors.Is(err, household.ErrInvalidGrace),
+		errors.Is(err, household.ErrInvalidVisibility):
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error(), "code": "INVALID_REQUEST"})
+	case errors.Is(err, household.ErrInstanceNotReady):
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": err.Error(), "code": "NOT_BOOTSTRAPPED"})
+	default:
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error(), "code": "INTERNAL"})
+	}
+}

--- a/backend/internal/model/household.go
+++ b/backend/internal/model/household.go
@@ -15,9 +15,12 @@ const (
 )
 
 // Account share visibility levels. Absence of an account_shares row = "private".
+// VisibilityPrivate is an API-level value: sending it on PUT clears the share.
+// It is never stored — the CHECK constraint only permits the other two.
 const (
-	VisibilityBalanceOnly     = "balance_only"
-	VisibilityBalanceAndTxns  = "balance_and_txns"
+	VisibilityPrivate        = "private"
+	VisibilityBalanceOnly    = "balance_only"
+	VisibilityBalanceAndTxns = "balance_and_txns"
 )
 
 type Household struct {

--- a/backend/internal/repository/household_repo.go
+++ b/backend/internal/repository/household_repo.go
@@ -1,0 +1,322 @@
+package repository
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"gorm.io/gorm"
+
+	"github.com/gregwym/offbook/backend/internal/model"
+)
+
+// HouseholdRepository owns CRUD for the households table itself.
+type HouseholdRepository interface {
+	Create(ctx context.Context, h *model.Household) error
+	GetByID(ctx context.Context, id int64) (*model.Household, error)
+	Update(ctx context.Context, h *model.Household) error
+	SoftDelete(ctx context.Context, id int64) error
+}
+
+// HouseholdMemberRepository manages the membership lifecycle (join, leave,
+// rejoin, purge). Reads return active rows by default; callers pass
+// IncludeLeft / IncludePurged when they need lifecycle introspection.
+type HouseholdMemberRepository interface {
+	Create(ctx context.Context, m *model.HouseholdMember) error
+	// GetActive returns the active (left_at IS NULL AND purged_at IS NULL) row
+	// for (householdID, userID), or ErrNotFound.
+	GetActive(ctx context.Context, householdID, userID int64) (*model.HouseholdMember, error)
+	// GetByID returns a row by its primary key irrespective of lifecycle state.
+	GetByID(ctx context.Context, id int64) (*model.HouseholdMember, error)
+	// GetMembershipForUser returns the user's not-yet-purged row in any
+	// household (active OR in-grace). At most one row by uniqueness invariant.
+	GetMembershipForUser(ctx context.Context, userID int64) (*model.HouseholdMember, error)
+	// ListActive returns all active members of a household. Order: role then id.
+	ListActive(ctx context.Context, householdID int64) ([]model.HouseholdMember, error)
+	// CountActiveOwners reports how many owners are still active (left_at IS NULL
+	// AND purged_at IS NULL). Used to enforce the LAST_OWNER guard.
+	CountActiveOwners(ctx context.Context, householdID int64) (int64, error)
+	// MarkLeft sets left_at = now on a single membership row. Idempotent only
+	// in the sense that it returns ErrNotFound if already left.
+	MarkLeft(ctx context.Context, id int64, at time.Time) error
+	// ClearLeft re-activates a not-yet-purged row by zeroing left_at.
+	ClearLeft(ctx context.Context, id int64) error
+}
+
+// HouseholdInviteRepository persists invite tokens. Tokens are HMAC-hashed by
+// the service before storage; only the raw token is given to the invitee.
+type HouseholdInviteRepository interface {
+	Create(ctx context.Context, i *model.HouseholdInvite) error
+	GetByTokenHash(ctx context.Context, tokenHash string) (*model.HouseholdInvite, error)
+	MarkAccepted(ctx context.Context, id int64, userID int64, at time.Time) error
+}
+
+// AccountShareRepository owns the per-account, per-household visibility rows.
+type AccountShareRepository interface {
+	// GetActive returns the active row for (accountID, householdID), or ErrNotFound.
+	GetActive(ctx context.Context, accountID, householdID int64) (*model.AccountShare, error)
+	// ListByAccount returns active shares for the given account.
+	ListByAccount(ctx context.Context, accountID int64) ([]model.AccountShare, error)
+	// Upsert creates or updates the (accountID, householdID) share. If a
+	// soft-deleted row exists for the same pair, it is resurrected with the
+	// new visibility and a fresh updated_at.
+	Upsert(ctx context.Context, accountID, householdID int64, visibility string) (*model.AccountShare, error)
+	// SoftDelete clears the active share (sets visibility back to implicit
+	// `private`). Returns ErrNotFound if no active row exists.
+	SoftDelete(ctx context.Context, accountID, householdID int64) error
+}
+
+// --- households ---
+
+type householdRepo struct{ db *gorm.DB }
+
+func NewHouseholdRepository(db *gorm.DB) HouseholdRepository {
+	return &householdRepo{db: db}
+}
+
+func (r *householdRepo) Create(ctx context.Context, h *model.Household) error {
+	return r.db.WithContext(ctx).Create(h).Error
+}
+
+func (r *householdRepo) GetByID(ctx context.Context, id int64) (*model.Household, error) {
+	var h model.Household
+	if err := r.db.WithContext(ctx).First(&h, id).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, ErrNotFound
+		}
+		return nil, err
+	}
+	return &h, nil
+}
+
+func (r *householdRepo) Update(ctx context.Context, h *model.Household) error {
+	res := r.db.WithContext(ctx).Save(h)
+	if res.Error != nil {
+		return res.Error
+	}
+	if res.RowsAffected == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+func (r *householdRepo) SoftDelete(ctx context.Context, id int64) error {
+	res := r.db.WithContext(ctx).Delete(&model.Household{}, id)
+	if res.Error != nil {
+		return res.Error
+	}
+	if res.RowsAffected == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+// --- household_members ---
+
+type householdMemberRepo struct{ db *gorm.DB }
+
+func NewHouseholdMemberRepository(db *gorm.DB) HouseholdMemberRepository {
+	return &householdMemberRepo{db: db}
+}
+
+func (r *householdMemberRepo) Create(ctx context.Context, m *model.HouseholdMember) error {
+	return r.db.WithContext(ctx).Create(m).Error
+}
+
+func (r *householdMemberRepo) GetActive(ctx context.Context, householdID, userID int64) (*model.HouseholdMember, error) {
+	var m model.HouseholdMember
+	err := r.db.WithContext(ctx).
+		Where("household_id = ? AND user_id = ? AND left_at IS NULL AND purged_at IS NULL", householdID, userID).
+		First(&m).Error
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, ErrNotFound
+		}
+		return nil, err
+	}
+	return &m, nil
+}
+
+func (r *householdMemberRepo) GetByID(ctx context.Context, id int64) (*model.HouseholdMember, error) {
+	var m model.HouseholdMember
+	if err := r.db.WithContext(ctx).First(&m, id).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, ErrNotFound
+		}
+		return nil, err
+	}
+	return &m, nil
+}
+
+func (r *householdMemberRepo) GetMembershipForUser(ctx context.Context, userID int64) (*model.HouseholdMember, error) {
+	var m model.HouseholdMember
+	err := r.db.WithContext(ctx).
+		Where("user_id = ? AND purged_at IS NULL", userID).
+		First(&m).Error
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, ErrNotFound
+		}
+		return nil, err
+	}
+	return &m, nil
+}
+
+func (r *householdMemberRepo) ListActive(ctx context.Context, householdID int64) ([]model.HouseholdMember, error) {
+	var out []model.HouseholdMember
+	err := r.db.WithContext(ctx).
+		Where("household_id = ? AND left_at IS NULL AND purged_at IS NULL", householdID).
+		Order("CASE role WHEN 'owner' THEN 0 WHEN 'contributor' THEN 1 ELSE 2 END, id").
+		Find(&out).Error
+	return out, err
+}
+
+func (r *householdMemberRepo) CountActiveOwners(ctx context.Context, householdID int64) (int64, error) {
+	var n int64
+	err := r.db.WithContext(ctx).
+		Model(&model.HouseholdMember{}).
+		Where("household_id = ? AND role = ? AND left_at IS NULL AND purged_at IS NULL",
+			householdID, model.RoleOwner).
+		Count(&n).Error
+	return n, err
+}
+
+func (r *householdMemberRepo) MarkLeft(ctx context.Context, id int64, at time.Time) error {
+	res := r.db.WithContext(ctx).
+		Model(&model.HouseholdMember{}).
+		Where("id = ? AND left_at IS NULL AND purged_at IS NULL", id).
+		Update("left_at", at)
+	if res.Error != nil {
+		return res.Error
+	}
+	if res.RowsAffected == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+func (r *householdMemberRepo) ClearLeft(ctx context.Context, id int64) error {
+	res := r.db.WithContext(ctx).
+		Model(&model.HouseholdMember{}).
+		Where("id = ? AND purged_at IS NULL", id).
+		Update("left_at", nil)
+	if res.Error != nil {
+		return res.Error
+	}
+	if res.RowsAffected == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+// --- household_invites ---
+
+type householdInviteRepo struct{ db *gorm.DB }
+
+func NewHouseholdInviteRepository(db *gorm.DB) HouseholdInviteRepository {
+	return &householdInviteRepo{db: db}
+}
+
+func (r *householdInviteRepo) Create(ctx context.Context, i *model.HouseholdInvite) error {
+	return r.db.WithContext(ctx).Create(i).Error
+}
+
+func (r *householdInviteRepo) GetByTokenHash(ctx context.Context, tokenHash string) (*model.HouseholdInvite, error) {
+	var i model.HouseholdInvite
+	if err := r.db.WithContext(ctx).Where("token_hash = ?", tokenHash).First(&i).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, ErrNotFound
+		}
+		return nil, err
+	}
+	return &i, nil
+}
+
+func (r *householdInviteRepo) MarkAccepted(ctx context.Context, id, userID int64, at time.Time) error {
+	res := r.db.WithContext(ctx).
+		Model(&model.HouseholdInvite{}).
+		Where("id = ? AND accepted_at IS NULL", id).
+		Updates(map[string]any{"accepted_at": at, "accepted_by": userID})
+	if res.Error != nil {
+		return res.Error
+	}
+	if res.RowsAffected == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+// --- account_shares ---
+
+type accountShareRepo struct{ db *gorm.DB }
+
+func NewAccountShareRepository(db *gorm.DB) AccountShareRepository {
+	return &accountShareRepo{db: db}
+}
+
+func (r *accountShareRepo) GetActive(ctx context.Context, accountID, householdID int64) (*model.AccountShare, error) {
+	var s model.AccountShare
+	err := r.db.WithContext(ctx).
+		Where("account_id = ? AND household_id = ?", accountID, householdID).
+		First(&s).Error
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, ErrNotFound
+		}
+		return nil, err
+	}
+	return &s, nil
+}
+
+func (r *accountShareRepo) ListByAccount(ctx context.Context, accountID int64) ([]model.AccountShare, error) {
+	var out []model.AccountShare
+	err := r.db.WithContext(ctx).
+		Where("account_id = ?", accountID).
+		Order("household_id").
+		Find(&out).Error
+	return out, err
+}
+
+func (r *accountShareRepo) Upsert(ctx context.Context, accountID, householdID int64, visibility string) (*model.AccountShare, error) {
+	// Look for any row — including soft-deleted — so we can resurrect rather than
+	// collide with the partial unique index later.
+	var s model.AccountShare
+	err := r.db.WithContext(ctx).
+		Unscoped().
+		Where("account_id = ? AND household_id = ?", accountID, householdID).
+		First(&s).Error
+	switch {
+	case err == nil:
+		s.Visibility = visibility
+		s.DeletedAt = gorm.DeletedAt{}
+		if err := r.db.WithContext(ctx).Unscoped().Save(&s).Error; err != nil {
+			return nil, err
+		}
+		return &s, nil
+	case errors.Is(err, gorm.ErrRecordNotFound):
+		s = model.AccountShare{
+			AccountID:   accountID,
+			HouseholdID: householdID,
+			Visibility:  visibility,
+		}
+		if err := r.db.WithContext(ctx).Create(&s).Error; err != nil {
+			return nil, err
+		}
+		return &s, nil
+	default:
+		return nil, err
+	}
+}
+
+func (r *accountShareRepo) SoftDelete(ctx context.Context, accountID, householdID int64) error {
+	res := r.db.WithContext(ctx).
+		Where("account_id = ? AND household_id = ?", accountID, householdID).
+		Delete(&model.AccountShare{})
+	if res.Error != nil {
+		return res.Error
+	}
+	if res.RowsAffected == 0 {
+		return ErrNotFound
+	}
+	return nil
+}

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gregwym/offbook/backend/internal/repository"
 	"github.com/gregwym/offbook/backend/internal/service"
 	"github.com/gregwym/offbook/backend/internal/service/auth"
+	"github.com/gregwym/offbook/backend/internal/service/household"
 )
 
 func New(cfg config.Config, gormDB *gorm.DB) *gin.Engine {
@@ -45,6 +46,18 @@ func New(cfg config.Config, gormDB *gorm.DB) *gin.Engine {
 	dashboardSvc := service.NewDashboardService(dashboardRepo)
 	dashboardHandler := handler.NewDashboardHandler(dashboardSvc)
 
+	householdSvc := household.NewService(
+		repository.NewHouseholdRepository(gormDB),
+		repository.NewHouseholdMemberRepository(gormDB),
+		repository.NewHouseholdInviteRepository(gormDB),
+		repository.NewAccountShareRepository(gormDB),
+		accountRepo,
+		repository.NewInstanceConfigRepository(gormDB),
+		repository.NewUserRepository(gormDB),
+		cfg.SessionSecret,
+	)
+	householdHandler := handler.NewHouseholdHandler(householdSvc)
+
 	v1 := r.Group("/api/v1")
 	{
 		// Open routes — no session required.
@@ -59,6 +72,7 @@ func New(cfg config.Config, gormDB *gorm.DB) *gin.Engine {
 		piiHandler.RegisterAccountRoutes(secured)
 		transactionHandler.Register(secured)
 		dashboardHandler.Register(secured)
+		householdHandler.Register(secured)
 	}
 
 	return r

--- a/backend/internal/service/auth/service.go
+++ b/backend/internal/service/auth/service.go
@@ -222,7 +222,7 @@ func (s *Service) InstanceConfig(ctx context.Context) (*model.InstanceConfig, er
 // issueSession mints a fresh token, stores its hash, and returns the raw
 // token so the handler can set the cookie.
 func (s *Service) issueSession(ctx context.Context, u *model.User) (*SigninResult, error) {
-	token, err := newToken()
+	token, err := NewToken()
 	if err != nil {
 		return nil, fmt.Errorf("token: %w", err)
 	}

--- a/backend/internal/service/auth/session.go
+++ b/backend/internal/service/auth/session.go
@@ -21,9 +21,10 @@ var (
 	ErrSessionExpired  = errors.New("session expired")
 )
 
-// newToken returns 32 bytes of random hex. Caller stores HashToken(token);
-// the raw token only ever lives in the cookie.
-func newToken() (string, error) {
+// NewToken returns 32 bytes of random hex. Caller stores HashToken(token);
+// the raw token only ever lives in the cookie (sessions) or in the link sent
+// to the invitee (household invites).
+func NewToken() (string, error) {
 	buf := make([]byte, 32)
 	if _, err := rand.Read(buf); err != nil {
 		return "", err

--- a/backend/internal/service/household/errors.go
+++ b/backend/internal/service/household/errors.go
@@ -1,0 +1,24 @@
+package household
+
+import "errors"
+
+// Domain errors. Handlers map these to HTTP status codes; tests use errors.Is.
+var (
+	ErrHouseholdNotFound     = errors.New("household not found")
+	ErrInviteNotFound        = errors.New("invite not found")
+	ErrInviteExpired         = errors.New("invite expired")
+	ErrInviteAlreadyAccepted = errors.New("invite already accepted")
+
+	ErrEmptyName        = errors.New("name must not be empty")
+	ErrInvalidRole      = errors.New("invalid role")
+	ErrInvalidGrace     = errors.New("grace_period_days must be >= 0")
+	ErrInvalidVisibility = errors.New("invalid visibility")
+
+	// Lifecycle / authorization
+	ErrForbidden        = errors.New("forbidden")
+	ErrNotMember        = errors.New("not a member of this household")
+	ErrAlreadyMember    = errors.New("already a member of a household")
+	ErrLastOwner        = errors.New("cannot leave: you are the last owner")
+	ErrAccountNotOwned  = errors.New("account does not belong to user")
+	ErrInstanceNotReady = errors.New("instance not configured")
+)

--- a/backend/internal/service/household/service.go
+++ b/backend/internal/service/household/service.go
@@ -1,0 +1,461 @@
+package household
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/gregwym/offbook/backend/internal/model"
+	"github.com/gregwym/offbook/backend/internal/repository"
+	"github.com/gregwym/offbook/backend/internal/service/auth"
+)
+
+// InviteTTL is how long a freshly minted invite token remains acceptable.
+const InviteTTL = 7 * 24 * time.Hour
+
+// HouseholdDetail is the GET /households/:id payload — household + active members.
+type HouseholdDetail struct {
+	Household *model.Household         `json:"household"`
+	Members   []model.HouseholdMember  `json:"members"`
+	Role      string                   `json:"role"` // requester's role in this household
+}
+
+// CreateInput is the body for POST /households.
+type CreateInput struct {
+	Name            string
+	GracePeriodDays *int
+}
+
+// UpdateInput patches name and/or grace_period_days. Owner-only.
+type UpdateInput struct {
+	Name            *string
+	GracePeriodDays *int
+}
+
+// CreateInviteInput is the body for POST /households/:id/invites.
+type CreateInviteInput struct {
+	Role string // owner | contributor | view_only; defaults to contributor
+}
+
+// CreateInviteResult bundles the raw token (only thing the invitee needs)
+// with the persisted invite metadata.
+type CreateInviteResult struct {
+	Invite *model.HouseholdInvite `json:"invite"`
+	Token  string                 `json:"token"`
+}
+
+// AcceptResult is what POST /invites/:token/accept returns.
+type AcceptResult struct {
+	Household *model.Household       `json:"household"`
+	Member    *model.HouseholdMember `json:"member"`
+	Resumed   bool                   `json:"resumed"`
+}
+
+// Service owns household lifecycle + per-account share management. It is the
+// SECOND non-aggregator service in service/household — the aggregator (next
+// issue) handles cross-user reads of domain data and shares this package's
+// import boundary: NEVER pii_repo.
+type Service struct {
+	households repository.HouseholdRepository
+	members    repository.HouseholdMemberRepository
+	invites    repository.HouseholdInviteRepository
+	shares     repository.AccountShareRepository
+	accounts   repository.AccountRepository
+	config     repository.InstanceConfigRepository
+	users      repository.UserRepository
+	secret     string
+	now        func() time.Time
+}
+
+func NewService(
+	households repository.HouseholdRepository,
+	members repository.HouseholdMemberRepository,
+	invites repository.HouseholdInviteRepository,
+	shares repository.AccountShareRepository,
+	accounts repository.AccountRepository,
+	config repository.InstanceConfigRepository,
+	users repository.UserRepository,
+	secret string,
+) *Service {
+	return &Service{
+		households: households,
+		members:    members,
+		invites:    invites,
+		shares:     shares,
+		accounts:   accounts,
+		config:     config,
+		users:      users,
+		secret:     secret,
+		now:        time.Now,
+	}
+}
+
+// SetClock lets tests freeze time for invite-expiry assertions.
+func (s *Service) SetClock(fn func() time.Time) { s.now = fn }
+
+// --- Household CRUD ---
+
+// Create makes a new household with the caller as `owner`. A user can belong
+// to at most one household (ADR-0006) — callers already in one get ErrAlreadyMember.
+func (s *Service) Create(ctx context.Context, userID int64, in CreateInput) (*model.Household, error) {
+	name := strings.TrimSpace(in.Name)
+	if name == "" {
+		return nil, ErrEmptyName
+	}
+	grace := 30
+	if in.GracePeriodDays != nil {
+		if *in.GracePeriodDays < 0 {
+			return nil, ErrInvalidGrace
+		}
+		grace = *in.GracePeriodDays
+	}
+	// At-most-one-household invariant.
+	if existing, err := s.members.GetMembershipForUser(ctx, userID); err == nil && existing != nil {
+		return nil, ErrAlreadyMember
+	} else if err != nil && !errors.Is(err, repository.ErrNotFound) {
+		return nil, fmt.Errorf("check existing membership: %w", err)
+	}
+
+	h := &model.Household{
+		Name:            name,
+		OwnerID:         userID,
+		GracePeriodDays: grace,
+	}
+	if err := s.households.Create(ctx, h); err != nil {
+		return nil, fmt.Errorf("create household: %w", err)
+	}
+	m := &model.HouseholdMember{
+		HouseholdID: h.ID,
+		UserID:      userID,
+		Role:        model.RoleOwner,
+		JoinedAt:    s.now(),
+	}
+	if err := s.members.Create(ctx, m); err != nil {
+		return nil, fmt.Errorf("seed owner member: %w", err)
+	}
+	return h, nil
+}
+
+// Get returns the household detail (with members) provided the caller is an
+// active member. Non-members get ErrNotMember (we don't leak existence).
+func (s *Service) Get(ctx context.Context, userID, householdID int64) (*HouseholdDetail, error) {
+	mem, err := s.members.GetActive(ctx, householdID, userID)
+	if err != nil {
+		if errors.Is(err, repository.ErrNotFound) {
+			return nil, ErrNotMember
+		}
+		return nil, err
+	}
+	h, err := s.households.GetByID(ctx, householdID)
+	if err != nil {
+		if errors.Is(err, repository.ErrNotFound) {
+			return nil, ErrHouseholdNotFound
+		}
+		return nil, err
+	}
+	members, err := s.members.ListActive(ctx, householdID)
+	if err != nil {
+		return nil, fmt.Errorf("list members: %w", err)
+	}
+	return &HouseholdDetail{Household: h, Members: members, Role: mem.Role}, nil
+}
+
+// Update mutates name / grace_period_days. Owner-only.
+func (s *Service) Update(ctx context.Context, userID, householdID int64, in UpdateInput) (*model.Household, error) {
+	if err := s.requireOwner(ctx, userID, householdID); err != nil {
+		return nil, err
+	}
+	h, err := s.households.GetByID(ctx, householdID)
+	if err != nil {
+		if errors.Is(err, repository.ErrNotFound) {
+			return nil, ErrHouseholdNotFound
+		}
+		return nil, err
+	}
+	if in.Name != nil {
+		n := strings.TrimSpace(*in.Name)
+		if n == "" {
+			return nil, ErrEmptyName
+		}
+		h.Name = n
+	}
+	if in.GracePeriodDays != nil {
+		if *in.GracePeriodDays < 0 {
+			return nil, ErrInvalidGrace
+		}
+		h.GracePeriodDays = *in.GracePeriodDays
+	}
+	if err := s.households.Update(ctx, h); err != nil {
+		return nil, fmt.Errorf("update household: %w", err)
+	}
+	return h, nil
+}
+
+// Dissolve soft-deletes a household. Owner-only. Membership rows remain so
+// historical aggregates can still reference them per ADR-0007.
+func (s *Service) Dissolve(ctx context.Context, userID, householdID int64) error {
+	if err := s.requireOwner(ctx, userID, householdID); err != nil {
+		return err
+	}
+	if err := s.households.SoftDelete(ctx, householdID); err != nil {
+		if errors.Is(err, repository.ErrNotFound) {
+			return ErrHouseholdNotFound
+		}
+		return fmt.Errorf("dissolve household: %w", err)
+	}
+	return nil
+}
+
+// --- Invites ---
+
+// CreateInvite mints a token for the household. Owner-only.
+// The signup_mode check is defense in depth — invites work regardless of mode
+// per ADR-0007, but we refuse if the instance was never bootstrapped at all.
+func (s *Service) CreateInvite(ctx context.Context, userID, householdID int64, in CreateInviteInput) (*CreateInviteResult, error) {
+	if err := s.requireOwner(ctx, userID, householdID); err != nil {
+		return nil, err
+	}
+	if _, err := s.config.Get(ctx); err != nil {
+		if errors.Is(err, repository.ErrNotFound) {
+			return nil, ErrInstanceNotReady
+		}
+		return nil, fmt.Errorf("get instance_config: %w", err)
+	}
+	role := strings.TrimSpace(in.Role)
+	if role == "" {
+		role = model.RoleContributor
+	}
+	if !validRole(role) {
+		return nil, ErrInvalidRole
+	}
+
+	token, err := auth.NewToken()
+	if err != nil {
+		return nil, fmt.Errorf("mint token: %w", err)
+	}
+	now := s.now()
+	inv := &model.HouseholdInvite{
+		HouseholdID: householdID,
+		TokenHash:   auth.HashToken(token, s.secret),
+		Role:        role,
+		CreatedBy:   userID,
+		ExpiresAt:   now.Add(InviteTTL),
+		CreatedAt:   now,
+	}
+	if err := s.invites.Create(ctx, inv); err != nil {
+		return nil, fmt.Errorf("create invite: %w", err)
+	}
+	return &CreateInviteResult{Invite: inv, Token: token}, nil
+}
+
+// AcceptInvite consumes a raw invite token for the calling user.
+// Auto-resume per ADR-0007: if the user has a not-yet-purged left_at row in
+// the same household, we clear left_at and return resumed=true. Otherwise we
+// enforce the at-most-one-household invariant and create a fresh row.
+func (s *Service) AcceptInvite(ctx context.Context, userID int64, rawToken string) (*AcceptResult, error) {
+	if rawToken == "" {
+		return nil, ErrInviteNotFound
+	}
+	inv, err := s.invites.GetByTokenHash(ctx, auth.HashToken(rawToken, s.secret))
+	if err != nil {
+		if errors.Is(err, repository.ErrNotFound) {
+			return nil, ErrInviteNotFound
+		}
+		return nil, err
+	}
+	now := s.now()
+	if !inv.ExpiresAt.After(now) {
+		return nil, ErrInviteExpired
+	}
+	if inv.AcceptedAt != nil {
+		// If the same user is re-accepting their own previously consumed token
+		// AND they have a left_at-marked row, that's the auto-resume path.
+		if inv.AcceptedBy != nil && *inv.AcceptedBy == userID {
+			if resumed, err := s.tryResume(ctx, userID, inv.HouseholdID); err == nil {
+				h, hErr := s.households.GetByID(ctx, inv.HouseholdID)
+				if hErr != nil {
+					return nil, hErr
+				}
+				return &AcceptResult{Household: h, Member: resumed, Resumed: true}, nil
+			}
+		}
+		return nil, ErrInviteAlreadyAccepted
+	}
+
+	// If the user already has a not-yet-purged row in this household, resume.
+	if resumed, err := s.tryResume(ctx, userID, inv.HouseholdID); err == nil {
+		if err := s.invites.MarkAccepted(ctx, inv.ID, userID, now); err != nil {
+			return nil, fmt.Errorf("mark invite accepted: %w", err)
+		}
+		h, err := s.households.GetByID(ctx, inv.HouseholdID)
+		if err != nil {
+			return nil, err
+		}
+		return &AcceptResult{Household: h, Member: resumed, Resumed: true}, nil
+	} else if !errors.Is(err, repository.ErrNotFound) {
+		return nil, err
+	}
+
+	// Fresh join — at-most-one-household enforced across all households.
+	if existing, err := s.members.GetMembershipForUser(ctx, userID); err == nil && existing != nil {
+		return nil, ErrAlreadyMember
+	} else if err != nil && !errors.Is(err, repository.ErrNotFound) {
+		return nil, err
+	}
+
+	m := &model.HouseholdMember{
+		HouseholdID: inv.HouseholdID,
+		UserID:      userID,
+		Role:        inv.Role,
+		JoinedAt:    now,
+	}
+	if err := s.members.Create(ctx, m); err != nil {
+		return nil, fmt.Errorf("create member: %w", err)
+	}
+	if err := s.invites.MarkAccepted(ctx, inv.ID, userID, now); err != nil {
+		return nil, fmt.Errorf("mark invite accepted: %w", err)
+	}
+	h, err := s.households.GetByID(ctx, inv.HouseholdID)
+	if err != nil {
+		return nil, err
+	}
+	return &AcceptResult{Household: h, Member: m, Resumed: false}, nil
+}
+
+// Leave is self-service: sets left_at on the caller's active membership.
+// Returns ErrLastOwner if the caller is the sole remaining owner.
+func (s *Service) Leave(ctx context.Context, userID, householdID int64) error {
+	mem, err := s.members.GetActive(ctx, householdID, userID)
+	if err != nil {
+		if errors.Is(err, repository.ErrNotFound) {
+			return ErrNotMember
+		}
+		return err
+	}
+	if mem.Role == model.RoleOwner {
+		n, err := s.members.CountActiveOwners(ctx, householdID)
+		if err != nil {
+			return fmt.Errorf("count owners: %w", err)
+		}
+		if n <= 1 {
+			return ErrLastOwner
+		}
+	}
+	if err := s.members.MarkLeft(ctx, mem.ID, s.now()); err != nil {
+		return fmt.Errorf("mark left: %w", err)
+	}
+	return nil
+}
+
+// --- Account shares ---
+
+// ListShares returns active shares for an account. Account-owner only.
+func (s *Service) ListShares(ctx context.Context, userID, accountID int64) ([]model.AccountShare, error) {
+	if err := s.requireAccountOwner(ctx, userID, accountID); err != nil {
+		return nil, err
+	}
+	return s.shares.ListByAccount(ctx, accountID)
+}
+
+// SetShare upserts visibility for (accountID, householdID) or deletes the row
+// when visibility == "private". Account-owner only.
+func (s *Service) SetShare(ctx context.Context, userID, accountID, householdID int64, visibility string) (*model.AccountShare, error) {
+	if err := s.requireAccountOwner(ctx, userID, accountID); err != nil {
+		return nil, err
+	}
+	// Confirm the household actually exists; otherwise an attacker could fish
+	// for valid household IDs via 404 vs 201 responses.
+	if _, err := s.households.GetByID(ctx, householdID); err != nil {
+		if errors.Is(err, repository.ErrNotFound) {
+			return nil, ErrHouseholdNotFound
+		}
+		return nil, err
+	}
+
+	switch visibility {
+	case model.VisibilityPrivate:
+		if err := s.shares.SoftDelete(ctx, accountID, householdID); err != nil {
+			if errors.Is(err, repository.ErrNotFound) {
+				// Already private — idempotent success.
+				return nil, nil
+			}
+			return nil, fmt.Errorf("clear share: %w", err)
+		}
+		return nil, nil
+	case model.VisibilityBalanceOnly, model.VisibilityBalanceAndTxns:
+		share, err := s.shares.Upsert(ctx, accountID, householdID, visibility)
+		if err != nil {
+			return nil, fmt.Errorf("upsert share: %w", err)
+		}
+		return share, nil
+	default:
+		return nil, ErrInvalidVisibility
+	}
+}
+
+// --- internal helpers ---
+
+func (s *Service) requireOwner(ctx context.Context, userID, householdID int64) error {
+	mem, err := s.members.GetActive(ctx, householdID, userID)
+	if err != nil {
+		if errors.Is(err, repository.ErrNotFound) {
+			return ErrNotMember
+		}
+		return err
+	}
+	if mem.Role != model.RoleOwner {
+		return ErrForbidden
+	}
+	return nil
+}
+
+func (s *Service) requireAccountOwner(ctx context.Context, userID, accountID int64) error {
+	acc, err := s.accounts.GetByID(ctx, userID, accountID)
+	if err != nil {
+		if errors.Is(err, repository.ErrNotFound) {
+			return ErrAccountNotOwned
+		}
+		return err
+	}
+	if acc.UserID != userID {
+		return ErrAccountNotOwned
+	}
+	return nil
+}
+
+// tryResume looks for a not-yet-purged left_at-marked row in the given
+// household for the user and clears left_at. Returns the resurrected member.
+func (s *Service) tryResume(ctx context.Context, userID, householdID int64) (*model.HouseholdMember, error) {
+	// We need ANY not-yet-purged row regardless of left_at. The active query
+	// would skip a left-but-not-purged user — so query by user across the
+	// household.
+	mem, err := s.members.GetMembershipForUser(ctx, userID)
+	if err != nil {
+		return nil, err
+	}
+	if mem.HouseholdID != householdID {
+		// User is in a different household — at-most-one applies and there's
+		// no resume path.
+		return nil, repository.ErrNotFound
+	}
+	if mem.LeftAt == nil {
+		// Already active; nothing to resume — but caller should treat this as
+		// "you're already in, that's fine".
+		return mem, nil
+	}
+	if err := s.members.ClearLeft(ctx, mem.ID); err != nil {
+		return nil, err
+	}
+	mem.LeftAt = nil
+	return mem, nil
+}
+
+func validRole(r string) bool {
+	switch r {
+	case model.RoleOwner, model.RoleContributor, model.RoleViewOnly:
+		return true
+	}
+	return false
+}

--- a/backend/internal/service/household/service_test.go
+++ b/backend/internal/service/household/service_test.go
@@ -1,0 +1,555 @@
+package household_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/joho/godotenv"
+	"github.com/shopspring/decimal"
+	"gorm.io/gorm"
+
+	"github.com/gregwym/offbook/backend/internal/db"
+	"github.com/gregwym/offbook/backend/internal/model"
+	"github.com/gregwym/offbook/backend/internal/repository"
+	"github.com/gregwym/offbook/backend/internal/service"
+	"github.com/gregwym/offbook/backend/internal/service/household"
+)
+
+const testSecret = "household-test-secret"
+
+func loadRepoDotenv() {
+	dir, err := os.Getwd()
+	if err != nil {
+		return
+	}
+	for i := 0; i < 8; i++ {
+		envPath := filepath.Join(dir, ".env")
+		if _, err := os.Stat(envPath); err == nil {
+			_ = godotenv.Load(envPath)
+			return
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return
+		}
+		dir = parent
+	}
+}
+
+func openTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	loadRepoDotenv()
+	url := os.Getenv("TEST_DATABASE_URL")
+	if url == "" {
+		url = os.Getenv("DATABASE_URL")
+	}
+	if url == "" {
+		t.Skip("no DATABASE_URL set; skipping integration test")
+	}
+	g, err := db.Open(url)
+	if err != nil {
+		t.Fatalf("db.Open: %v", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := db.Ping(ctx, g); err != nil {
+		t.Skipf("db.Ping: %v; skipping integration test", err)
+	}
+	return g
+}
+
+// newSvc builds a real household.Service backed by Postgres, and pre-seeds
+// instance_config so invite creation is not gated by ErrInstanceNotReady.
+// All seeded rows are cleaned up via t.Cleanup.
+func newSvc(t *testing.T) (*household.Service, *service.AccountService, *gorm.DB) {
+	t.Helper()
+	g := openTestDB(t)
+	ensureBootstrapped(t, g)
+	accRepo := repository.NewAccountRepository(g)
+	svc := household.NewService(
+		repository.NewHouseholdRepository(g),
+		repository.NewHouseholdMemberRepository(g),
+		repository.NewHouseholdInviteRepository(g),
+		repository.NewAccountShareRepository(g),
+		accRepo,
+		repository.NewInstanceConfigRepository(g),
+		repository.NewUserRepository(g),
+		testSecret,
+	)
+	return svc, service.NewAccountService(accRepo), g
+}
+
+// ensureBootstrapped writes a singleton instance_config row if missing so the
+// household service's CreateInvite passes its "not bootstrapped" defense.
+// We don't clean this up because it's harmless idempotent state shared across tests.
+func ensureBootstrapped(t *testing.T, g *gorm.DB) {
+	t.Helper()
+	var cfg model.InstanceConfig
+	if err := g.First(&cfg).Error; err == nil {
+		return
+	} else if !errors.Is(err, gorm.ErrRecordNotFound) {
+		t.Fatalf("read instance_config: %v", err)
+	}
+	cfg = model.InstanceConfig{ID: 1, SignupMode: model.SignupModeInviteOnly}
+	if err := g.Create(&cfg).Error; err != nil {
+		t.Fatalf("seed instance_config: %v", err)
+	}
+}
+
+// seedUser inserts a throwaway user and registers a cascading cleanup that
+// strips FK-dependent rows (shares, members, accounts, sessions) before the
+// user itself is removed. This makes tests independent of t.Cleanup ordering.
+func seedUser(t *testing.T, g *gorm.DB, label string) int64 {
+	t.Helper()
+	u := &model.User{
+		Email:        fmt.Sprintf("hh-%s-%d@example.test", label, time.Now().UnixNano()),
+		PasswordHash: "x",
+		LastScope:    model.ScopePersonal,
+		DefaultScope: model.ScopePersonal,
+	}
+	if err := g.Create(u).Error; err != nil {
+		t.Fatalf("seed user: %v", err)
+	}
+	t.Cleanup(func() {
+		var accountIDs []int64
+		g.Unscoped().Model(&model.Account{}).Where("user_id = ?", u.ID).Pluck("id", &accountIDs)
+		if len(accountIDs) > 0 {
+			g.Unscoped().Where("account_id IN ?", accountIDs).Delete(&model.AccountShare{})
+		}
+		g.Unscoped().Where("user_id = ?", u.ID).Delete(&model.Account{})
+		g.Unscoped().Where("user_id = ?", u.ID).Delete(&model.HouseholdMember{})
+		g.Unscoped().Where("user_id = ?", u.ID).Delete(&model.Session{})
+		g.Unscoped().Delete(&model.User{}, u.ID)
+	})
+	return u.ID
+}
+
+func seedAccount(t *testing.T, g *gorm.DB, userID int64, label string) *model.Account {
+	t.Helper()
+	acc := &model.Account{
+		UserID:          userID,
+		Name:            "hh-acct-" + label + "-" + fmt.Sprintf("%d", time.Now().UnixNano()),
+		InstitutionSlug: "fixture",
+		AccountType:     "checking",
+		Currency:        "USD",
+		Balance:         decimal.Zero,
+		IsActive:        true,
+	}
+	if err := g.Create(acc).Error; err != nil {
+		t.Fatalf("seed account: %v", err)
+	}
+	t.Cleanup(func() { g.Unscoped().Delete(&model.Account{}, acc.ID) })
+	return acc
+}
+
+// cleanupHousehold removes the household and all its dependent rows. The model
+// uses partial unique indexes (purged_at, deleted_at), and tests share a DB,
+// so we hard-delete by IDs to keep tests independent.
+func cleanupHousehold(t *testing.T, g *gorm.DB, householdID int64) {
+	t.Helper()
+	t.Cleanup(func() {
+		g.Unscoped().Where("household_id = ?", householdID).Delete(&model.AccountShare{})
+		g.Unscoped().Where("household_id = ?", householdID).Delete(&model.HouseholdInvite{})
+		g.Unscoped().Where("household_id = ?", householdID).Delete(&model.HouseholdMember{})
+		g.Unscoped().Delete(&model.Household{}, householdID)
+	})
+}
+
+// TestCreate_CreatorBecomesOwner verifies the creator is enrolled as `owner`
+// and the household carries the chosen grace_period_days.
+func TestCreate_CreatorBecomesOwner(t *testing.T) {
+	svc, _, g := newSvc(t)
+	ctx := context.Background()
+	userID := seedUser(t, g, "creator")
+
+	grace := 14
+	hh, err := svc.Create(ctx, userID, household.CreateInput{
+		Name:            "Test House",
+		GracePeriodDays: &grace,
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	cleanupHousehold(t, g, hh.ID)
+
+	if hh.OwnerID != userID {
+		t.Errorf("OwnerID = %d, want %d", hh.OwnerID, userID)
+	}
+	if hh.GracePeriodDays != grace {
+		t.Errorf("GracePeriodDays = %d, want %d", hh.GracePeriodDays, grace)
+	}
+	detail, err := svc.Get(ctx, userID, hh.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if detail.Role != model.RoleOwner {
+		t.Errorf("requester role = %q, want owner", detail.Role)
+	}
+	if len(detail.Members) != 1 || detail.Members[0].UserID != userID || detail.Members[0].Role != model.RoleOwner {
+		t.Errorf("members = %+v, want exactly one owner row for caller", detail.Members)
+	}
+}
+
+// TestCreate_RejectsSecondHouseholdForUser enforces at-most-one (ADR-0006).
+func TestCreate_RejectsSecondHouseholdForUser(t *testing.T) {
+	svc, _, g := newSvc(t)
+	ctx := context.Background()
+	userID := seedUser(t, g, "double")
+
+	hh1, err := svc.Create(ctx, userID, household.CreateInput{Name: "First"})
+	if err != nil {
+		t.Fatalf("first create: %v", err)
+	}
+	cleanupHousehold(t, g, hh1.ID)
+
+	_, err = svc.Create(ctx, userID, household.CreateInput{Name: "Second"})
+	if !errors.Is(err, household.ErrAlreadyMember) {
+		t.Errorf("second create err = %v, want ErrAlreadyMember", err)
+	}
+}
+
+// TestInviteAndAccept_HappyPath covers the canonical invite flow: owner mints
+// a token, the invitee accepts, both are active members.
+func TestInviteAndAccept_HappyPath(t *testing.T) {
+	svc, _, g := newSvc(t)
+	ctx := context.Background()
+	ownerID := seedUser(t, g, "owner")
+	guestID := seedUser(t, g, "guest")
+
+	hh, err := svc.Create(ctx, ownerID, household.CreateInput{Name: "Invite House"})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	cleanupHousehold(t, g, hh.ID)
+
+	res, err := svc.CreateInvite(ctx, ownerID, hh.ID, household.CreateInviteInput{Role: model.RoleContributor})
+	if err != nil {
+		t.Fatalf("CreateInvite: %v", err)
+	}
+	if res.Token == "" {
+		t.Fatalf("expected raw token in CreateInviteResult")
+	}
+
+	accepted, err := svc.AcceptInvite(ctx, guestID, res.Token)
+	if err != nil {
+		t.Fatalf("AcceptInvite: %v", err)
+	}
+	if accepted.Resumed {
+		t.Errorf("Resumed = true, want false on fresh accept")
+	}
+	if accepted.Member.UserID != guestID || accepted.Member.Role != model.RoleContributor {
+		t.Errorf("Member = %+v, want guest as contributor", accepted.Member)
+	}
+
+	detail, err := svc.Get(ctx, ownerID, hh.ID)
+	if err != nil {
+		t.Fatalf("owner Get: %v", err)
+	}
+	if len(detail.Members) != 2 {
+		t.Errorf("members count = %d, want 2", len(detail.Members))
+	}
+
+	// Re-accepting the same token by a different user must be rejected.
+	other := seedUser(t, g, "other")
+	if _, err := svc.AcceptInvite(ctx, other, res.Token); !errors.Is(err, household.ErrInviteAlreadyAccepted) {
+		t.Errorf("re-accept by another user err = %v, want ErrInviteAlreadyAccepted", err)
+	}
+}
+
+// TestAccept_InviteExpired exercises the InviteTTL boundary.
+func TestAccept_InviteExpired(t *testing.T) {
+	svc, _, g := newSvc(t)
+	ctx := context.Background()
+	ownerID := seedUser(t, g, "expire-owner")
+	guestID := seedUser(t, g, "expire-guest")
+
+	// Freeze clock far in past for invite minting.
+	past := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	svc.SetClock(func() time.Time { return past })
+	hh, err := svc.Create(ctx, ownerID, household.CreateInput{Name: "Expiring"})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	cleanupHousehold(t, g, hh.ID)
+	res, err := svc.CreateInvite(ctx, ownerID, hh.ID, household.CreateInviteInput{})
+	if err != nil {
+		t.Fatalf("CreateInvite: %v", err)
+	}
+
+	// Jump past TTL.
+	svc.SetClock(func() time.Time { return past.Add(household.InviteTTL + time.Hour) })
+	if _, err := svc.AcceptInvite(ctx, guestID, res.Token); !errors.Is(err, household.ErrInviteExpired) {
+		t.Errorf("err = %v, want ErrInviteExpired", err)
+	}
+}
+
+// TestLeaveAndRejoin_PreservesShares is the headline ADR-0007 case: a member
+// leaves (left_at set), the share they had on their account stays put, and
+// re-accepting a fresh invite within grace clears left_at and they see the
+// same account_shares row.
+func TestLeaveAndRejoin_PreservesShares(t *testing.T) {
+	svc, _, g := newSvc(t)
+	ctx := context.Background()
+	ownerID := seedUser(t, g, "rj-owner")
+	guestID := seedUser(t, g, "rj-guest")
+
+	hh, err := svc.Create(ctx, ownerID, household.CreateInput{Name: "Rejoin House"})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	cleanupHousehold(t, g, hh.ID)
+
+	// Invite + accept guest.
+	inv, err := svc.CreateInvite(ctx, ownerID, hh.ID, household.CreateInviteInput{})
+	if err != nil {
+		t.Fatalf("CreateInvite: %v", err)
+	}
+	if _, err := svc.AcceptInvite(ctx, guestID, inv.Token); err != nil {
+		t.Fatalf("AcceptInvite: %v", err)
+	}
+
+	// Guest shares one of their own accounts with the household.
+	guestAcct := seedAccount(t, g, guestID, "shared")
+	share, err := svc.SetShare(ctx, guestID, guestAcct.ID, hh.ID, model.VisibilityBalanceAndTxns)
+	if err != nil {
+		t.Fatalf("SetShare: %v", err)
+	}
+	if share == nil || share.Visibility != model.VisibilityBalanceAndTxns {
+		t.Fatalf("share = %+v, want balance_and_txns", share)
+	}
+	t.Cleanup(func() { g.Unscoped().Delete(&model.AccountShare{}, share.ID) })
+
+	// Guest leaves.
+	if err := svc.Leave(ctx, guestID, hh.ID); err != nil {
+		t.Fatalf("Leave: %v", err)
+	}
+
+	// Verify left_at is set, share row is still intact.
+	var memAfter model.HouseholdMember
+	if err := g.Where("household_id = ? AND user_id = ?", hh.ID, guestID).First(&memAfter).Error; err != nil {
+		t.Fatalf("re-read member: %v", err)
+	}
+	if memAfter.LeftAt == nil {
+		t.Errorf("LeftAt = nil after Leave, want set")
+	}
+	var shareAfter model.AccountShare
+	if err := g.First(&shareAfter, share.ID).Error; err != nil {
+		t.Errorf("account_shares row purged on leave: %v (must persist for rejoin per ADR-0007)", err)
+	}
+
+	// Owner issues a new invite; guest accepts; auto-resume clears left_at.
+	inv2, err := svc.CreateInvite(ctx, ownerID, hh.ID, household.CreateInviteInput{})
+	if err != nil {
+		t.Fatalf("second CreateInvite: %v", err)
+	}
+	res, err := svc.AcceptInvite(ctx, guestID, inv2.Token)
+	if err != nil {
+		t.Fatalf("rejoin AcceptInvite: %v", err)
+	}
+	if !res.Resumed {
+		t.Errorf("Resumed = false, want true on auto-resume")
+	}
+
+	// left_at must be cleared and the SAME member row reused (no duplicate).
+	var memRejoined model.HouseholdMember
+	if err := g.First(&memRejoined, memAfter.ID).Error; err != nil {
+		t.Fatalf("re-read member after rejoin: %v", err)
+	}
+	if memRejoined.LeftAt != nil {
+		t.Errorf("LeftAt = %v after rejoin, want nil", memRejoined.LeftAt)
+	}
+	var dupCount int64
+	g.Model(&model.HouseholdMember{}).
+		Where("household_id = ? AND user_id = ? AND purged_at IS NULL", hh.ID, guestID).
+		Count(&dupCount)
+	if dupCount != 1 {
+		t.Errorf("active membership rows for guest = %d, want exactly 1", dupCount)
+	}
+}
+
+// TestLeave_LastOwnerReturns409 verifies the canonical ADR-0007 guard.
+func TestLeave_LastOwnerReturns409(t *testing.T) {
+	svc, _, g := newSvc(t)
+	ctx := context.Background()
+	ownerID := seedUser(t, g, "lo")
+
+	hh, err := svc.Create(ctx, ownerID, household.CreateInput{Name: "Solo"})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	cleanupHousehold(t, g, hh.ID)
+
+	if err := svc.Leave(ctx, ownerID, hh.ID); !errors.Is(err, household.ErrLastOwner) {
+		t.Errorf("err = %v, want ErrLastOwner", err)
+	}
+
+	// Owner with a contributor present — leaving still rejected because the
+	// contributor isn't an owner.
+	contribID := seedUser(t, g, "lo-contrib")
+	inv, err := svc.CreateInvite(ctx, ownerID, hh.ID, household.CreateInviteInput{Role: model.RoleContributor})
+	if err != nil {
+		t.Fatalf("CreateInvite: %v", err)
+	}
+	if _, err := svc.AcceptInvite(ctx, contribID, inv.Token); err != nil {
+		t.Fatalf("Accept: %v", err)
+	}
+	if err := svc.Leave(ctx, ownerID, hh.ID); !errors.Is(err, household.ErrLastOwner) {
+		t.Errorf("with contributor, owner leave err = %v, want ErrLastOwner", err)
+	}
+}
+
+// TestSetShare_RoundTripsAllVisibilityStates covers the API contract:
+// each PUT (balance_only → balance_and_txns → private) is observable on
+// the next GET; private deletes the row.
+func TestSetShare_RoundTripsAllVisibilityStates(t *testing.T) {
+	svc, _, g := newSvc(t)
+	ctx := context.Background()
+	ownerID := seedUser(t, g, "share-owner")
+	hh, err := svc.Create(ctx, ownerID, household.CreateInput{Name: "Share House"})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	cleanupHousehold(t, g, hh.ID)
+
+	acct := seedAccount(t, g, ownerID, "share-flow")
+
+	// Initial state: no share row exists for this account.
+	shares, err := svc.ListShares(ctx, ownerID, acct.ID)
+	if err != nil {
+		t.Fatalf("ListShares: %v", err)
+	}
+	if len(shares) != 0 {
+		t.Errorf("initial shares = %d, want 0", len(shares))
+	}
+
+	cases := []struct {
+		name       string
+		visibility string
+		expectRow  bool
+	}{
+		{"balance_only first", model.VisibilityBalanceOnly, true},
+		{"upgrade to balance_and_txns", model.VisibilityBalanceAndTxns, true},
+		{"private deletes", model.VisibilityPrivate, false},
+		{"re-share after delete", model.VisibilityBalanceOnly, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			share, err := svc.SetShare(ctx, ownerID, acct.ID, hh.ID, tc.visibility)
+			if err != nil {
+				t.Fatalf("SetShare %q: %v", tc.visibility, err)
+			}
+			got, err := svc.ListShares(ctx, ownerID, acct.ID)
+			if err != nil {
+				t.Fatalf("ListShares: %v", err)
+			}
+			if tc.expectRow {
+				if share == nil || share.Visibility != tc.visibility {
+					t.Errorf("returned share = %+v, want visibility %q", share, tc.visibility)
+				}
+				if len(got) != 1 || got[0].Visibility != tc.visibility {
+					t.Errorf("ListShares = %+v, want one row with %q", got, tc.visibility)
+				}
+			} else {
+				if share != nil {
+					t.Errorf("SetShare(private) returned %+v, want nil", share)
+				}
+				if len(got) != 0 {
+					t.Errorf("ListShares after private = %d rows, want 0", len(got))
+				}
+			}
+		})
+	}
+}
+
+// TestSetShare_RejectsInvalidVisibility exercises the validation contract.
+func TestSetShare_RejectsInvalidVisibility(t *testing.T) {
+	svc, _, g := newSvc(t)
+	ctx := context.Background()
+	ownerID := seedUser(t, g, "share-bad")
+	hh, err := svc.Create(ctx, ownerID, household.CreateInput{Name: "Bad Vis"})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	cleanupHousehold(t, g, hh.ID)
+	acct := seedAccount(t, g, ownerID, "bad-vis")
+
+	if _, err := svc.SetShare(ctx, ownerID, acct.ID, hh.ID, "bogus"); !errors.Is(err, household.ErrInvalidVisibility) {
+		t.Errorf("err = %v, want ErrInvalidVisibility", err)
+	}
+}
+
+// TestShares_TenantIsolation is the multi-tenant guard for the share endpoints.
+// User B must not be able to read or write the shares of User A's account.
+func TestShares_TenantIsolation(t *testing.T) {
+	svc, _, g := newSvc(t)
+	ctx := context.Background()
+	userA := seedUser(t, g, "iso-a")
+	userB := seedUser(t, g, "iso-b")
+
+	hh, err := svc.Create(ctx, userA, household.CreateInput{Name: "Iso"})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	cleanupHousehold(t, g, hh.ID)
+	acctA := seedAccount(t, g, userA, "iso-a-acct")
+
+	if _, err := svc.ListShares(ctx, userB, acctA.ID); !errors.Is(err, household.ErrAccountNotOwned) {
+		t.Errorf("B list shares of A's account err = %v, want ErrAccountNotOwned", err)
+	}
+	if _, err := svc.SetShare(ctx, userB, acctA.ID, hh.ID, model.VisibilityBalanceOnly); !errors.Is(err, household.ErrAccountNotOwned) {
+		t.Errorf("B set share of A's account err = %v, want ErrAccountNotOwned", err)
+	}
+}
+
+// TestGet_NonMemberRejected verifies non-members can't fingerprint household
+// existence via the detail endpoint.
+func TestGet_NonMemberRejected(t *testing.T) {
+	svc, _, g := newSvc(t)
+	ctx := context.Background()
+	ownerID := seedUser(t, g, "g-owner")
+	outsiderID := seedUser(t, g, "g-outsider")
+
+	hh, err := svc.Create(ctx, ownerID, household.CreateInput{Name: "Closed"})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	cleanupHousehold(t, g, hh.ID)
+
+	if _, err := svc.Get(ctx, outsiderID, hh.ID); !errors.Is(err, household.ErrNotMember) {
+		t.Errorf("non-member Get err = %v, want ErrNotMember", err)
+	}
+}
+
+// TestUpdate_OwnerOnly enforces that contributors cannot mutate household state.
+func TestUpdate_OwnerOnly(t *testing.T) {
+	svc, _, g := newSvc(t)
+	ctx := context.Background()
+	ownerID := seedUser(t, g, "u-owner")
+	contribID := seedUser(t, g, "u-contrib")
+
+	hh, err := svc.Create(ctx, ownerID, household.CreateInput{Name: "Owner Only"})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	cleanupHousehold(t, g, hh.ID)
+	inv, err := svc.CreateInvite(ctx, ownerID, hh.ID, household.CreateInviteInput{Role: model.RoleContributor})
+	if err != nil {
+		t.Fatalf("CreateInvite: %v", err)
+	}
+	if _, err := svc.AcceptInvite(ctx, contribID, inv.Token); err != nil {
+		t.Fatalf("Accept: %v", err)
+	}
+
+	newName := "Renamed By Contrib"
+	if _, err := svc.Update(ctx, contribID, hh.ID, household.UpdateInput{Name: &newName}); !errors.Is(err, household.ErrForbidden) {
+		t.Errorf("contributor Update err = %v, want ErrForbidden", err)
+	}
+	if _, err := svc.Update(ctx, ownerID, hh.ID, household.UpdateInput{Name: &newName}); err != nil {
+		t.Errorf("owner Update err = %v, want nil", err)
+	}
+}


### PR DESCRIPTION
## Summary
- `service/household.Service` for household CRUD, invite/accept/leave/auto-resume (ADR-0007), and per-account 3-level visibility (ADR-0006)
- Repositories: `HouseholdRepository`, `HouseholdMemberRepository`, `HouseholdInviteRepository`, `AccountShareRepository`
- Handler under `/api/v1`: households, invites, leave-self, account shares
- Invite tokens reuse `auth.NewToken` + `auth.HashToken` — DB stores HMAC, raw token only ever leaves to the invitee
- 11 integration tests against the real test DB; all green; `golangci-lint` clean

## Test plan
- [x] `go test ./...` green
- [x] `command make lint` → 0 issues
- [x] Smoke: create household → mint invite → second user accepts → owner sees both members → share an account (3 visibility states + private) → owner solo-leave returns 409 LAST_OWNER

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)