### PR TITLE
M2.5 #46: Aggregator + privacy tests + /me/scope + frontend stubs

### DIFF
--- a/backend/internal/handler/household_aggregator_handler.go
+++ b/backend/internal/handler/household_aggregator_handler.go
@@ -1,0 +1,125 @@
+package handler
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/gregwym/offbook/backend/internal/repository"
+	"github.com/gregwym/offbook/backend/internal/service/auth"
+	"github.com/gregwym/offbook/backend/internal/service/household"
+)
+
+// HouseholdAggregatorHandler is the only handler that calls the aggregator.
+// It looks up the requester's household via the member repo (read-only) and
+// routes the call to the aggregator. No domain repository is touched here.
+type HouseholdAggregatorHandler struct {
+	agg     *household.Aggregator
+	members repository.HouseholdMemberRepository
+}
+
+func NewHouseholdAggregatorHandler(agg *household.Aggregator, members repository.HouseholdMemberRepository) *HouseholdAggregatorHandler {
+	return &HouseholdAggregatorHandler{agg: agg, members: members}
+}
+
+// Register mounts /h/dashboard, /h/budgets/pace, /h/goals/progress,
+// /h/ai/context. All are gated by the secured group + the membership lookup
+// below (no membership ⇒ 403).
+func (h *HouseholdAggregatorHandler) Register(g *gin.RouterGroup) {
+	r := g.Group("/h")
+	r.GET("/dashboard", h.Dashboard)
+	r.GET("/budgets/pace", h.BudgetPace)
+	r.GET("/goals/progress", h.GoalProgress)
+	r.GET("/ai/context", h.AIContext)
+}
+
+func (h *HouseholdAggregatorHandler) requireHousehold(c *gin.Context) (int64, bool) {
+	uid := auth.MustUserID(c.Request.Context())
+	mem, err := h.members.GetMembershipForUser(c.Request.Context(), uid)
+	if err != nil {
+		if errors.Is(err, repository.ErrNotFound) {
+			c.JSON(http.StatusForbidden, gin.H{"error": "no household membership", "code": "NO_HOUSEHOLD"})
+			return 0, false
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error(), "code": "INTERNAL"})
+		return 0, false
+	}
+	if mem.LeftAt != nil {
+		// In-grace member — can rejoin via invite, but household routes are gated
+		// on active membership.
+		c.JSON(http.StatusForbidden, gin.H{"error": "membership inactive", "code": "MEMBERSHIP_INACTIVE"})
+		return 0, false
+	}
+	return mem.HouseholdID, true
+}
+
+func (h *HouseholdAggregatorHandler) Dashboard(c *gin.Context) {
+	hhID, ok := h.requireHousehold(c)
+	if !ok {
+		return
+	}
+	period := c.DefaultQuery("period", household.PeriodCurrentMonth)
+	out, err := h.agg.Dashboard(c.Request.Context(), hhID, period)
+	if err != nil {
+		writeAggregatorErr(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"data": out})
+}
+
+func (h *HouseholdAggregatorHandler) BudgetPace(c *gin.Context) {
+	hhID, ok := h.requireHousehold(c)
+	if !ok {
+		return
+	}
+	period := c.DefaultQuery("period", household.PeriodCurrentMonth)
+	out, err := h.agg.BudgetPace(c.Request.Context(), hhID, period)
+	if err != nil {
+		writeAggregatorErr(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"data": out, "total": int64(len(out))})
+}
+
+func (h *HouseholdAggregatorHandler) GoalProgress(c *gin.Context) {
+	hhID, ok := h.requireHousehold(c)
+	if !ok {
+		return
+	}
+	out, err := h.agg.GoalProgress(c.Request.Context(), hhID)
+	if err != nil {
+		writeAggregatorErr(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"data": out, "total": int64(len(out))})
+}
+
+func (h *HouseholdAggregatorHandler) AIContext(c *gin.Context) {
+	hhID, ok := h.requireHousehold(c)
+	if !ok {
+		return
+	}
+	uid := auth.MustUserID(c.Request.Context())
+	out, err := h.agg.AIContext(c.Request.Context(), hhID, uid)
+	if err != nil {
+		writeAggregatorErr(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"data": out})
+}
+
+func writeAggregatorErr(c *gin.Context, err error) {
+	switch {
+	case errors.Is(err, household.ErrHouseholdNotFound):
+		c.JSON(http.StatusNotFound, gin.H{"error": err.Error(), "code": "NOT_FOUND"})
+	case errors.Is(err, household.ErrInvalidPeriod):
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error":   err.Error(),
+			"code":    "INVALID_PERIOD",
+			"allowed": []string{household.PeriodCurrentMonth, household.PeriodLast30D, household.PeriodYTD},
+		})
+	default:
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error(), "code": "INTERNAL"})
+	}
+}

--- a/backend/internal/handler/scope_handler.go
+++ b/backend/internal/handler/scope_handler.go
@@ -1,0 +1,57 @@
+package handler
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/gregwym/offbook/backend/internal/service"
+	"github.com/gregwym/offbook/backend/internal/service/auth"
+)
+
+// ScopeHandler exposes GET/PATCH /me/scope. Both routes require a valid
+// session; mounted under the secured group in router.New.
+type ScopeHandler struct {
+	svc *service.ScopeService
+}
+
+func NewScopeHandler(s *service.ScopeService) *ScopeHandler {
+	return &ScopeHandler{svc: s}
+}
+
+func (h *ScopeHandler) Register(g *gin.RouterGroup) {
+	g.GET("/me/scope", h.Get)
+	g.PATCH("/me/scope", h.Patch)
+}
+
+func (h *ScopeHandler) Get(c *gin.Context) {
+	view, err := h.svc.Get(c.Request.Context(), auth.MustUserID(c.Request.Context()))
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error(), "code": "INTERNAL"})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"data": view})
+}
+
+type patchScopeRequest struct {
+	Scope string `json:"scope"`
+}
+
+func (h *ScopeHandler) Patch(c *gin.Context) {
+	var req patchScopeRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error(), "code": "INVALID_REQUEST"})
+		return
+	}
+	view, err := h.svc.Set(c.Request.Context(), auth.MustUserID(c.Request.Context()), req.Scope)
+	if err != nil {
+		if errors.Is(err, service.ErrInvalidScope) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error(), "code": "INVALID_SCOPE"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error(), "code": "INTERNAL"})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"data": view})
+}

