### PR TITLE
M2 #31: Accounts frontend — list, create, edit, soft-delete, PII panel

### DIFF
--- a/frontend/src/api/accounts.ts
+++ b/frontend/src/api/accounts.ts
@@ -1,0 +1,57 @@
+import { apiClient, type ApiItem, type ApiList } from './client'
+import type {
+  Account,
+  AccountPII,
+  CreateAccountInput,
+  UpdateAccountInput,
+} from '../types/account'
+
+export type AccountListFilter = {
+  institution_slug?: string
+  account_type?: string
+  is_active?: boolean
+  limit?: number
+  offset?: number
+}
+
+export async function listAccounts(f: AccountListFilter = {}): Promise<{ items: Account[]; total: number }> {
+  const params: Record<string, string | number | boolean> = {}
+  if (f.institution_slug) params.institution_slug = f.institution_slug
+  if (f.account_type) params.account_type = f.account_type
+  if (f.is_active !== undefined) params.is_active = f.is_active
+  if (f.limit !== undefined) params.limit = f.limit
+  if (f.offset !== undefined) params.offset = f.offset
+  const res = await apiClient.get<ApiList<Account>>('/accounts', { params })
+  return { items: res.data.data, total: res.data.total }
+}
+
+export async function getAccount(id: number): Promise<Account> {
+  const res = await apiClient.get<ApiItem<Account>>(`/accounts/${id}`)
+  return res.data.data
+}
+
+export async function createAccount(input: CreateAccountInput): Promise<Account> {
+  const res = await apiClient.post<ApiItem<Account>>('/accounts', input)
+  return res.data.data
+}
+
+export async function updateAccount(id: number, input: UpdateAccountInput): Promise<Account> {
+  const res = await apiClient.patch<ApiItem<Account>>(`/accounts/${id}`, input)
+  return res.data.data
+}
+
+export async function deleteAccount(id: number): Promise<void> {
+  await apiClient.delete(`/accounts/${id}`)
+}
+
+// PII reads/writes always hit a separate endpoint, by design — never bundled
+// into account responses. Mask in the UI; the network tab is auditable.
+export async function getAccountPII(id: number): Promise<AccountPII> {
+  const res = await apiClient.get<ApiItem<AccountPII>>(`/accounts/${id}/pii`)
+  return res.data.data
+}
+
+export async function updateAccountPII(id: number, fields: AccountPII): Promise<AccountPII> {
+  const res = await apiClient.put<ApiItem<AccountPII>>(`/accounts/${id}/pii`, fields)
+  return res.data.data
+}

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -4,10 +4,13 @@ import axios from 'axios'
 // environments (preview build, prod, container) set VITE_API_BASE_URL.
 const baseURL = import.meta.env.VITE_API_BASE_URL ?? '/api/v1'
 
+// withCredentials: true so the session cookie set by /auth/* and /setup/admin
+// is sent on every subsequent request. The vite proxy preserves Set-Cookie /
+// Cookie headers, and the backend's CORS middleware sets Allow-Credentials.
 export const apiClient = axios.create({
   baseURL,
   headers: { 'Content-Type': 'application/json' },
-  withCredentials: false,
+  withCredentials: true,
 })
 
 // Standard backend envelope shapes (mirror backend handler conventions).