--- a/backend/internal/repository/household_aggregator_repo.go
+++ b/backend/internal/repository/household_aggregator_repo.go
@@ -1,0 +1,282 @@
+package repository
+
+import (
+	"context"
+	"time"
+
+	"github.com/shopspring/decimal"
+	"gorm.io/gorm"
+
+	"github.com/gregwym/offbook/backend/internal/model"
+)
+
+// AccountShareView is what the aggregator needs to apply lifecycle filtering:
+// a share row joined with the owning user_id of the account. It is NOT
+// surfaced through any handler — only the household aggregator consumes it.
+type AccountShareView struct {
+	AccountID   int64
+	HouseholdID int64
+	UserID      int64
+	Visibility  string
+}
+
+// HouseholdAggregatorRepository is the cross-user reader that powers
+// service/household/aggregator.go. By design it serves aggregated values
+// (sums, counts, category rollups) and lightweight shapes — never raw
+// transaction rows. It MUST NOT import pii_repo.
+type HouseholdAggregatorRepository interface {
+	// ListAccountShares returns active shares for the household whose visibility
+	// is in `allowedVisibilities`, joined with the owning user_id of the account.
+	// Soft-deleted accounts and shares are excluded.
+	ListAccountShares(ctx context.Context, householdID int64, allowedVisibilities []string) ([]AccountShareView, error)
+
+	// ListMembersIncludingLeft returns all not-yet-purged members of the
+	// household (active + left-within-grace). Callers split by left_at.
+	ListMembersIncludingLeft(ctx context.Context, householdID int64) ([]model.HouseholdMember, error)
+
+	// SumBalances returns sum(balance) across the given account IDs.
+	// Returns decimal.Zero on empty input — no SQL is issued in that case.
+	SumBalances(ctx context.Context, accountIDs []int64) (decimal.Decimal, error)
+
+	// PeriodIncomeSpending returns (income, spending) over [from, to)
+	// across the given account IDs. Spending is returned as a positive value.
+	PeriodIncomeSpending(ctx context.Context, accountIDs []int64, from, to time.Time) (decimal.Decimal, decimal.Decimal, error)
+
+	// PeriodTransactionCount counts non-deleted transactions in [from, to)
+	// across the given account IDs.
+	PeriodTransactionCount(ctx context.Context, accountIDs []int64, from, to time.Time) (int64, error)
+
+	// CategoryAggregates rolls up SUM(amount) by category over [from, to).
+	// `LEFT JOIN categories` so uncategorized rows are bucketed as "Uncategorized".
+	CategoryAggregates(ctx context.Context, accountIDs []int64, from, to time.Time) ([]CategoryAggregate, error)
+
+	// SpendingByCategory returns SUM(-amount) FILTER (amount < 0) for one
+	// category over [from, to) across the given account IDs. Returns a
+	// positive number (spending). Used by BudgetPace.
+	SpendingByCategory(ctx context.Context, accountIDs []int64, categoryID int64, from, to time.Time) (decimal.Decimal, error)
+
+	// ListSharedBudgets returns shared_budgets for the household (optionally
+	// filtered by period). M2.5 ships no CRUD for these — readers tolerate
+	// an empty result set.
+	ListSharedBudgets(ctx context.Context, householdID int64, period string) ([]model.SharedBudget, error)
+
+	// ListSharedGoals returns shared_goals for the household.
+	ListSharedGoals(ctx context.Context, householdID int64) ([]model.SharedGoal, error)
+
+	// ListSharedThreads returns ai_threads where shared_with_household = true
+	// and household_id matches. Order: most recently updated first.
+	ListSharedThreads(ctx context.Context, householdID int64, limit int) ([]model.AIThread, error)
+
+	// ListPersonalThreadsForUser returns the user's own threads NOT shared
+	// with any household. Order: most recently updated first.
+	ListPersonalThreadsForUser(ctx context.Context, userID int64, limit int) ([]model.AIThread, error)
+}
+
+type householdAggregatorRepo struct{ db *gorm.DB }
+
+func NewHouseholdAggregatorRepository(db *gorm.DB) HouseholdAggregatorRepository {
+	return &householdAggregatorRepo{db: db}
+}
+
+func (r *householdAggregatorRepo) ListAccountShares(ctx context.Context, householdID int64, allowed []string) ([]AccountShareView, error) {
+	if len(allowed) == 0 {
+		return nil, nil
+	}
+	var rows []AccountShareView
+	err := r.db.WithContext(ctx).Raw(`
+		SELECT s.account_id   AS account_id,
+		       s.household_id AS household_id,
+		       a.user_id      AS user_id,
+		       s.visibility   AS visibility
+		FROM account_shares s
+		JOIN accounts a ON a.id = s.account_id
+		WHERE s.deleted_at IS NULL
+		  AND a.deleted_at IS NULL
+		  AND s.household_id = ?
+		  AND s.visibility IN ?
+	`, householdID, allowed).Scan(&rows).Error
+	if err != nil {
+		return nil, err
+	}
+	return rows, nil
+}
+
+func (r *householdAggregatorRepo) ListMembersIncludingLeft(ctx context.Context, householdID int64) ([]model.HouseholdMember, error) {
+	var out []model.HouseholdMember
+	err := r.db.WithContext(ctx).
+		Where("household_id = ? AND purged_at IS NULL", householdID).
+		Order("CASE role WHEN 'owner' THEN 0 WHEN 'contributor' THEN 1 ELSE 2 END, id").
+		Find(&out).Error
+	return out, err
+}
+
+func (r *householdAggregatorRepo) SumBalances(ctx context.Context, accountIDs []int64) (decimal.Decimal, error) {
+	if len(accountIDs) == 0 {
+		return decimal.Zero, nil
+	}
+	var s string
+	err := r.db.WithContext(ctx).Raw(`
+		SELECT COALESCE(SUM(balance), 0)::text
+		FROM accounts
+		WHERE deleted_at IS NULL
+		  AND id IN ?
+	`, accountIDs).Scan(&s).Error
+	if err != nil {
+		return decimal.Zero, err
+	}
+	d, _ := decimal.NewFromString(s)
+	return d, nil
+}
+
+func (r *householdAggregatorRepo) PeriodIncomeSpending(ctx context.Context, accountIDs []int64, from, to time.Time) (decimal.Decimal, decimal.Decimal, error) {
+	if len(accountIDs) == 0 {
+		return decimal.Zero, decimal.Zero, nil
+	}
+	type incExp struct {
+		Income   string
+		Spending string
+	}
+	var ie incExp
+	err := r.db.WithContext(ctx).Raw(`
+		SELECT
+			COALESCE(SUM(amount)  FILTER (WHERE amount > 0), 0)::text  AS income,
+			COALESCE(SUM(-amount) FILTER (WHERE amount < 0), 0)::text  AS spending
+		FROM transactions
+		WHERE deleted_at IS NULL
+		  AND account_id IN ?
+		  AND transaction_date >= ?
+		  AND transaction_date <  ?
+	`, accountIDs, from, to).Scan(&ie).Error
+	if err != nil {
+		return decimal.Zero, decimal.Zero, err
+	}
+	inc, _ := decimal.NewFromString(ie.Income)
+	sp, _ := decimal.NewFromString(ie.Spending)
+	return inc, sp, nil
+}
+
+func (r *householdAggregatorRepo) PeriodTransactionCount(ctx context.Context, accountIDs []int64, from, to time.Time) (int64, error) {
+	if len(accountIDs) == 0 {
+		return 0, nil
+	}
+	var n int64
+	err := r.db.WithContext(ctx).Raw(`
+		SELECT COUNT(*)
+		FROM transactions
+		WHERE deleted_at IS NULL
+		  AND account_id IN ?
+		  AND transaction_date >= ?
+		  AND transaction_date <  ?
+	`, accountIDs, from, to).Scan(&n).Error
+	return n, err
+}
+
+func (r *householdAggregatorRepo) CategoryAggregates(ctx context.Context, accountIDs []int64, from, to time.Time) ([]CategoryAggregate, error) {
+	if len(accountIDs) == 0 {
+		return nil, nil
+	}
+	type rawRow struct {
+		CategoryID *int64
+		Name       *string
+		Amount     string
+	}
+	var rows []rawRow
+	err := r.db.WithContext(ctx).Raw(`
+		SELECT t.category_id                    AS category_id,
+		       c.name                           AS name,
+		       COALESCE(SUM(t.amount), 0)::text AS amount
+		FROM transactions t
+		LEFT JOIN categories c ON c.id = t.category_id
+		WHERE t.deleted_at IS NULL
+		  AND t.account_id IN ?
+		  AND t.transaction_date >= ?
+		  AND t.transaction_date <  ?
+		GROUP BY t.category_id, c.name
+		ORDER BY ABS(COALESCE(SUM(t.amount), 0)) DESC
+	`, accountIDs, from, to).Scan(&rows).Error
+	if err != nil {
+		return nil, err
+	}
+	out := make([]CategoryAggregate, 0, len(rows))
+	for _, row := range rows {
+		amt, _ := decimal.NewFromString(row.Amount)
+		name := "Uncategorized"
+		if row.Name != nil {
+			name = *row.Name
+		}
+		out = append(out, CategoryAggregate{
+			CategoryID: row.CategoryID,
+			Name:       name,
+			Amount:     amt,
+		})
+	}
+	return out, nil
+}
+
+func (r *householdAggregatorRepo) SpendingByCategory(ctx context.Context, accountIDs []int64, categoryID int64, from, to time.Time) (decimal.Decimal, error) {
+	if len(accountIDs) == 0 {
+		return decimal.Zero, nil
+	}
+	var s string
+	err := r.db.WithContext(ctx).Raw(`
+		SELECT COALESCE(SUM(-amount) FILTER (WHERE amount < 0), 0)::text
+		FROM transactions
+		WHERE deleted_at IS NULL
+		  AND account_id IN ?
+		  AND category_id = ?
+		  AND transaction_date >= ?
+		  AND transaction_date <  ?
+	`, accountIDs, categoryID, from, to).Scan(&s).Error
+	if err != nil {
+		return decimal.Zero, err
+	}
+	d, _ := decimal.NewFromString(s)
+	return d, nil
+}
+
+func (r *householdAggregatorRepo) ListSharedBudgets(ctx context.Context, householdID int64, period string) ([]model.SharedBudget, error) {
+	q := r.db.WithContext(ctx).Where("household_id = ? AND is_active = ?", householdID, true)
+	if period != "" {
+		q = q.Where("period = ?", period)
+	}
+	var out []model.SharedBudget
+	if err := q.Order("id").Find(&out).Error; err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (r *householdAggregatorRepo) ListSharedGoals(ctx context.Context, householdID int64) ([]model.SharedGoal, error) {
+	var out []model.SharedGoal
+	err := r.db.WithContext(ctx).
+		Where("household_id = ?", householdID).
+		Order("id").
+		Find(&out).Error
+	return out, err
+}
+
+func (r *householdAggregatorRepo) ListSharedThreads(ctx context.Context, householdID int64, limit int) ([]model.AIThread, error) {
+	if limit <= 0 {
+		limit = 50
+	}
+	var out []model.AIThread
+	err := r.db.WithContext(ctx).
+		Where("household_id = ? AND shared_with_household = ?", householdID, true).
+		Order("updated_at DESC, id DESC").
+		Limit(limit).
+		Find(&out).Error
+	return out, err
+}
+
+func (r *householdAggregatorRepo) ListPersonalThreadsForUser(ctx context.Context, userID int64, limit int) ([]model.AIThread, error) {
+	if limit <= 0 {
+		limit = 50
+	}
+	var out []model.AIThread
+	err := r.db.WithContext(ctx).
+		Where("user_id = ? AND shared_with_household = ?", userID, false).
+		Order("updated_at DESC, id DESC").
+		Limit(limit).
+		Find(&out).Error
+	return out, err
+}

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -46,17 +46,29 @@ func New(cfg config.Config, gormDB *gorm.DB) *gin.Engine {
 	dashboardSvc := service.NewDashboardService(dashboardRepo)
 	dashboardHandler := handler.NewDashboardHandler(dashboardSvc)
 
+	householdRepo := repository.NewHouseholdRepository(gormDB)
+	memberRepo := repository.NewHouseholdMemberRepository(gormDB)
+	userRepo := repository.NewUserRepository(gormDB)
 	householdSvc := household.NewService(
-		repository.NewHouseholdRepository(gormDB),
-		repository.NewHouseholdMemberRepository(gormDB),
+		householdRepo,
+		memberRepo,
 		repository.NewHouseholdInviteRepository(gormDB),
 		repository.NewAccountShareRepository(gormDB),
 		accountRepo,
 		repository.NewInstanceConfigRepository(gormDB),
-		repository.NewUserRepository(gormDB),
+		userRepo,
 		cfg.SessionSecret,
 	)
 	householdHandler := handler.NewHouseholdHandler(householdSvc)
+
+	aggregator := household.NewAggregator(
+		repository.NewHouseholdAggregatorRepository(gormDB),
+		householdRepo,
+	)
+	aggregatorHandler := handler.NewHouseholdAggregatorHandler(aggregator, memberRepo)
+
+	scopeSvc := service.NewScopeService(userRepo, memberRepo)
+	scopeHandler := handler.NewScopeHandler(scopeSvc)
 
 	v1 := r.Group("/api/v1")
 	{
@@ -73,6 +85,8 @@ func New(cfg config.Config, gormDB *gorm.DB) *gin.Engine {
 		transactionHandler.Register(secured)
 		dashboardHandler.Register(secured)
 		householdHandler.Register(secured)
+		aggregatorHandler.Register(secured)
+		scopeHandler.Register(secured)
 	}
 
 	return r

--- a/backend/internal/service/household/aggregator.go
+++ b/backend/internal/service/household/aggregator.go
@@ -1,0 +1,403 @@
+package household
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/shopspring/decimal"
+
+	"github.com/gregwym/offbook/backend/internal/model"
+	"github.com/gregwym/offbook/backend/internal/repository"
+)
+
+// Aggregator is the SINGLE cross-user reader for household surfaces. Per
+// ADR-0008 and .claude/rules/go-backend.md, no other package may read across
+// user_ids and this package must NEVER import pii_repo. The aggregator only
+// returns aggregated values (sums, counts, percentages) and lightweight
+// metadata — never raw transaction rows.
+//
+// Lifecycle filtering:
+//   - LIVE aggregates (Dashboard, BudgetPace, GoalProgress current spend)
+//     count only ACTIVE members (left_at IS NULL).
+//   - HISTORICAL aggregates (returned alongside live ones where labeled)
+//     include in-grace members (left_at IS NOT NULL AND now - left_at <= grace).
+//   - PURGED members are excluded everywhere — they don't appear in
+//     repository.ListMembersIncludingLeft to begin with.
+type Aggregator struct {
+	repo            repository.HouseholdAggregatorRepository
+	households      repository.HouseholdRepository
+	now             func() time.Time
+}
+
+func NewAggregator(
+	repo repository.HouseholdAggregatorRepository,
+	households repository.HouseholdRepository,
+) *Aggregator {
+	return &Aggregator{
+		repo:       repo,
+		households: households,
+		now:        time.Now,
+	}
+}
+
+// SetClock lets tests freeze time for grace-window assertions.
+func (a *Aggregator) SetClock(fn func() time.Time) { a.now = fn }
+
+// --- return types ---
+
+// HouseholdDashboard mirrors the personal DashboardSummary but is keyed by
+// household + aggregates only across opt-in shared accounts. All money fields
+// are strings to preserve precision across the wire.
+type HouseholdDashboard struct {
+	Period           PeriodWindow              `json:"period"`
+	NetWorth         string                    `json:"net_worth"`         // sum across balance_only + balance_and_txns shares
+	Income           string                    `json:"income"`            // period; balance_and_txns only
+	Spending         string                    `json:"spending"`          // period; balance_and_txns only
+	AccountCount     int                       `json:"account_count"`     // shared accounts count (any visibility)
+	TransactionCount int64                     `json:"transaction_count"` // period; balance_and_txns only
+	ByCategory       []CategorySpendingItem    `json:"by_category"`       // period; balance_and_txns only
+	LiveMemberCount  int                       `json:"live_member_count"`
+	InGraceCount     int                       `json:"in_grace_count"`
+}
+
+// PeriodWindow is the resolved [from, to) window. Mirrors service.PeriodWindow
+// in shape; we keep it local so service/household doesn't import service/.
+type PeriodWindow struct {
+	Key  string    `json:"key"`
+	From time.Time `json:"from"`
+	To   time.Time `json:"to"`
+}
+
+type CategorySpendingItem struct {
+	CategoryID *int64 `json:"category_id"`
+	Name       string `json:"name"`
+	Amount     string `json:"amount"`
+}
+
+// BudgetPaceItem is one shared_budget rolled up with its current-period spend.
+// Pace is spend / budget (when budget > 0); 0 otherwise.
+type BudgetPaceItem struct {
+	BudgetID   int64  `json:"budget_id"`
+	CategoryID int64  `json:"category_id"`
+	Period     string `json:"period"`
+	Budget     string `json:"budget"`
+	Spent      string `json:"spent"`
+	Pace       string `json:"pace"` // ratio 0..N (1.0 = on budget)
+}
+
+// GoalProgressItem reports completion of a shared_goal.
+type GoalProgressItem struct {
+	GoalID        int64      `json:"goal_id"`
+	Name          string     `json:"name"`
+	TargetAmount  string     `json:"target_amount"`
+	CurrentAmount string     `json:"current_amount"`
+	Progress      string     `json:"progress"` // ratio 0..1
+	TargetDate    *time.Time `json:"target_date,omitempty"`
+}
+
+// HouseholdAIContext is what the AI advisor sees when the requester is in a
+// household. Includes the LIVE dashboard summary, the shared-thread list, AND
+// the requester's PERSONAL threads — never another member's private threads.
+type HouseholdAIContext struct {
+	HouseholdID      int64                `json:"household_id"`
+	NetWorth         string               `json:"net_worth"`
+	Income           string               `json:"income"`
+	Spending         string               `json:"spending"`
+	Period           PeriodWindow         `json:"period"`
+	SharedThreads    []ThreadSummary      `json:"shared_threads"`
+	PersonalThreads  []ThreadSummary      `json:"personal_threads"`
+}
+
+// ThreadSummary excludes message content — the aggregator never returns raw
+// chat bodies; the AI service hydrates messages on demand under tenant rules.
+type ThreadSummary struct {
+	ID                  int64     `json:"id"`
+	UserID              int64     `json:"user_id"`
+	Title               *string   `json:"title,omitempty"`
+	SharedWithHousehold bool      `json:"shared_with_household"`
+	UpdatedAt           time.Time `json:"updated_at"`
+}
+
+// --- core methods ---
+
+// Dashboard returns the household-level rollup for the period. Aggregates over
+// shared accounts owned by ACTIVE members (live). In-grace members are not
+// included in live spend — but their member count is surfaced separately so
+// the UI can hint at the lifecycle state.
+func (a *Aggregator) Dashboard(ctx context.Context, householdID int64, period string) (*HouseholdDashboard, error) {
+	if err := a.requireHousehold(ctx, householdID); err != nil {
+		return nil, err
+	}
+	from, to, err := ResolvePeriod(period, a.now())
+	if err != nil {
+		return nil, err
+	}
+
+	live, inGrace, err := a.liveAndInGrace(ctx, householdID)
+	if err != nil {
+		return nil, err
+	}
+	liveUserIDs := userIDs(live)
+
+	netWorthShares, err := a.repo.ListAccountShares(ctx, householdID,
+		[]string{model.VisibilityBalanceOnly, model.VisibilityBalanceAndTxns})
+	if err != nil {
+		return nil, fmt.Errorf("list shares (net-worth): %w", err)
+	}
+	netWorthAccounts := filterAccountsByUsers(netWorthShares, liveUserIDs)
+
+	txShares, err := a.repo.ListAccountShares(ctx, householdID,
+		[]string{model.VisibilityBalanceAndTxns})
+	if err != nil {
+		return nil, fmt.Errorf("list shares (txns): %w", err)
+	}
+	txAccounts := filterAccountsByUsers(txShares, liveUserIDs)
+
+	netWorth, err := a.repo.SumBalances(ctx, netWorthAccounts)
+	if err != nil {
+		return nil, fmt.Errorf("sum balances: %w", err)
+	}
+	income, spending, err := a.repo.PeriodIncomeSpending(ctx, txAccounts, from, to)
+	if err != nil {
+		return nil, fmt.Errorf("income/spending: %w", err)
+	}
+	txCount, err := a.repo.PeriodTransactionCount(ctx, txAccounts, from, to)
+	if err != nil {
+		return nil, fmt.Errorf("transaction count: %w", err)
+	}
+	rawCats, err := a.repo.CategoryAggregates(ctx, txAccounts, from, to)
+	if err != nil {
+		return nil, fmt.Errorf("category aggregates: %w", err)
+	}
+	cats := make([]CategorySpendingItem, 0, len(rawCats))
+	for _, c := range rawCats {
+		cats = append(cats, CategorySpendingItem{
+			CategoryID: c.CategoryID,
+			Name:       c.Name,
+			Amount:     c.Amount.String(),
+		})
+	}
+
+	return &HouseholdDashboard{
+		Period:           PeriodWindow{Key: period, From: from, To: to},
+		NetWorth:         netWorth.String(),
+		Income:           income.String(),
+		Spending:         spending.String(),
+		AccountCount:     len(netWorthAccounts),
+		TransactionCount: txCount,
+		ByCategory:       cats,
+		LiveMemberCount:  len(live),
+		InGraceCount:     len(inGrace),
+	}, nil
+}
+
+// BudgetPace rolls up each shared_budget for the household against its
+// current-period spend (across balance_and_txns shares owned by live members).
+func (a *Aggregator) BudgetPace(ctx context.Context, householdID int64, period string) ([]BudgetPaceItem, error) {
+	if err := a.requireHousehold(ctx, householdID); err != nil {
+		return nil, err
+	}
+	from, to, err := ResolvePeriod(period, a.now())
+	if err != nil {
+		return nil, err
+	}
+
+	budgets, err := a.repo.ListSharedBudgets(ctx, householdID, "")
+	if err != nil {
+		return nil, fmt.Errorf("list shared_budgets: %w", err)
+	}
+	live, _, err := a.liveAndInGrace(ctx, householdID)
+	if err != nil {
+		return nil, err
+	}
+	liveUserIDs := userIDs(live)
+	txShares, err := a.repo.ListAccountShares(ctx, householdID,
+		[]string{model.VisibilityBalanceAndTxns})
+	if err != nil {
+		return nil, fmt.Errorf("list shares: %w", err)
+	}
+	txAccounts := filterAccountsByUsers(txShares, liveUserIDs)
+
+	out := make([]BudgetPaceItem, 0, len(budgets))
+	for _, b := range budgets {
+		spent, err := a.repo.SpendingByCategory(ctx, txAccounts, b.CategoryID, from, to)
+		if err != nil {
+			return nil, fmt.Errorf("spending for budget %d: %w", b.ID, err)
+		}
+		pace := decimal.Zero
+		if !b.Amount.IsZero() {
+			pace = spent.Div(b.Amount)
+		}
+		out = append(out, BudgetPaceItem{
+			BudgetID:   b.ID,
+			CategoryID: b.CategoryID,
+			Period:     b.Period,
+			Budget:     b.Amount.String(),
+			Spent:      spent.String(),
+			Pace:       pace.String(),
+		})
+	}
+	return out, nil
+}
+
+// GoalProgress returns each shared_goal's progress ratio. No transaction
+// queries — current_amount is canonical state.
+func (a *Aggregator) GoalProgress(ctx context.Context, householdID int64) ([]GoalProgressItem, error) {
+	if err := a.requireHousehold(ctx, householdID); err != nil {
+		return nil, err
+	}
+	goals, err := a.repo.ListSharedGoals(ctx, householdID)
+	if err != nil {
+		return nil, fmt.Errorf("list shared_goals: %w", err)
+	}
+	out := make([]GoalProgressItem, 0, len(goals))
+	for _, g := range goals {
+		progress := decimal.Zero
+		if !g.TargetAmount.IsZero() {
+			progress = g.CurrentAmount.Div(g.TargetAmount)
+		}
+		out = append(out, GoalProgressItem{
+			GoalID:        g.ID,
+			Name:          g.Name,
+			TargetAmount:  g.TargetAmount.String(),
+			CurrentAmount: g.CurrentAmount.String(),
+			Progress:      progress.String(),
+			TargetDate:    g.TargetDate,
+		})
+	}
+	return out, nil
+}
+
+// AIContext bundles the live dashboard summary, the household's shared
+// threads, and the REQUESTER's personal threads. It NEVER returns another
+// member's personal threads.
+func (a *Aggregator) AIContext(ctx context.Context, householdID, requesterUserID int64) (*HouseholdAIContext, error) {
+	if err := a.requireHousehold(ctx, householdID); err != nil {
+		return nil, err
+	}
+	from, to, err := ResolvePeriod(PeriodCurrentMonth, a.now())
+	if err != nil {
+		return nil, err
+	}
+
+	live, _, err := a.liveAndInGrace(ctx, householdID)
+	if err != nil {
+		return nil, err
+	}
+	liveUserIDs := userIDs(live)
+	nwShares, err := a.repo.ListAccountShares(ctx, householdID,
+		[]string{model.VisibilityBalanceOnly, model.VisibilityBalanceAndTxns})
+	if err != nil {
+		return nil, err
+	}
+	nwAccounts := filterAccountsByUsers(nwShares, liveUserIDs)
+	txShares, err := a.repo.ListAccountShares(ctx, householdID,
+		[]string{model.VisibilityBalanceAndTxns})
+	if err != nil {
+		return nil, err
+	}
+	txAccounts := filterAccountsByUsers(txShares, liveUserIDs)
+
+	netWorth, err := a.repo.SumBalances(ctx, nwAccounts)
+	if err != nil {
+		return nil, err
+	}
+	income, spending, err := a.repo.PeriodIncomeSpending(ctx, txAccounts, from, to)
+	if err != nil {
+		return nil, err
+	}
+
+	shared, err := a.repo.ListSharedThreads(ctx, householdID, 50)
+	if err != nil {
+		return nil, err
+	}
+	personal, err := a.repo.ListPersonalThreadsForUser(ctx, requesterUserID, 50)
+	if err != nil {
+		return nil, err
+	}
+
+	return &HouseholdAIContext{
+		HouseholdID:     householdID,
+		NetWorth:        netWorth.String(),
+		Income:          income.String(),
+		Spending:        spending.String(),
+		Period:          PeriodWindow{Key: PeriodCurrentMonth, From: from, To: to},
+		SharedThreads:   toThreadSummaries(shared),
+		PersonalThreads: toThreadSummaries(personal),
+	}, nil
+}
+
+// --- internal helpers ---
+
+func (a *Aggregator) requireHousehold(ctx context.Context, householdID int64) error {
+	if _, err := a.households.GetByID(ctx, householdID); err != nil {
+		if errors.Is(err, repository.ErrNotFound) {
+			return ErrHouseholdNotFound
+		}
+		return err
+	}
+	return nil
+}
+
+// liveAndInGrace partitions members into active and in-grace lists, using
+// the household's grace_period_days as the cutoff for "in-grace". Purged
+// members are absent from ListMembersIncludingLeft.
+func (a *Aggregator) liveAndInGrace(ctx context.Context, householdID int64) ([]model.HouseholdMember, []model.HouseholdMember, error) {
+	hh, err := a.households.GetByID(ctx, householdID)
+	if err != nil {
+		return nil, nil, err
+	}
+	all, err := a.repo.ListMembersIncludingLeft(ctx, householdID)
+	if err != nil {
+		return nil, nil, fmt.Errorf("list members: %w", err)
+	}
+	now := a.now()
+	grace := time.Duration(hh.GracePeriodDays) * 24 * time.Hour
+	var live, inGrace []model.HouseholdMember
+	for _, m := range all {
+		if m.LeftAt == nil {
+			live = append(live, m)
+			continue
+		}
+		if now.Sub(*m.LeftAt) <= grace {
+			inGrace = append(inGrace, m)
+		}
+		// Beyond grace: dropped from BOTH lists. The purge runner (deferred)
+		// will set purged_at; until then the row is invisible to live readers.
+	}
+	return live, inGrace, nil
+}
+
+func userIDs(members []model.HouseholdMember) map[int64]struct{} {
+	out := make(map[int64]struct{}, len(members))
+	for _, m := range members {
+		out[m.UserID] = struct{}{}
+	}
+	return out
+}
+
+func filterAccountsByUsers(shares []repository.AccountShareView, allowedUsers map[int64]struct{}) []int64 {
+	out := make([]int64, 0, len(shares))
+	for _, s := range shares {
+		if _, ok := allowedUsers[s.UserID]; ok {
+			out = append(out, s.AccountID)
+		}
+	}
+	return out
+}
+
+func toThreadSummaries(threads []model.AIThread) []ThreadSummary {
+	out := make([]ThreadSummary, 0, len(threads))
+	for _, t := range threads {
+		out = append(out, ThreadSummary{
+			ID:                  t.ID,
+			UserID:              t.UserID,
+			Title:               t.Title,
+			SharedWithHousehold: t.SharedWithHousehold,
+			UpdatedAt:           t.UpdatedAt,
+		})
+	}
+	return out
+}

--- a/backend/internal/service/household/aggregator_test.go
+++ b/backend/internal/service/household/aggregator_test.go
@@ -1,0 +1,414 @@
+package household_test
+
+import (
+	"context"
+	"fmt"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/shopspring/decimal"
+	"gorm.io/gorm"
+
+	"github.com/gregwym/offbook/backend/internal/model"
+	"github.com/gregwym/offbook/backend/internal/repository"
+	"github.com/gregwym/offbook/backend/internal/service/household"
+)
+
+// newAggregator wires the aggregator the same way router.go does, against
+// the real test DB. Returns the aggregator + an active member helper so
+// tests can avoid retyping seeding boilerplate.
+func newAggregator(t *testing.T) (*household.Aggregator, *gorm.DB) {
+	t.Helper()
+	g := openTestDB(t)
+	ensureBootstrapped(t, g)
+	agg := household.NewAggregator(
+		repository.NewHouseholdAggregatorRepository(g),
+		repository.NewHouseholdRepository(g),
+	)
+	return agg, g
+}
+
+// seedHousehold creates a household with the given owner; returns the
+// household and registers cleanup. Members are added separately.
+func seedHouseholdRow(t *testing.T, g *gorm.DB, ownerID int64, name string, grace int) *model.Household {
+	t.Helper()
+	hh := &model.Household{
+		Name:            name + "-" + fmt.Sprintf("%d", time.Now().UnixNano()),
+		OwnerID:         ownerID,
+		GracePeriodDays: grace,
+	}
+	if err := g.Create(hh).Error; err != nil {
+		t.Fatalf("seed household: %v", err)
+	}
+	cleanupHousehold(t, g, hh.ID)
+	return hh
+}
+
+func addMember(t *testing.T, g *gorm.DB, hhID, userID int64, role string, leftAt *time.Time) *model.HouseholdMember {
+	t.Helper()
+	m := &model.HouseholdMember{
+		HouseholdID: hhID,
+		UserID:      userID,
+		Role:        role,
+		JoinedAt:    time.Now().Add(-30 * 24 * time.Hour),
+		LeftAt:      leftAt,
+	}
+	if err := g.Create(m).Error; err != nil {
+		t.Fatalf("seed member: %v", err)
+	}
+	return m
+}
+
+func setShare(t *testing.T, g *gorm.DB, accountID, hhID int64, vis string) {
+	t.Helper()
+	s := &model.AccountShare{AccountID: accountID, HouseholdID: hhID, Visibility: vis}
+	if err := g.Create(s).Error; err != nil {
+		t.Fatalf("seed share: %v", err)
+	}
+	t.Cleanup(func() { g.Unscoped().Delete(&model.AccountShare{}, s.ID) })
+}
+
+func seedTxn(t *testing.T, g *gorm.DB, userID, accountID int64, amount string, catID *int64, when time.Time) {
+	t.Helper()
+	amt, _ := decimal.NewFromString(amount)
+	tx := &model.Transaction{
+		UserID:          userID,
+		AccountID:       accountID,
+		CategoryID:      catID,
+		Amount:          amt,
+		Currency:        "USD",
+		Source:          "manual",
+		TransactionDate: when,
+	}
+	if err := g.Create(tx).Error; err != nil {
+		t.Fatalf("seed txn: %v", err)
+	}
+	t.Cleanup(func() { g.Unscoped().Delete(&model.Transaction{}, tx.ID) })
+}
+
+func setBalance(t *testing.T, g *gorm.DB, acct *model.Account, balance string) {
+	t.Helper()
+	d, _ := decimal.NewFromString(balance)
+	if err := g.Model(acct).Update("balance", d).Error; err != nil {
+		t.Fatalf("update balance: %v", err)
+	}
+}
+
+// TestHouseholdPackage_DoesNotImportPIIRepo is the static check from
+// .claude/rules/testing.md item (a) — fails if any non-test file in the
+// household package imports the PII layer (pii_repo or pii_service).
+// Test files are allowed to import service/ for assembling integration
+// fixtures.
+func TestHouseholdPackage_DoesNotImportPIIRepo(t *testing.T) {
+	dir, err := filepath.Abs(".")
+	if err != nil {
+		t.Fatalf("abs: %v", err)
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read dir: %v", err)
+	}
+	fset := token.NewFileSet()
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		file, err := parser.ParseFile(fset, filepath.Join(dir, name), nil, parser.ImportsOnly)
+		if err != nil {
+			t.Fatalf("parse %s: %v", name, err)
+		}
+		for _, imp := range file.Imports {
+			path := strings.Trim(imp.Path.Value, `"`)
+			if strings.Contains(path, "pii") {
+				t.Errorf("%s imports forbidden PII path %q — service/household must NEVER depend on PII (see ADR-0008)", name, path)
+			}
+		}
+	}
+}
+
+// TestAggregator_ExcludesPrivateAccounts covers privacy item (c).
+func TestAggregator_ExcludesPrivateAccounts(t *testing.T) {
+	agg, g := newAggregator(t)
+	ctx := context.Background()
+	ownerID := seedUser(t, g, "exp-owner")
+	hh := seedHouseholdRow(t, g, ownerID, "Excludes Private", 30)
+	addMember(t, g, hh.ID, ownerID, model.RoleOwner, nil)
+
+	shared := seedAccount(t, g, ownerID, "shared")
+	priv := seedAccount(t, g, ownerID, "private")
+	setBalance(t, g, shared, "500.00")
+	setBalance(t, g, priv, "9999.99")
+	// Only the shared account has a row; the "private" one has none — that's
+	// the architectural definition of private.
+	setShare(t, g, shared.ID, hh.ID, model.VisibilityBalanceAndTxns)
+
+	when := time.Now().Add(-time.Hour)
+	seedTxn(t, g, ownerID, shared.ID, "-25", nil, when)
+	seedTxn(t, g, ownerID, priv.ID, "-9999", nil, when) // must not surface anywhere
+
+	d, err := agg.Dashboard(ctx, hh.ID, household.PeriodCurrentMonth)
+	if err != nil {
+		t.Fatalf("Dashboard: %v", err)
+	}
+	if d.NetWorth != "500" {
+		t.Errorf("NetWorth = %q, want 500", d.NetWorth)
+	}
+	if d.AccountCount != 1 {
+		t.Errorf("AccountCount = %d, want 1 (private must not count)", d.AccountCount)
+	}
+	if d.Spending != "25" {
+		t.Errorf("Spending = %q, want 25", d.Spending)
+	}
+	if d.TransactionCount != 1 {
+		t.Errorf("TransactionCount = %d, want 1", d.TransactionCount)
+	}
+}
+
+// TestAggregator_BalanceOnlyExcludedFromCategory covers item (d):
+// balance_only contributes to net worth but never to per-category aggregates.
+func TestAggregator_BalanceOnlyExcludedFromCategory(t *testing.T) {
+	agg, g := newAggregator(t)
+	ctx := context.Background()
+	ownerID := seedUser(t, g, "bo-owner")
+	hh := seedHouseholdRow(t, g, ownerID, "Balance Only", 30)
+	addMember(t, g, hh.ID, ownerID, model.RoleOwner, nil)
+
+	balOnly := seedAccount(t, g, ownerID, "bal-only")
+	full := seedAccount(t, g, ownerID, "full")
+	setBalance(t, g, balOnly, "1000")
+	setBalance(t, g, full, "500")
+	setShare(t, g, balOnly.ID, hh.ID, model.VisibilityBalanceOnly)
+	setShare(t, g, full.ID, hh.ID, model.VisibilityBalanceAndTxns)
+
+	when := time.Now().Add(-time.Hour)
+	// Transaction on the balance_only account must NOT appear in the breakdown.
+	seedTxn(t, g, ownerID, balOnly.ID, "-100", nil, when)
+	seedTxn(t, g, ownerID, full.ID, "-50", nil, when)
+
+	d, err := agg.Dashboard(ctx, hh.ID, household.PeriodCurrentMonth)
+	if err != nil {
+		t.Fatalf("Dashboard: %v", err)
+	}
+	if d.NetWorth != "1500" {
+		t.Errorf("NetWorth = %q, want 1500 (balance_only included)", d.NetWorth)
+	}
+	if d.Spending != "50" {
+		t.Errorf("Spending = %q, want 50 (only balance_and_txns spend)", d.Spending)
+	}
+	if d.TransactionCount != 1 {
+		t.Errorf("TransactionCount = %d, want 1", d.TransactionCount)
+	}
+	// The balance_only transaction's category must not appear at all.
+	for _, row := range d.ByCategory {
+		if row.Amount == "-100" {
+			t.Errorf("balance_only txn leaked into ByCategory: %+v", row)
+		}
+	}
+}
+
+// TestAggregator_InGraceExcludedFromLive covers item (e). A member who left
+// within grace must not contribute to live aggregates.
+func TestAggregator_InGraceExcludedFromLive(t *testing.T) {
+	agg, g := newAggregator(t)
+	ctx := context.Background()
+
+	ownerID := seedUser(t, g, "grace-owner")
+	leaverID := seedUser(t, g, "grace-leaver")
+
+	hh := seedHouseholdRow(t, g, ownerID, "Grace House", 30)
+	addMember(t, g, hh.ID, ownerID, model.RoleOwner, nil)
+	leftAt := time.Now().Add(-7 * 24 * time.Hour) // left a week ago, well within 30d grace
+	addMember(t, g, hh.ID, leaverID, model.RoleContributor, &leftAt)
+
+	ownerAcct := seedAccount(t, g, ownerID, "owner-acct")
+	leaverAcct := seedAccount(t, g, leaverID, "leaver-acct")
+	setBalance(t, g, ownerAcct, "100")
+	setBalance(t, g, leaverAcct, "999")
+	setShare(t, g, ownerAcct.ID, hh.ID, model.VisibilityBalanceAndTxns)
+	setShare(t, g, leaverAcct.ID, hh.ID, model.VisibilityBalanceAndTxns)
+
+	when := time.Now().Add(-time.Hour)
+	seedTxn(t, g, leaverID, leaverAcct.ID, "-555", nil, when)
+	seedTxn(t, g, ownerID, ownerAcct.ID, "-10", nil, when)
+
+	d, err := agg.Dashboard(ctx, hh.ID, household.PeriodCurrentMonth)
+	if err != nil {
+		t.Fatalf("Dashboard: %v", err)
+	}
+	if d.NetWorth != "100" {
+		t.Errorf("NetWorth = %q, want 100 (in-grace member excluded)", d.NetWorth)
+	}
+	if d.Spending != "10" {
+		t.Errorf("Spending = %q, want 10", d.Spending)
+	}
+	if d.AccountCount != 1 {
+		t.Errorf("AccountCount = %d, want 1", d.AccountCount)
+	}
+	if d.LiveMemberCount != 1 {
+		t.Errorf("LiveMemberCount = %d, want 1", d.LiveMemberCount)
+	}
+	if d.InGraceCount != 1 {
+		t.Errorf("InGraceCount = %d, want 1 (leaver still in grace window)", d.InGraceCount)
+	}
+}
+
+// TestAggregator_NoRawTransactionRows covers item (f) — reflection walk over
+// every aggregator return type asserts no model.Transaction or
+// []model.Transaction shapes are reachable.
+func TestAggregator_NoRawTransactionRows(t *testing.T) {
+	forbid := reflect.TypeOf(model.Transaction{})
+	check := func(name string, sample any) {
+		walkType(t, name, reflect.TypeOf(sample), forbid, map[reflect.Type]struct{}{})
+	}
+	check("HouseholdDashboard", household.HouseholdDashboard{})
+	check("BudgetPaceItem", household.BudgetPaceItem{})
+	check("GoalProgressItem", household.GoalProgressItem{})
+	check("HouseholdAIContext", household.HouseholdAIContext{})
+	check("ThreadSummary", household.ThreadSummary{})
+}
+
+func walkType(t *testing.T, path string, ty, forbid reflect.Type, seen map[reflect.Type]struct{}) {
+	if ty == nil {
+		return
+	}
+	if _, ok := seen[ty]; ok {
+		return
+	}
+	seen[ty] = struct{}{}
+	if ty == forbid {
+		t.Errorf("%s reaches forbidden type %s — aggregator returns must not embed raw txns", path, forbid)
+		return
+	}
+	switch ty.Kind() {
+	case reflect.Pointer, reflect.Slice, reflect.Array, reflect.Chan, reflect.Map:
+		if ty.Kind() == reflect.Map {
+			walkType(t, path+"[key]", ty.Key(), forbid, seen)
+		}
+		walkType(t, path+"[elem]", ty.Elem(), forbid, seen)
+	case reflect.Struct:
+		for i := 0; i < ty.NumField(); i++ {
+			f := ty.Field(i)
+			walkType(t, path+"."+f.Name, f.Type, forbid, seen)
+		}
+	}
+}
+
+// TestAggregator_AIContextNoCrossMemberLeak covers item (g) — Member A's
+// AIContext never includes Member B's non-shared threads.
+func TestAggregator_AIContextNoCrossMemberLeak(t *testing.T) {
+	agg, g := newAggregator(t)
+	ctx := context.Background()
+
+	a := seedUser(t, g, "ai-a")
+	b := seedUser(t, g, "ai-b")
+	hh := seedHouseholdRow(t, g, a, "AI House", 30)
+	addMember(t, g, hh.ID, a, model.RoleOwner, nil)
+	addMember(t, g, hh.ID, b, model.RoleContributor, nil)
+
+	// Member A: one personal thread, one shared thread.
+	aPersonal := &model.AIThread{UserID: a, SharedWithHousehold: false, Title: ptr("A personal")}
+	if err := g.Create(aPersonal).Error; err != nil {
+		t.Fatalf("seed a personal: %v", err)
+	}
+	t.Cleanup(func() { g.Unscoped().Delete(aPersonal) })
+	aShared := &model.AIThread{UserID: a, HouseholdID: &hh.ID, SharedWithHousehold: true, Title: ptr("A shared")}
+	if err := g.Create(aShared).Error; err != nil {
+		t.Fatalf("seed a shared: %v", err)
+	}
+	t.Cleanup(func() { g.Unscoped().Delete(aShared) })
+
+	// Member B: one personal thread (MUST NOT be visible to A), one shared.
+	bPersonal := &model.AIThread{UserID: b, SharedWithHousehold: false, Title: ptr("B personal")}
+	if err := g.Create(bPersonal).Error; err != nil {
+		t.Fatalf("seed b personal: %v", err)
+	}
+	t.Cleanup(func() { g.Unscoped().Delete(bPersonal) })
+	bShared := &model.AIThread{UserID: b, HouseholdID: &hh.ID, SharedWithHousehold: true, Title: ptr("B shared")}
+	if err := g.Create(bShared).Error; err != nil {
+		t.Fatalf("seed b shared: %v", err)
+	}
+	t.Cleanup(func() { g.Unscoped().Delete(bShared) })
+
+	out, err := agg.AIContext(ctx, hh.ID, a)
+	if err != nil {
+		t.Fatalf("AIContext: %v", err)
+	}
+	for _, th := range out.PersonalThreads {
+		if th.UserID != a {
+			t.Errorf("AIContext.PersonalThreads leaks user %d into A's view: %+v", th.UserID, th)
+		}
+	}
+	// Shared threads should include BOTH members' shared threads — that's the point.
+	var sawA, sawB bool
+	for _, th := range out.SharedThreads {
+		if th.ID == aShared.ID {
+			sawA = true
+		}
+		if th.ID == bShared.ID {
+			sawB = true
+		}
+	}
+	if !sawA || !sawB {
+		t.Errorf("SharedThreads = %+v, want both A and B's shared threads", out.SharedThreads)
+	}
+	// And neither member's personal thread should show up in the SharedThreads list.
+	for _, th := range out.SharedThreads {
+		if th.ID == aPersonal.ID || th.ID == bPersonal.ID {
+			t.Errorf("personal thread leaked into SharedThreads: %+v", th)
+		}
+	}
+}
+
+// TestAggregator_HistoricalIncludesInGrace verifies the historical lens
+// (member list including left-within-grace). The current aggregator surface
+// doesn't expose historical aggregates yet (deferred until shared_budgets
+// roll-up history), but the partition lives in liveAndInGrace and the
+// dashboard exposes the count. So we assert via the count contract.
+func TestAggregator_HistoricalIncludesInGrace(t *testing.T) {
+	agg, g := newAggregator(t)
+	ctx := context.Background()
+
+	ownerID := seedUser(t, g, "hist-owner")
+	leaverID := seedUser(t, g, "hist-leaver")
+	hh := seedHouseholdRow(t, g, ownerID, "Hist House", 30)
+	addMember(t, g, hh.ID, ownerID, model.RoleOwner, nil)
+	// Inside grace.
+	in := time.Now().Add(-3 * 24 * time.Hour)
+	addMember(t, g, hh.ID, leaverID, model.RoleContributor, &in)
+
+	d, err := agg.Dashboard(ctx, hh.ID, household.PeriodCurrentMonth)
+	if err != nil {
+		t.Fatalf("Dashboard: %v", err)
+	}
+	if d.LiveMemberCount != 1 || d.InGraceCount != 1 {
+		t.Errorf("counts live=%d in_grace=%d, want 1/1", d.LiveMemberCount, d.InGraceCount)
+	}
+
+	// Outside grace: pretend grace is 1 day.
+	g.Model(hh).Update("grace_period_days", 1)
+	d2, err := agg.Dashboard(ctx, hh.ID, household.PeriodCurrentMonth)
+	if err != nil {
+		t.Fatalf("Dashboard #2: %v", err)
+	}
+	if d2.InGraceCount != 0 {
+		t.Errorf("after grace shrink, InGraceCount = %d, want 0", d2.InGraceCount)
+	}
+}
+
+// TestAggregator_HouseholdNotFound surfaces a clean error when the household
+// is gone (e.g. dissolved between handler call and aggregator dispatch).
+func TestAggregator_HouseholdNotFound(t *testing.T) {
+	agg, _ := newAggregator(t)
+	if _, err := agg.Dashboard(context.Background(), 999_999_999, household.PeriodCurrentMonth); err == nil {
+		t.Fatalf("expected ErrHouseholdNotFound, got nil")
+	}
+}
+
+func ptr[T any](v T) *T { return &v }

--- a/backend/internal/service/household/period.go
+++ b/backend/internal/service/household/period.go
@@ -1,0 +1,46 @@
+package household
+
+import (
+	"errors"
+	"strings"
+	"time"
+)
+
+// Period keys understood by aggregator endpoints under /h/...
+// Mirrors service.Period* constants intentionally — keeping a local copy
+// means service/household has no import dependency on service/.
+const (
+	PeriodCurrentMonth = "current_month"
+	PeriodLast30D      = "last_30d"
+	PeriodYTD          = "ytd"
+)
+
+// ErrInvalidPeriod is returned for unknown period keys.
+var ErrInvalidPeriod = errors.New("invalid period")
+
+// ResolvePeriod returns the [from, to) window for the named period.
+// Boundaries are local-time to match the personal dashboard's behavior.
+func ResolvePeriod(key string, now time.Time) (time.Time, time.Time, error) {
+	key = strings.TrimSpace(key)
+	if key == "" {
+		key = PeriodCurrentMonth
+	}
+	switch key {
+	case PeriodCurrentMonth:
+		from := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, now.Location())
+		to := from.AddDate(0, 1, 0)
+		return from, to, nil
+	case PeriodLast30D:
+		today := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
+		from := today.AddDate(0, 0, -30)
+		to := today.AddDate(0, 0, 1)
+		return from, to, nil
+	case PeriodYTD:
+		from := time.Date(now.Year(), time.January, 1, 0, 0, 0, 0, now.Location())
+		today := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
+		to := today.AddDate(0, 0, 1)
+		return from, to, nil
+	default:
+		return time.Time{}, time.Time{}, ErrInvalidPeriod
+	}
+}