--- a/frontend/src/components/AmountDisplay.tsx
+++ b/frontend/src/components/AmountDisplay.tsx
@@ -1,0 +1,52 @@
+// AmountDisplay is the ONLY allowed place to format monetary values in the
+// UI. Money arrives as a decimal string (NUMERIC(30,18)) — never convert to
+// Number before display: that loses precision at crypto scale (BTC has 8
+// places, ETH has 18). We slice the string and let Intl.NumberFormat handle
+// the integer + fractional parts separately.
+
+type Props = {
+  amount: string | undefined | null
+  currency?: string
+  // Override display precision; default is currency-default (2 for fiat).
+  fractionDigits?: number
+  // Apply red text when negative (handy for spending columns).
+  signed?: boolean
+  className?: string
+}
+
+const DEFAULT_FRACTION: Record<string, number> = {
+  USD: 2, EUR: 2, GBP: 2, JPY: 0, CAD: 2, AUD: 2,
+  BTC: 8, ETH: 6,
+}
+
+export function AmountDisplay({ amount, currency = 'USD', fractionDigits, signed, className }: Props) {
+  if (amount === undefined || amount === null || amount === '') {
+    return <span className={className}>—</span>
+  }
+  const fraction = fractionDigits ?? DEFAULT_FRACTION[currency] ?? 2
+  const negative = amount.trim().startsWith('-')
+  const text = formatDecimal(amount, fraction, currency)
+  const color = signed && negative ? 'text-red-700' : signed && !negative ? 'text-emerald-700' : ''
+  return <span className={[color, className ?? ''].join(' ').trim()}>{text}</span>
+}
+
+function formatDecimal(value: string, fraction: number, currency: string): string {
+  const trimmed = value.trim()
+  const sign = trimmed.startsWith('-') ? '-' : ''
+  const abs = sign ? trimmed.slice(1) : trimmed
+  const [intPart = '0', fracRaw = ''] = abs.split('.')
+
+  // Group integer part using locale separators via Intl.
+  const intFormatted = new Intl.NumberFormat(undefined, { useGrouping: true }).format(
+    BigInt(intPart || '0'),
+  )
+
+  let fracOut = ''
+  if (fraction > 0) {
+    const padded = (fracRaw + '0'.repeat(fraction)).slice(0, fraction)
+    fracOut = padded.length > 0 ? '.' + padded : ''
+  }
+
+  // Currency suffix keeps the format simple and unambiguous across symbols.
+  return `${sign}${intFormatted}${fracOut} ${currency}`
+}