--- a/backend/internal/service/scope_service.go
+++ b/backend/internal/service/scope_service.go
@@ -1,0 +1,91 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/gregwym/offbook/backend/internal/model"
+	"github.com/gregwym/offbook/backend/internal/repository"
+)
+
+// ErrInvalidScope is returned when a caller asks to switch to a scope that
+// isn't one of {personal, household}, or that isn't available to them
+// (e.g. asking for household when not a member).
+var ErrInvalidScope = errors.New("invalid scope")
+
+// ScopeView is the GET /me/scope payload. `active` is what the sidebar
+// renders; `available` is the union the picker can switch to.
+type ScopeView struct {
+	Active      string   `json:"active"`
+	Available   []string `json:"available"`
+	HouseholdID *int64   `json:"household_id,omitempty"`
+}
+
+// ScopeService owns persistence of users.last_scope and computes the user's
+// available scopes by checking active household membership. Touches users +
+// household_members repos only.
+type ScopeService struct {
+	users   repository.UserRepository
+	members repository.HouseholdMemberRepository
+}
+
+func NewScopeService(users repository.UserRepository, members repository.HouseholdMemberRepository) *ScopeService {
+	return &ScopeService{users: users, members: members}
+}
+
+// Get reports the user's active + available scopes. If users.last_scope is
+// household but the user is no longer in a household (e.g. left during grace
+// without rejoining), we degrade to personal in the response without
+// persisting — the next PATCH will pin it.
+func (s *ScopeService) Get(ctx context.Context, userID int64) (*ScopeView, error) {
+	u, err := s.users.GetByID(ctx, userID)
+	if err != nil {
+		return nil, fmt.Errorf("get user: %w", err)
+	}
+	mem, err := s.members.GetMembershipForUser(ctx, userID)
+	var hasHousehold bool
+	var hhID *int64
+	if err == nil && mem != nil && mem.LeftAt == nil {
+		hasHousehold = true
+		id := mem.HouseholdID
+		hhID = &id
+	} else if err != nil && !errors.Is(err, repository.ErrNotFound) {
+		return nil, fmt.Errorf("lookup membership: %w", err)
+	}
+
+	available := []string{model.ScopePersonal}
+	if hasHousehold {
+		available = append(available, model.ScopeHousehold)
+	}
+
+	active := u.LastScope
+	if active == model.ScopeHousehold && !hasHousehold {
+		active = model.ScopePersonal
+	}
+	if active != model.ScopePersonal && active != model.ScopeHousehold {
+		active = model.ScopePersonal
+	}
+	return &ScopeView{Active: active, Available: available, HouseholdID: hhID}, nil
+}
+
+// Set persists users.last_scope. Rejects requests to enter household scope
+// when the user is not an active member.
+func (s *ScopeService) Set(ctx context.Context, userID int64, scope string) (*ScopeView, error) {
+	switch scope {
+	case model.ScopePersonal, model.ScopeHousehold:
+		// ok
+	default:
+		return nil, ErrInvalidScope
+	}
+	if scope == model.ScopeHousehold {
+		mem, err := s.members.GetMembershipForUser(ctx, userID)
+		if err != nil || mem == nil || mem.LeftAt != nil {
+			return nil, ErrInvalidScope
+		}
+	}
+	if err := s.users.UpdateLastScope(ctx, userID, scope); err != nil {
+		return nil, fmt.Errorf("update last_scope: %w", err)
+	}
+	return s.Get(ctx, userID)
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,6 +4,12 @@ import { AccountsPage } from './pages/AccountsPage'
 import { AIPage } from './pages/AIPage'
 import { BudgetsPage } from './pages/BudgetsPage'
 import { DashboardPage } from './pages/DashboardPage'
+import { HouseholdAIPage } from './pages/HouseholdAIPage'
+import { HouseholdBudgetsPage } from './pages/HouseholdBudgetsPage'
+import { HouseholdDashboardPage } from './pages/HouseholdDashboardPage'
+import { HouseholdGoalsPage } from './pages/HouseholdGoalsPage'
+import { HouseholdMembersPage } from './pages/HouseholdMembersPage'
+import { HouseholdSettingsPage } from './pages/HouseholdSettingsPage'
 import { ImportPage } from './pages/ImportPage'
 import { InvestmentsPage } from './pages/InvestmentsPage'
 import { SavingsGoalsPage } from './pages/SavingsGoalsPage'
@@ -24,6 +30,13 @@ export default function App() {
         <Route path="/import" element={<ImportPage />} />
         <Route path="/ai" element={<AIPage />} />
         <Route path="/settings" element={<SettingsPage />} />
+
+        <Route path="/h/dashboard" element={<HouseholdDashboardPage />} />
+        <Route path="/h/budgets"   element={<HouseholdBudgetsPage />} />
+        <Route path="/h/goals"     element={<HouseholdGoalsPage />} />
+        <Route path="/h/members"   element={<HouseholdMembersPage />} />
+        <Route path="/h/ai"        element={<HouseholdAIPage />} />
+        <Route path="/h/settings"  element={<HouseholdSettingsPage />} />
       </Route>
     </Routes>
   )

--- a/frontend/src/api/scope.ts
+++ b/frontend/src/api/scope.ts
@@ -1,0 +1,15 @@
+import { apiClient, type ApiItem } from './client'
+import type { Scope, ScopeView } from '../types/scope'
+
+// GET /me/scope — current active scope + the set the user can switch to.
+export async function getScope(): Promise<ScopeView> {
+  const res = await apiClient.get<ApiItem<ScopeView>>('/me/scope')
+  return res.data.data
+}
+
+// PATCH /me/scope — persists the new scope on users.last_scope.
+// Returns the canonical ScopeView the server settled on.
+export async function setScope(scope: Scope): Promise<ScopeView> {
+  const res = await apiClient.patch<ApiItem<ScopeView>>('/me/scope', { scope })
+  return res.data.data
+}

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -7,11 +7,19 @@ import {
   Settings,
   Target,
   TrendingUp,
+  Users,
   Wallet,
 } from 'lucide-react'
+import { useEffect } from 'react'
 import { NavLink, Outlet } from 'react-router-dom'
+import { useScopeStore } from '../store/scopeStore'
+import { SCOPE_HOUSEHOLD, SCOPE_PERSONAL, type Scope } from '../types/scope'
 
-const NAV_ITEMS: Array<{ to: string; label: string; icon: typeof LayoutDashboard }> = [
+type NavItem = { to: string; label: string; icon: typeof LayoutDashboard }
+
+// Personal-scope routes — mutually exclusive with HOUSEHOLD_NAV per
+// .claude/rules/frontend.md (sidebar renders only the active scope's list).
+const PERSONAL_NAV: NavItem[] = [
   { to: '/dashboard',     label: 'Dashboard',     icon: LayoutDashboard },
   { to: '/accounts',      label: 'Accounts',      icon: Wallet },
   { to: '/transactions',  label: 'Transactions',  icon: Receipt },
@@ -23,13 +31,36 @@ const NAV_ITEMS: Array<{ to: string; label: string; icon: typeof LayoutDashboard
   { to: '/settings',      label: 'Settings',      icon: Settings },
 ]
 
+// Household-scope routes — all under /h/* (frontend rule). Only rendered when
+// the user has an active membership AND has picked household scope.
+const HOUSEHOLD_NAV: NavItem[] = [
+  { to: '/h/dashboard', label: 'Dashboard',    icon: LayoutDashboard },
+  { to: '/h/budgets',   label: 'Budgets',      icon: Target },
+  { to: '/h/goals',     label: 'Goals',        icon: PiggyBank },
+  { to: '/h/members',   label: 'Members',      icon: Users },
+  { to: '/h/ai',        label: 'AI Advisor',   icon: Bot },
+  { to: '/h/settings',  label: 'Settings',     icon: Settings },
+]
+
 export function AppShell() {
+  const { active, available, hydrated, hydrate, setScope } = useScopeStore()
+
+  useEffect(() => {
+    if (!hydrated) {
+      void hydrate()
+    }
+  }, [hydrated, hydrate])
+
+  const items = active === SCOPE_HOUSEHOLD ? HOUSEHOLD_NAV : PERSONAL_NAV
+  const canSwitch = available.includes(SCOPE_HOUSEHOLD)
+
   return (
     <div className="flex h-screen w-screen bg-gray-50">
       <aside className="flex w-60 flex-col border-r border-gray-200 bg-white">
         <div className="px-6 py-5 text-lg font-semibold text-gray-900">offbook</div>
+        {canSwitch && <ScopePicker active={active} onChange={setScope} />}
         <nav className="flex-1 space-y-1 px-3 pb-4">
-          {NAV_ITEMS.map(({ to, label, icon: Icon }) => (
+          {items.map(({ to, label, icon: Icon }) => (
             <NavLink
               key={to}
               to={to}
@@ -53,6 +84,36 @@ export function AppShell() {
           <Outlet />
         </div>
       </main>
+    </div>
+  )
+}
+
+// ScopePicker is a binary toggle between personal (👤) and household (🏠).
+// Hidden when the user has no household membership.
+function ScopePicker({ active, onChange }: { active: Scope; onChange: (s: Scope) => void }) {
+  const opts: Array<{ key: Scope; emoji: string; label: string }> = [
+    { key: SCOPE_PERSONAL,  emoji: '\u{1F464}', label: 'Personal' },
+    { key: SCOPE_HOUSEHOLD, emoji: '\u{1F3E0}', label: 'Household' },
+  ]
+  return (
+    <div className="mx-3 mb-3 flex rounded-md border border-gray-200 bg-gray-50 p-1">
+      {opts.map((o) => (
+        <button
+          key={o.key}
+          type="button"
+          onClick={() => onChange(o.key)}
+          aria-pressed={active === o.key}
+          className={[
+            'flex-1 rounded px-2 py-1 text-xs font-medium transition',
+            active === o.key
+              ? 'bg-white text-gray-900 shadow-sm'
+              : 'text-gray-500 hover:text-gray-700',
+          ].join(' ')}
+        >
+          <span className="mr-1">{o.emoji}</span>
+          {o.label}
+        </button>
+      ))}
     </div>
   )
 }

--- a/frontend/src/pages/HouseholdAIPage.tsx
+++ b/frontend/src/pages/HouseholdAIPage.tsx
@@ -1,0 +1,5 @@
+import { PageStub } from '../components/PageStub'
+
+export function HouseholdAIPage() {
+  return <PageStub title="Household AI Advisor" description="Shared-context chat coming later." />
+}

--- a/frontend/src/pages/HouseholdBudgetsPage.tsx
+++ b/frontend/src/pages/HouseholdBudgetsPage.tsx
@@ -1,0 +1,5 @@
+import { PageStub } from '../components/PageStub'
+
+export function HouseholdBudgetsPage() {
+  return <PageStub title="Household Budgets" description="Shared budgets CRUD coming later." />
+}

--- a/frontend/src/pages/HouseholdDashboardPage.tsx
+++ b/frontend/src/pages/HouseholdDashboardPage.tsx
@@ -1,0 +1,5 @@
+import { PageStub } from '../components/PageStub'
+
+export function HouseholdDashboardPage() {
+  return <PageStub title="Household Dashboard" description="Hi-fi layout coming in a later milestone." />
+}

--- a/frontend/src/pages/HouseholdGoalsPage.tsx
+++ b/frontend/src/pages/HouseholdGoalsPage.tsx
@@ -1,0 +1,5 @@
+import { PageStub } from '../components/PageStub'
+
+export function HouseholdGoalsPage() {
+  return <PageStub title="Household Goals" description="Shared savings goals coming later." />
+}

--- a/frontend/src/pages/HouseholdMembersPage.tsx
+++ b/frontend/src/pages/HouseholdMembersPage.tsx
@@ -1,0 +1,5 @@
+import { PageStub } from '../components/PageStub'
+
+export function HouseholdMembersPage() {
+  return <PageStub title="Household Members" description="Members table UI coming later." />
+}

--- a/frontend/src/pages/HouseholdSettingsPage.tsx
+++ b/frontend/src/pages/HouseholdSettingsPage.tsx
@@ -1,0 +1,5 @@
+import { PageStub } from '../components/PageStub'
+
+export function HouseholdSettingsPage() {
+  return <PageStub title="Household Settings" description="Invite, grace period, dissolve — coming later." />
+}

--- a/frontend/src/store/scopeStore.ts
+++ b/frontend/src/store/scopeStore.ts
@@ -1,0 +1,64 @@
+import { create } from 'zustand'
+import { getScope, setScope as apiSetScope } from '../api/scope'
+import { SCOPE_PERSONAL, type Scope } from '../types/scope'
+
+type ScopeState = {
+  active: Scope
+  available: Scope[]
+  householdId: number | null
+  hydrated: boolean
+  loading: boolean
+  error: string | null
+  hydrate: () => Promise<void>
+  setScope: (scope: Scope) => Promise<void>
+}
+
+// scopeStore is the canonical client-side reflection of /me/scope. The
+// AppShell sidebar reads `active` + `available` to decide which route list
+// to render. Mutations go through PATCH /me/scope so the server is the
+// source of truth — we never mutate `active` locally without persisting.
+export const useScopeStore = create<ScopeState>((set) => ({
+  active: SCOPE_PERSONAL,
+  available: [SCOPE_PERSONAL],
+  householdId: null,
+  hydrated: false,
+  loading: false,
+  error: null,
+
+  hydrate: async () => {
+    set({ loading: true, error: null })
+    try {
+      const view = await getScope()
+      set({
+        active: view.active,
+        available: view.available,
+        householdId: view.household_id ?? null,
+        hydrated: true,
+        loading: false,
+      })
+    } catch (err) {
+      set({
+        error: err instanceof Error ? err.message : 'failed to load scope',
+        loading: false,
+      })
+    }
+  },
+
+  setScope: async (scope) => {
+    set({ loading: true, error: null })
+    try {
+      const view = await apiSetScope(scope)
+      set({
+        active: view.active,
+        available: view.available,
+        householdId: view.household_id ?? null,
+        loading: false,
+      })
+    } catch (err) {
+      set({
+        error: err instanceof Error ? err.message : 'failed to set scope',
+        loading: false,
+      })
+    }
+  },
+}))

--- a/frontend/src/types/scope.ts
+++ b/frontend/src/types/scope.ts
@@ -1,0 +1,12 @@
+// Scope values must match backend model.Scope* constants exactly.
+export const SCOPE_PERSONAL = 'personal' as const
+export const SCOPE_HOUSEHOLD = 'household' as const
+
+export type Scope = typeof SCOPE_PERSONAL | typeof SCOPE_HOUSEHOLD
+
+// ScopeView mirrors backend service.ScopeView.
+export type ScopeView = {
+  active: Scope
+  available: Scope[]
+  household_id?: number | null
+}


### PR DESCRIPTION
Closes #46.

## Summary

- **Aggregator** (`internal/service/household/aggregator.go`): the single cross-user reader for household surfaces. Methods: `Dashboard`, `BudgetPace`, `GoalProgress`, `AIContext`. NO `pii_repo` import (statically enforced).
- **Lifecycle filtering**: live aggregates exclude in-grace members; historical (member counts) include them. Members beyond grace are dropped from both. Private accounts excluded everywhere; `balance_only` excluded from category breakdowns.
- **Cross-user repo** (`internal/repository/household_aggregator_repo.go`): aggregation queries scoped to opt-in shared accounts. Returns sums/counts/category rows only — no raw transactions.
- **Privacy tests** (6 distinct checks per `.claude/rules/testing.md`):
  1. Static import scan rejects any non-test file in `service/household` importing PII
  2. Reflection walk asserts `model.Transaction` is unreachable from every aggregator return type
  3. Private accounts excluded from balance/spend/category/count
  4. `balance_only` included in net worth, excluded from category breakdown
  5. In-grace member's accounts/txns excluded from live aggregates
  6. AIContext for member A never includes member B's non-shared threads
- **Scope API**: `GET /me/scope` returns `{active, available, household_id}`; `PATCH /me/scope` persists to `users.last_scope`. Refuses household scope when user has no active membership.
- **Frontend**: zustand `scopeStore` hydrates from `/me/scope` and exposes `setScope`. AppShell renders a binary 👤/🏠 picker (hidden if user has no household). Sidebar renders ONLY the active scope's route list. Six `/h/*` PageStubs: dashboard, budgets, goals, members, ai, settings.

## Test plan

- [x] `go test ./...` green (11 aggregator/privacy tests + existing M2.5 suite)
- [x] `command make lint` clean
- [x] `pnpm build` + `pnpm lint` clean
- [x] End-to-end smoke: fresh setup-admin → create household → /me/scope before/after → PATCH to household → /h/{dashboard,budgets/pace,goals/progress,ai/context} → bad period → 400 with allowed list

🤖 Generated with [Claude Code](https://claude.com/claude-code)