--- a/frontend/src/components/PIIPanel.tsx
+++ b/frontend/src/components/PIIPanel.tsx
@@ -1,0 +1,136 @@
+import { useState } from 'react'
+import { Eye, EyeOff } from 'lucide-react'
+import { getAccountPII, updateAccountPII } from '../api/accounts'
+import { PII_FIELDS, type AccountPII, type AccountPIIField } from '../types/account'
+
+type Props = {
+  accountID: number
+}
+
+const FIELD_LABELS: Record<AccountPIIField, string> = {
+  holder_name: 'Holder name',
+  account_number: 'Account number',
+  routing_number: 'Routing number',
+  address: 'Address',
+}
+
+// PIIPanel is a collapsible inside the Edit modal. PII is fetched ONLY when
+// the panel is expanded — verifiable in DevTools network: open the modal,
+// observe NO /pii call until the user clicks "Show". This matches the
+// architectural promise that PII access is deliberate and auditable.
+export function PIIPanel({ accountID }: Props) {
+  const [expanded, setExpanded] = useState(false)
+  const [loaded, setLoaded] = useState(false)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [reveal, setReveal] = useState<Record<AccountPIIField, boolean>>({
+    holder_name: false, account_number: false, routing_number: false, address: false,
+  })
+  const [values, setValues] = useState<AccountPII>({})
+  const [saving, setSaving] = useState(false)
+
+  const toggle = async () => {
+    const next = !expanded
+    setExpanded(next)
+    if (next && !loaded) {
+      setLoading(true)
+      setError(null)
+      try {
+        const pii = await getAccountPII(accountID)
+        setValues(pii)
+        setLoaded(true)
+      } catch (err) {
+        setError(errMsg(err))
+      } finally {
+        setLoading(false)
+      }
+    }
+  }
+
+  const save = async () => {
+    setSaving(true)
+    setError(null)
+    try {
+      // Filter out empty strings — the backend rejects empty values per
+      // ErrEmptyPIIValue. Users clear a field by leaving it blank, which we
+      // simply omit from the PUT.
+      const payload: AccountPII = {}
+      for (const f of PII_FIELDS) {
+        const v = values[f]
+        if (v && v.trim() !== '') payload[f] = v.trim()
+      }
+      const fresh = await updateAccountPII(accountID, payload)
+      setValues(fresh)
+    } catch (err) {
+      setError(errMsg(err))
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <div className="rounded-md border border-gray-200">
+      <button
+        type="button"
+        onClick={toggle}
+        className="flex w-full items-center justify-between px-4 py-3 text-sm font-medium text-gray-700 hover:bg-gray-50"
+      >
+        <span>PII (holder, account number, routing, address)</span>
+        <span className="text-xs text-gray-500">{expanded ? 'Hide' : 'Show'}</span>
+      </button>
+      {expanded && (
+        <div className="space-y-3 border-t border-gray-200 px-4 py-3">
+          {loading && <div className="text-sm text-gray-500">Loading…</div>}
+          {error && <div className="text-sm text-red-700">{error}</div>}
+          {!loading && (
+            <>
+              {PII_FIELDS.map((field) => (
+                <div key={field}>
+                  <label className="mb-1 block text-xs font-medium text-gray-600">
+                    {FIELD_LABELS[field]}
+                  </label>
+                  <div className="flex items-stretch gap-2">
+                    <input
+                      type={reveal[field] ? 'text' : 'password'}
+                      value={values[field] ?? ''}
+                      onChange={(e) => setValues({ ...values, [field]: e.target.value })}
+                      autoComplete="off"
+                      className="flex-1 rounded border border-gray-300 px-2 py-1 text-sm"
+                    />
+                    <button
+                      type="button"
+                      onClick={() => setReveal({ ...reveal, [field]: !reveal[field] })}
+                      className="rounded border border-gray-300 px-2 text-gray-600 hover:bg-gray-100"
+                      aria-label={reveal[field] ? 'Hide' : 'Reveal'}
+                    >
+                      {reveal[field] ? <EyeOff size={14} /> : <Eye size={14} />}
+                    </button>
+                  </div>
+                </div>
+              ))}
+              <div className="flex justify-end">
+                <button
+                  type="button"
+                  onClick={save}
+                  disabled={saving}
+                  className="rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-indigo-700 disabled:opacity-50"
+                >
+                  {saving ? 'Saving…' : 'Save PII'}
+                </button>
+              </div>
+            </>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function errMsg(err: unknown): string {
+  if (err && typeof err === 'object' && 'response' in err) {
+    const r = (err as { response?: { data?: { error?: string } } }).response
+    if (r?.data?.error) return r.data.error
+  }
+  if (err instanceof Error) return err.message
+  return 'request failed'
+}

--- a/frontend/src/pages/AccountsPage.tsx
+++ b/frontend/src/pages/AccountsPage.tsx
@@ -1,5 +1,260 @@
-import { PageStub } from '../components/PageStub'
+import { useEffect, useState, type ReactNode } from 'react'
+import { Pencil, Plus, Trash2 } from 'lucide-react'
+import { AmountDisplay } from '../components/AmountDisplay'
+import { PIIPanel } from '../components/PIIPanel'
+import { useAccountsStore } from '../store/accountsStore'
+import {
+  ACCOUNT_TYPES,
+  type Account,
+  type AccountType,
+  type CreateAccountInput,
+  type UpdateAccountInput,
+} from '../types/account'
 
 export function AccountsPage() {
-  return <PageStub title="Accounts" />
+  const { accounts, loading, error, fetch, create, update, remove } = useAccountsStore()
+  const [adding, setAdding] = useState(false)
+  const [editing, setEditing] = useState<Account | null>(null)
+
+  useEffect(() => {
+    void fetch()
+  }, [fetch])
+
+  return (
+    <div>
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold text-gray-900">Accounts</h1>
+          <p className="mt-1 text-sm text-gray-500">Manage your accounts and PII.</p>
+        </div>
+        <button
+          type="button"
+          onClick={() => setAdding(true)}
+          className="inline-flex items-center gap-2 rounded-md bg-indigo-600 px-3 py-2 text-sm font-medium text-white hover:bg-indigo-700"
+        >
+          <Plus size={16} /> Add account
+        </button>
+      </div>
+
+      {error && (
+        <div className="mt-4 rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
+          {error}
+        </div>
+      )}
+
+      <div className="mt-6 overflow-hidden rounded-lg border border-gray-200 bg-white">
+        <table className="min-w-full divide-y divide-gray-200 text-sm">
+          <thead className="bg-gray-50 text-xs font-medium uppercase tracking-wider text-gray-500">
+            <tr>
+              <th className="px-4 py-2 text-left">Name</th>
+              <th className="px-4 py-2 text-left">Institution</th>
+              <th className="px-4 py-2 text-left">Type</th>
+              <th className="px-4 py-2 text-left">Last 4</th>
+              <th className="px-4 py-2 text-right">Balance</th>
+              <th className="px-4 py-2 text-center">Active</th>
+              <th className="px-4 py-2"></th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-gray-100">
+            {loading && accounts.length === 0 && (
+              <tr><td colSpan={7} className="px-4 py-6 text-center text-gray-400">Loading…</td></tr>
+            )}
+            {!loading && accounts.length === 0 && (
+              <tr><td colSpan={7} className="px-4 py-6 text-center text-gray-400">No accounts yet.</td></tr>
+            )}
+            {accounts.map((a) => (
+              <tr key={a.id} className="hover:bg-gray-50">
+                <td className="px-4 py-2 font-medium text-gray-900">{a.name}</td>
+                <td className="px-4 py-2 text-gray-700">{a.institution_slug}</td>
+                <td className="px-4 py-2 text-gray-700">{a.account_type}</td>
+                <td className="px-4 py-2 text-gray-700">{a.last_four ?? '—'}</td>
+                <td className="px-4 py-2 text-right">
+                  <AmountDisplay amount={a.balance} currency={a.currency} />
+                </td>
+                <td className="px-4 py-2 text-center">
+                  <span className={a.is_active ? 'text-emerald-700' : 'text-gray-400'}>
+                    {a.is_active ? 'yes' : 'no'}
+                  </span>
+                </td>
+                <td className="px-4 py-2 text-right">
+                  <button
+                    type="button"
+                    onClick={() => setEditing(a)}
+                    className="mr-2 text-gray-500 hover:text-gray-900"
+                    aria-label="Edit"
+                  >
+                    <Pencil size={16} />
+                  </button>
+                  <button
+                    type="button"
+                    onClick={async () => {
+                      if (window.confirm(`Delete "${a.name}"?`)) {
+                        await remove(a.id)
+                      }
+                    }}
+                    className="text-gray-500 hover:text-red-700"
+                    aria-label="Delete"
+                  >
+                    <Trash2 size={16} />
+                  </button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      {adding && (
+        <AccountFormModal
+          mode="create"
+          onClose={() => setAdding(false)}
+          onSubmit={async (input) => {
+            await create(input as CreateAccountInput)
+            setAdding(false)
+          }}
+        />
+      )}
+
+      {editing && (
+        <AccountFormModal
+          mode="edit"
+          account={editing}
+          onClose={() => setEditing(null)}
+          onSubmit={async (input) => {
+            await update(editing.id, input)
+            setEditing(null)
+          }}
+        />
+      )}
+    </div>
+  )
+}
+
+type FormProps = {
+  mode: 'create' | 'edit'
+  account?: Account
+  onClose: () => void
+  onSubmit: (input: CreateAccountInput | UpdateAccountInput) => Promise<void>
+}
+
+// Single form used for both create and edit. In edit mode, PII access is
+// available inline (PIIPanel fetches on-demand).
+function AccountFormModal({ mode, account, onClose, onSubmit }: FormProps) {
+  const [name, setName] = useState(account?.name ?? '')
+  const [institution, setInstitution] = useState(account?.institution_slug ?? '')
+  const [accountType, setAccountType] = useState<AccountType>(account?.account_type ?? 'checking')
+  const [currency, setCurrency] = useState(account?.currency ?? 'USD')
+  const [balance, setBalance] = useState(account?.balance ?? '0')
+  const [lastFour, setLastFour] = useState(account?.last_four ?? '')
+  const [isActive, setIsActive] = useState(account?.is_active ?? true)
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const validate = (): string | null => {
+    if (!name.trim()) return 'Name is required.'
+    if (!institution.trim()) return 'Institution is required.'
+    if (currency.trim().length !== 3) return 'Currency must be a 3-letter code.'
+    if (lastFour && !/^\d{4}$/.test(lastFour)) return 'Last 4 must be exactly 4 digits.'
+    return null
+  }
+
+  const submit = async () => {
+    const v = validate()
+    if (v) {
+      setError(v)
+      return
+    }
+    setError(null)
+    setSubmitting(true)
+    try {
+      await onSubmit({
+        name: name.trim(),
+        institution_slug: institution.trim(),
+        account_type: accountType,
+        currency: currency.trim().toUpperCase(),
+        balance,
+        last_four: lastFour.trim() === '' ? null : lastFour.trim(),
+        is_active: isActive,
+      })
+    } catch (err) {
+      setError(errMsg(err))
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-20 flex items-center justify-center bg-black/40 p-4">
+      <div className="w-full max-w-lg rounded-lg bg-white shadow-xl">
+        <div className="border-b border-gray-200 px-5 py-3 text-lg font-semibold text-gray-900">
+          {mode === 'create' ? 'Add account' : `Edit "${account?.name}"`}
+        </div>
+        <div className="space-y-3 px-5 py-4">
+          {error && <div className="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">{error}</div>}
+          <Field label="Name">
+            <input className={inputClass} value={name} onChange={(e) => setName(e.target.value)} />
+          </Field>
+          <Field label="Institution slug">
+            <input className={inputClass} value={institution} onChange={(e) => setInstitution(e.target.value)} placeholder="e.g. chase" />
+          </Field>
+          <div className="grid grid-cols-2 gap-3">
+            <Field label="Type">
+              <select className={inputClass} value={accountType} onChange={(e) => setAccountType(e.target.value as AccountType)}>
+                {ACCOUNT_TYPES.map((t) => (
+                  <option key={t} value={t}>{t}</option>
+                ))}
+              </select>
+            </Field>
+            <Field label="Currency">
+              <input className={inputClass} value={currency} maxLength={3} onChange={(e) => setCurrency(e.target.value.toUpperCase())} />
+            </Field>
+          </div>
+          <div className="grid grid-cols-2 gap-3">
+            <Field label="Balance">
+              <input className={inputClass} value={balance} onChange={(e) => setBalance(e.target.value)} inputMode="decimal" />
+            </Field>
+            <Field label="Last 4 (optional)">
+              <input className={inputClass} value={lastFour ?? ''} maxLength={4} onChange={(e) => setLastFour(e.target.value)} />
+            </Field>
+          </div>
+          <label className="flex items-center gap-2 text-sm text-gray-700">
+            <input type="checkbox" checked={isActive} onChange={(e) => setIsActive(e.target.checked)} />
+            Active
+          </label>
+          {mode === 'edit' && account && <PIIPanel accountID={account.id} />}
+        </div>
+        <div className="flex justify-end gap-2 border-t border-gray-200 px-5 py-3">
+          <button type="button" onClick={onClose} className="rounded-md border border-gray-300 px-3 py-1.5 text-sm">Cancel</button>
+          <button
+            type="button"
+            onClick={submit}
+            disabled={submitting}
+            className="rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-indigo-700 disabled:opacity-50"
+          >
+            {submitting ? 'Saving…' : mode === 'create' ? 'Create' : 'Save'}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+const inputClass = 'w-full rounded border border-gray-300 px-2 py-1 text-sm'
+
+function Field({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <label className="block text-sm">
+      <span className="mb-1 block text-xs font-medium text-gray-600">{label}</span>
+      {children}
+    </label>
+  )
+}
+
+function errMsg(err: unknown): string {
+  if (err && typeof err === 'object' && 'response' in err) {
+    const r = (err as { response?: { data?: { error?: string } } }).response
+    if (r?.data?.error) return r.data.error
+  }
+  if (err instanceof Error) return err.message
+  return 'request failed'
 }

--- a/frontend/src/store/accountsStore.ts
+++ b/frontend/src/store/accountsStore.ts
@@ -1,0 +1,85 @@
+import { create } from 'zustand'
+import {
+  createAccount as apiCreate,
+  deleteAccount as apiDelete,
+  listAccounts,
+  updateAccount as apiUpdate,
+  type AccountListFilter,
+} from '../api/accounts'
+import type { Account, CreateAccountInput, UpdateAccountInput } from '../types/account'
+
+type State = {
+  accounts: Account[]
+  total: number
+  loading: boolean
+  error: string | null
+  filter: AccountListFilter
+  fetch: (f?: AccountListFilter) => Promise<void>
+  create: (input: CreateAccountInput) => Promise<Account>
+  update: (id: number, input: UpdateAccountInput) => Promise<Account>
+  remove: (id: number) => Promise<void>
+}
+
+export const useAccountsStore = create<State>((set, get) => ({
+  accounts: [],
+  total: 0,
+  loading: false,
+  error: null,
+  filter: {},
+
+  fetch: async (f) => {
+    const filter = f ?? get().filter
+    set({ loading: true, error: null, filter })
+    try {
+      const { items, total } = await listAccounts(filter)
+      set({ accounts: items, total, loading: false })
+    } catch (err) {
+      set({ loading: false, error: errMsg(err) })
+    }
+  },
+
+  create: async (input) => {
+    set({ loading: true, error: null })
+    try {
+      const acct = await apiCreate(input)
+      // Refetch instead of splicing: server-side ordering + filtering wins.
+      await get().fetch()
+      return acct
+    } catch (err) {
+      set({ loading: false, error: errMsg(err) })
+      throw err
+    }
+  },
+
+  update: async (id, input) => {
+    set({ error: null })
+    try {
+      const acct = await apiUpdate(id, input)
+      set({ accounts: get().accounts.map((a) => (a.id === id ? acct : a)) })
+      return acct
+    } catch (err) {
+      set({ error: errMsg(err) })
+      throw err
+    }
+  },
+
+  remove: async (id) => {
+    set({ error: null })
+    try {
+      await apiDelete(id)
+      set({ accounts: get().accounts.filter((a) => a.id !== id) })
+    } catch (err) {
+      set({ error: errMsg(err) })
+      throw err
+    }
+  },
+}))
+
+function errMsg(err: unknown): string {
+  if (err && typeof err === 'object' && 'response' in err) {
+    const r = (err as { response?: { data?: { error?: string } } }).response
+    if (r?.data?.error) return r.data.error
+  }
+  if (err instanceof Error) return err.message
+  return 'request failed'
+}

--- a/frontend/src/types/account.ts
+++ b/frontend/src/types/account.ts
@@ -1,0 +1,51 @@
+// Account mirrors backend model.Account. Money fields arrive as decimal
+// strings (NUMERIC(30,18)) — never parse into Number; format via AmountDisplay.
+export type Account = {
+  id: number
+  user_id: number
+  name: string
+  institution_slug: string
+  account_type: AccountType
+  currency: string
+  balance: string
+  last_four?: string | null
+  plaid_account_id?: string | null
+  plaid_item_id?: string | null
+  is_active: boolean
+  created_at: string
+  updated_at: string
+}
+
+// Mirrors the CHECK constraint in migration 000001 + service.validAccountTypes.
+export const ACCOUNT_TYPES = [
+  'checking',
+  'savings',
+  'credit_card',
+  'loan',
+  'investment',
+  'crypto',
+  'cash',
+  'other',
+] as const
+export type AccountType = (typeof ACCOUNT_TYPES)[number]
+
+// CreateAccountRequest mirrors backend handler.createAccountRequest. Balance
+// is a decimal string when sent over the wire.
+export type CreateAccountInput = {
+  name: string
+  institution_slug: string
+  account_type: AccountType
+  currency: string
+  balance?: string
+  last_four?: string | null
+  is_active?: boolean
+}
+
+// UpdateAccountInput is a sparse patch; only provided fields are mutated.
+export type UpdateAccountInput = Partial<CreateAccountInput>
+
+// AccountPII mirrors the map[string]string returned by GET /accounts/:id/pii.
+// The allowlist matches backend service.allowedAccountPIIFields.
+export const PII_FIELDS = ['holder_name', 'account_number', 'routing_number', 'address'] as const
+export type AccountPIIField = (typeof PII_FIELDS)[number]
+export type AccountPII = Partial<Record<AccountPIIField, string>>


### PR DESCRIPTION
Closes #31.

## Summary

- `types/account.ts` mirrors backend `model.Account` + the 4-field PII allowlist (`holder_name`, `account_number`, `routing_number`, `address`).
- `api/accounts.ts` wraps GET/POST/PATCH/DELETE `/accounts` + GET/PUT `/accounts/:id/pii`.
- `store/accountsStore.ts`: zustand store (`accounts`, `loading`, `error`, `filter`, `fetch/create/update/remove`).
- **`components/AmountDisplay.tsx`** — the **only** allowed money formatter. Formats from the decimal string (no Number conversion) so NUMERIC(30,18) precision survives, with currency-aware fraction digits.
- **`components/PIIPanel.tsx`** — collapsible inside the Edit modal. PII is fetched **only when expanded** (verifiable in DevTools network), masked by default, click-to-reveal per field. Save filters out blank values to match the backend's reject-on-empty contract.
- `pages/AccountsPage.tsx`: list, Add Account modal, Edit modal (with PII panel), confirm-then-soft-delete. Form validates account_type enum and 3-letter currency code to match backend constraints.
- `api/client.ts`: `withCredentials: true` so the session cookie flows on every authenticated call (M2.5 gate).

## Test plan

- [x] `pnpm build` (tsc + vite) green
- [x] `pnpm lint` green
- [x] Backend curl smoke: create → list shows no PII keys → PUT /pii → GET /pii → PATCH balance → DELETE 204
- [ ] Manual browser run-through: not performed (no browser available in this session). Functional surface verified via API + types; the UI shape matches issue acceptance criteria.

🤖 Generated with [Claude Code](https://claude.com/claude-code)