### PR TITLE
M2 #32: Transactions page (filters, inline category, pagination) + Dashboard page

### DIFF
--- a/backend/internal/handler/category_handler.go
+++ b/backend/internal/handler/category_handler.go
@@ -1,0 +1,30 @@
+package handler
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/gregwym/offbook/backend/internal/service"
+)
+
+type CategoryHandler struct {
+	svc *service.CategoryService
+}
+
+func NewCategoryHandler(s *service.CategoryService) *CategoryHandler {
+	return &CategoryHandler{svc: s}
+}
+
+func (h *CategoryHandler) Register(g *gin.RouterGroup) {
+	g.GET("/categories", h.List)
+}
+
+func (h *CategoryHandler) List(c *gin.Context) {
+	cats, err := h.svc.List(c.Request.Context())
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error(), "code": "INTERNAL"})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"data": cats, "total": int64(len(cats))})
+}

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -42,6 +42,9 @@ func New(cfg config.Config, gormDB *gorm.DB) *gin.Engine {
 	transactionSvc := service.NewTransactionService(transactionRepo, accountRepo, categoryRepo)
 	transactionHandler := handler.NewTransactionHandler(transactionSvc)
 
+	categorySvc := service.NewCategoryService(categoryRepo)
+	categoryHandler := handler.NewCategoryHandler(categorySvc)
+
 	dashboardRepo := repository.NewDashboardRepository(gormDB)
 	dashboardSvc := service.NewDashboardService(dashboardRepo)
 	dashboardHandler := handler.NewDashboardHandler(dashboardSvc)
@@ -83,6 +86,7 @@ func New(cfg config.Config, gormDB *gorm.DB) *gin.Engine {
 		accountHandler.Register(secured)
 		piiHandler.RegisterAccountRoutes(secured)
 		transactionHandler.Register(secured)
+		categoryHandler.Register(secured)
 		dashboardHandler.Register(secured)
 		householdHandler.Register(secured)
 		aggregatorHandler.Register(secured)

--- a/backend/internal/service/category_service.go
+++ b/backend/internal/service/category_service.go
@@ -1,0 +1,23 @@
+package service
+
+import (
+	"context"
+
+	"github.com/gregwym/offbook/backend/internal/model"
+	"github.com/gregwym/offbook/backend/internal/repository"
+)
+
+// CategoryService is intentionally thin — categories are shared lookup data
+// (seeded in migration 000002) with no per-user ownership. The repository
+// already returns canonically-ordered rows.
+type CategoryService struct {
+	repo repository.CategoryRepository
+}
+
+func NewCategoryService(repo repository.CategoryRepository) *CategoryService {
+	return &CategoryService{repo: repo}
+}
+
+func (s *CategoryService) List(ctx context.Context) ([]model.Category, error) {
+	return s.repo.List(ctx)
+}

--- a/frontend/src/api/categories.ts
+++ b/frontend/src/api/categories.ts
@@ -1,0 +1,8 @@
+import { apiClient, type ApiList } from './client'
+import type { Category } from '../types/category'
+
+// Categories are seeded lookup data — single GET, no filters.
+export async function listCategories(): Promise<Category[]> {
+  const res = await apiClient.get<ApiList<Category>>('/categories')
+  return res.data.data
+}

--- a/frontend/src/api/dashboard.ts
+++ b/frontend/src/api/dashboard.ts
@@ -1,0 +1,9 @@
+import { apiClient, type ApiItem } from './client'
+import type { DashboardPeriod, DashboardSummary } from '../types/dashboard'
+
+export async function getDashboardSummary(period: DashboardPeriod): Promise<DashboardSummary> {
+  const res = await apiClient.get<ApiItem<DashboardSummary>>('/dashboard/summary', {
+    params: { period },
+  })
+  return res.data.data
+}

--- a/frontend/src/api/transactions.ts
+++ b/frontend/src/api/transactions.ts
@@ -1,0 +1,49 @@
+import { apiClient, type ApiItem, type ApiList } from './client'
+import type {
+  CreateTransactionInput,
+  Transaction,
+  UpdateTransactionInput,
+} from '../types/transaction'
+
+export type TransactionListFilter = {
+  account_id?: number
+  // Pass null for uncategorized-only (mapped to ?category_id=null on the wire).
+  category_id?: number | null
+  from?: string  // YYYY-MM-DD
+  to?: string
+  search?: string
+  limit?: number
+  offset?: number
+}
+
+export async function listTransactions(
+  f: TransactionListFilter = {},
+): Promise<{ items: Transaction[]; total: number }> {
+  const params: Record<string, string | number> = {}
+  if (f.account_id !== undefined) params.account_id = f.account_id
+  if (f.category_id !== undefined) {
+    params.category_id = f.category_id === null ? 'null' : f.category_id
+  }
+  if (f.from) params.from = f.from
+  if (f.to) params.to = f.to
+  if (f.search) params.search = f.search
+  if (f.limit !== undefined) params.limit = f.limit
+  if (f.offset !== undefined) params.offset = f.offset
+
+  const res = await apiClient.get<ApiList<Transaction>>('/transactions', { params })
+  return { items: res.data.data, total: res.data.total }
+}
+
+export async function createTransaction(input: CreateTransactionInput): Promise<Transaction> {
+  const res = await apiClient.post<ApiItem<Transaction>>('/transactions', input)
+  return res.data.data
+}
+
+export async function updateTransaction(id: number, input: UpdateTransactionInput): Promise<Transaction> {
+  const res = await apiClient.patch<ApiItem<Transaction>>(`/transactions/${id}`, input)
+  return res.data.data
+}
+
+export async function deleteTransaction(id: number): Promise<void> {
+  await apiClient.delete(`/transactions/${id}`)
+}

--- a/frontend/src/hooks/useDebounce.ts
+++ b/frontend/src/hooks/useDebounce.ts
@@ -1,0 +1,12 @@
+import { useEffect, useState } from 'react'
+
+// useDebounce returns a value that lags behind `value` by `delayMs`.
+// Used for search inputs so we don't issue a request per keystroke.
+export function useDebounce<T>(value: T, delayMs: number): T {
+  const [debounced, setDebounced] = useState(value)
+  useEffect(() => {
+    const t = setTimeout(() => setDebounced(value), delayMs)
+    return () => clearTimeout(t)
+  }, [value, delayMs])
+  return debounced
+}

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -1,5 +1,119 @@
-import { PageStub } from '../components/PageStub'
+import { useEffect, useState } from 'react'
+import { AmountDisplay } from '../components/AmountDisplay'
+import { getDashboardSummary } from '../api/dashboard'
+import { DASHBOARD_PERIODS, type DashboardPeriod, type DashboardSummary } from '../types/dashboard'
+
+const PERIOD_LABELS: Record<DashboardPeriod, string> = {
+  current_month: 'Current month',
+  last_30d: 'Last 30 days',
+  ytd: 'Year to date',
+}
 
 export function DashboardPage() {
-  return <PageStub title="Dashboard" />
+  const [period, setPeriod] = useState<DashboardPeriod>('current_month')
+  const [summary, setSummary] = useState<DashboardSummary | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    const run = async () => {
+      setLoading(true)
+      setError(null)
+      try {
+        const s = await getDashboardSummary(period)
+        if (!cancelled) setSummary(s)
+      } catch (err) {
+        if (!cancelled) setError(errMsg(err))
+      } finally {
+        if (!cancelled) setLoading(false)
+      }
+    }
+    void run()
+    return () => { cancelled = true }
+  }, [period])
+
+  return (
+    <div>
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-semibold text-gray-900">Dashboard</h1>
+        <select
+          className="rounded border border-gray-300 px-2 py-1 text-sm"
+          value={period}
+          onChange={(e) => setPeriod(e.target.value as DashboardPeriod)}
+        >
+          {DASHBOARD_PERIODS.map((p) => (
+            <option key={p} value={p}>{PERIOD_LABELS[p]}</option>
+          ))}
+        </select>
+      </div>
+
+      {error && (
+        <div className="mt-4 rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">{error}</div>
+      )}
+
+      <div className="mt-6 grid grid-cols-1 gap-4 md:grid-cols-3">
+        <SummaryCard label="Net worth">
+          <AmountDisplay amount={summary?.net_worth} />
+        </SummaryCard>
+        <SummaryCard label="Income (period)">
+          <AmountDisplay amount={summary?.income} />
+        </SummaryCard>
+        <SummaryCard label="Spending (period)">
+          <AmountDisplay amount={summary?.spending} />
+        </SummaryCard>
+      </div>
+
+      <div className="mt-4 grid grid-cols-1 gap-4 md:grid-cols-2">
+        <SummaryCard label="Accounts">
+          <span className="text-2xl font-semibold text-gray-900">{summary?.account_count ?? '—'}</span>
+        </SummaryCard>
+        <SummaryCard label="Transactions (period)">
+          <span className="text-2xl font-semibold text-gray-900">{summary?.transaction_count ?? '—'}</span>
+        </SummaryCard>
+      </div>
+
+      <div className="mt-6 rounded-lg border border-gray-200 bg-white p-4">
+        <h2 className="mb-3 text-sm font-medium uppercase tracking-wider text-gray-500">Spending by category</h2>
+        {loading && !summary && <div className="text-sm text-gray-400">Loading…</div>}
+        {summary && summary.by_category.length === 0 && (
+          <div className="text-sm text-gray-400">No transactions in this period.</div>
+        )}
+        {summary && summary.by_category.length > 0 && (
+          <ul className="divide-y divide-gray-100 text-sm">
+            {summary.by_category.map((row) => (
+              <li key={`${row.category_id ?? 'null'}`} className="flex items-center justify-between py-2">
+                <span className="text-gray-700">{row.name}</span>
+                <AmountDisplay amount={row.amount} signed />
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+
+      {summary && (
+        <p className="mt-3 text-xs text-gray-400">
+          {summary.period.from.slice(0, 10)} → {summary.period.to.slice(0, 10)}
+        </p>
+      )}
+    </div>
+  )
+}
+
+function SummaryCard({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="rounded-lg border border-gray-200 bg-white p-4">
+      <div className="text-xs font-medium uppercase tracking-wider text-gray-500">{label}</div>
+      <div className="mt-2 text-2xl font-semibold text-gray-900">{children}</div>
+    </div>
+  )
+}
+
+function errMsg(err: unknown): string {
+  if (err && typeof err === 'object' && 'response' in err) {
+    const r = (err as { response?: { data?: { error?: string } } }).response
+    if (r?.data?.error) return r.data.error
+  }
+  if (err instanceof Error) return err.message
+  return 'request failed'
 }

--- a/frontend/src/pages/TransactionsPage.tsx
+++ b/frontend/src/pages/TransactionsPage.tsx
@@ -1,5 +1,355 @@
-import { PageStub } from '../components/PageStub'
+import { useEffect, useMemo, useState, type ReactNode } from 'react'
+import { Plus, Trash2 } from 'lucide-react'
+import { AmountDisplay } from '../components/AmountDisplay'
+import { useAccountsStore } from '../store/accountsStore'
+import { useCategoriesStore } from '../store/categoriesStore'
+import { useTransactionsStore } from '../store/transactionsStore'
+import { useDebounce } from '../hooks/useDebounce'
+import type { Account } from '../types/account'
+import type { Category } from '../types/category'
+import type { CreateTransactionInput, Transaction, TransactionSource } from '../types/transaction'
+import { TRANSACTION_SOURCES } from '../types/transaction'
 
 export function TransactionsPage() {
-  return <PageStub title="Transactions" />
+  const {
+    transactions, total, loading, error,
+    filter, page, pageSize,
+    fetch, setFilter, setPage, create, setCategory, remove,
+  } = useTransactionsStore()
+  const { accounts, fetch: fetchAccounts } = useAccountsStore()
+  const { categories, fetch: fetchCategories } = useCategoriesStore()
+
+  // Local filter inputs — synced into the store via setFilter on change.
+  const [accountID, setAccountID] = useState<string>(String(filter.account_id ?? ''))
+  const [categoryID, setCategoryID] = useState<string>(
+    filter.category_id === undefined ? '' : filter.category_id === null ? 'null' : String(filter.category_id),
+  )
+  const [from, setFrom] = useState<string>(filter.from ?? '')
+  const [to, setTo] = useState<string>(filter.to ?? '')
+  const [searchInput, setSearchInput] = useState<string>(filter.search ?? '')
+  const search = useDebounce(searchInput, 300)
+  const [adding, setAdding] = useState(false)
+
+  useEffect(() => {
+    void fetchAccounts()
+    void fetchCategories()
+    void fetch()
+  }, [fetch, fetchAccounts, fetchCategories])
+
+  // Propagate the typed inputs into the store filter. setFilter resets page to 0.
+  useEffect(() => {
+    setFilter({
+      account_id: accountID === '' ? undefined : Number(accountID),
+      category_id: categoryID === '' ? undefined : categoryID === 'null' ? null : Number(categoryID),
+      from: from === '' ? undefined : from,
+      to: to === '' ? undefined : to,
+      search: search === '' ? undefined : search,
+    })
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [accountID, categoryID, from, to, search])
+
+  const totalPages = Math.max(1, Math.ceil(total / pageSize))
+  const accountByID = useMemo(() => mapByID(accounts), [accounts])
+  const categoryByID = useMemo(() => mapByID(categories), [categories])
+
+  return (
+    <div>
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold text-gray-900">Transactions</h1>
+          <p className="mt-1 text-sm text-gray-500">{total} total</p>
+        </div>
+        <button
+          type="button"
+          onClick={() => setAdding(true)}
+          className="inline-flex items-center gap-2 rounded-md bg-indigo-600 px-3 py-2 text-sm font-medium text-white hover:bg-indigo-700"
+        >
+          <Plus size={16} /> Add transaction
+        </button>
+      </div>
+
+      {error && (
+        <div className="mt-4 rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">{error}</div>
+      )}
+
+      <div className="mt-4 grid grid-cols-1 gap-3 md:grid-cols-5">
+        <Field label="Account">
+          <select className={inputClass} value={accountID} onChange={(e) => setAccountID(e.target.value)}>
+            <option value="">All</option>
+            {accounts.map((a) => <option key={a.id} value={a.id}>{a.name}</option>)}
+          </select>
+        </Field>
+        <Field label="Category">
+          <select className={inputClass} value={categoryID} onChange={(e) => setCategoryID(e.target.value)}>
+            <option value="">All</option>
+            <option value="null">Uncategorized</option>
+            {categories.map((c) => <option key={c.id} value={c.id}>{c.name}</option>)}
+          </select>
+        </Field>
+        <Field label="From">
+          <input type="date" className={inputClass} value={from} onChange={(e) => setFrom(e.target.value)} />
+        </Field>
+        <Field label="To">
+          <input type="date" className={inputClass} value={to} onChange={(e) => setTo(e.target.value)} />
+        </Field>
+        <Field label="Search">
+          <input className={inputClass} placeholder="description or merchant" value={searchInput} onChange={(e) => setSearchInput(e.target.value)} />
+        </Field>
+      </div>
+
+      <div className="mt-4 overflow-hidden rounded-lg border border-gray-200 bg-white">
+        <table className="min-w-full divide-y divide-gray-200 text-sm">
+          <thead className="bg-gray-50 text-xs font-medium uppercase tracking-wider text-gray-500">
+            <tr>
+              <th className="px-3 py-2 text-left">Date</th>
+              <th className="px-3 py-2 text-left">Description</th>
+              <th className="px-3 py-2 text-left">Merchant</th>
+              <th className="px-3 py-2 text-right">Amount</th>
+              <th className="px-3 py-2 text-left">Account</th>
+              <th className="px-3 py-2 text-left">Category</th>
+              <th className="px-3 py-2"></th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-gray-100">
+            {loading && transactions.length === 0 && (
+              <tr><td colSpan={7} className="px-4 py-6 text-center text-gray-400">Loading…</td></tr>
+            )}
+            {!loading && transactions.length === 0 && (
+              <tr><td colSpan={7} className="px-4 py-6 text-center text-gray-400">No transactions match these filters.</td></tr>
+            )}
+            {transactions.map((t) => (
+              <TransactionRow
+                key={t.id}
+                tx={t}
+                account={t.account_id ? accountByID.get(t.account_id) : undefined}
+                categories={categories}
+                currentCategory={t.category_id ? categoryByID.get(t.category_id) : undefined}
+                onCategoryChange={(catID) => { void setCategory(t.id, catID) }}
+                onDelete={async () => {
+                  if (window.confirm('Delete this transaction?')) {
+                    await remove(t.id)
+                  }
+                }}
+              />
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      <div className="mt-3 flex items-center justify-end gap-2 text-sm">
+        <button
+          type="button"
+          onClick={() => setPage(page - 1)}
+          disabled={page === 0}
+          className="rounded border border-gray-300 px-2 py-1 disabled:opacity-50"
+        >Prev</button>
+        <span className="text-gray-600">Page {page + 1} / {totalPages}</span>
+        <button
+          type="button"
+          onClick={() => setPage(page + 1)}
+          disabled={page + 1 >= totalPages}
+          className="rounded border border-gray-300 px-2 py-1 disabled:opacity-50"
+        >Next</button>
+      </div>
+
+      {adding && (
+        <AddTransactionModal
+          accounts={accounts}
+          categories={categories}
+          onClose={() => setAdding(false)}
+          onSubmit={async (input) => {
+            await create(input)
+            setAdding(false)
+          }}
+        />
+      )}
+    </div>
+  )
+}
+
+type RowProps = {
+  tx: Transaction
+  account?: Account
+  categories: Category[]
+  currentCategory?: Category
+  onCategoryChange: (catID: number | null) => void
+  onDelete: () => Promise<void>
+}
+
+function TransactionRow({ tx, account, categories, currentCategory, onCategoryChange, onDelete }: RowProps) {
+  return (
+    <tr className="hover:bg-gray-50">
+      <td className="px-3 py-2 text-gray-700">{tx.transaction_date}</td>
+      <td className="px-3 py-2 text-gray-900">{tx.description ?? '—'}</td>
+      <td className="px-3 py-2 text-gray-700">{tx.merchant_name ?? '—'}</td>
+      <td className="px-3 py-2 text-right">
+        <AmountDisplay amount={tx.amount} currency={tx.currency} signed />
+      </td>
+      <td className="px-3 py-2 text-gray-700">{account?.name ?? `#${tx.account_id}`}</td>
+      <td className="px-3 py-2">
+        <select
+          value={currentCategory ? currentCategory.id : ''}
+          onChange={(e) => {
+            const v = e.target.value
+            onCategoryChange(v === '' ? null : Number(v))
+          }}
+          className="rounded border border-gray-300 px-1.5 py-1 text-sm"
+        >
+          <option value="">Uncategorized</option>
+          {categories.map((c) => <option key={c.id} value={c.id}>{c.name}</option>)}
+        </select>
+      </td>
+      <td className="px-3 py-2 text-right">
+        <button
+          type="button"
+          onClick={onDelete}
+          className="text-gray-500 hover:text-red-700"
+          aria-label="Delete"
+        >
+          <Trash2 size={16} />
+        </button>
+      </td>
+    </tr>
+  )
+}
+
+type AddProps = {
+  accounts: Account[]
+  categories: Category[]
+  onClose: () => void
+  onSubmit: (input: CreateTransactionInput) => Promise<void>
+}
+
+function AddTransactionModal({ accounts, categories, onClose, onSubmit }: AddProps) {
+  const [accountID, setAccountID] = useState<string>(accounts[0] ? String(accounts[0].id) : '')
+  const [categoryID, setCategoryID] = useState<string>('')
+  const [amount, setAmount] = useState('0.00')
+  const [currency, setCurrency] = useState(accounts[0]?.currency ?? 'USD')
+  const [description, setDescription] = useState('')
+  const [merchant, setMerchant] = useState('')
+  const [date, setDate] = useState<string>(new Date().toISOString().slice(0, 10))
+  const [source, setSource] = useState<TransactionSource>('manual')
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const submit = async () => {
+    if (!accountID) {
+      setError('Account is required.')
+      return
+    }
+    if (!amount.trim()) {
+      setError('Amount is required.')
+      return
+    }
+    if (!date) {
+      setError('Date is required.')
+      return
+    }
+    setError(null)
+    setSubmitting(true)
+    try {
+      await onSubmit({
+        account_id: Number(accountID),
+        category_id: categoryID === '' ? null : Number(categoryID),
+        amount,
+        currency: currency.toUpperCase(),
+        description: description.trim() || null,
+        merchant_name: merchant.trim() || null,
+        transaction_date: date,
+        source,
+      })
+    } catch (err) {
+      setError(errMsg(err))
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-20 flex items-center justify-center bg-black/40 p-4">
+      <div className="w-full max-w-lg rounded-lg bg-white shadow-xl">
+        <div className="border-b border-gray-200 px-5 py-3 text-lg font-semibold text-gray-900">Add transaction</div>
+        <div className="space-y-3 px-5 py-4">
+          {error && <div className="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">{error}</div>}
+          <Field label="Account">
+            <select className={inputClass} value={accountID} onChange={(e) => {
+              setAccountID(e.target.value)
+              const acc = accounts.find((a) => String(a.id) === e.target.value)
+              if (acc) setCurrency(acc.currency)
+            }}>
+              <option value="">(none)</option>
+              {accounts.map((a) => <option key={a.id} value={a.id}>{a.name}</option>)}
+            </select>
+          </Field>
+          <Field label="Category">
+            <select className={inputClass} value={categoryID} onChange={(e) => setCategoryID(e.target.value)}>
+              <option value="">Uncategorized</option>
+              {categories.map((c) => <option key={c.id} value={c.id}>{c.name}</option>)}
+            </select>
+          </Field>
+          <div className="grid grid-cols-2 gap-3">
+            <Field label="Amount (negative = spending)">
+              <input className={inputClass} value={amount} onChange={(e) => setAmount(e.target.value)} inputMode="decimal" />
+            </Field>
+            <Field label="Currency">
+              <input className={inputClass} value={currency} maxLength={3} onChange={(e) => setCurrency(e.target.value.toUpperCase())} />
+            </Field>
+          </div>
+          <Field label="Description">
+            <input className={inputClass} value={description} onChange={(e) => setDescription(e.target.value)} />
+          </Field>
+          <Field label="Merchant">
+            <input className={inputClass} value={merchant} onChange={(e) => setMerchant(e.target.value)} />
+          </Field>
+          <div className="grid grid-cols-2 gap-3">
+            <Field label="Date">
+              <input type="date" className={inputClass} value={date} onChange={(e) => setDate(e.target.value)} />
+            </Field>
+            <Field label="Source">
+              <select className={inputClass} value={source} onChange={(e) => setSource(e.target.value as TransactionSource)}>
+                {TRANSACTION_SOURCES.map((s) => <option key={s} value={s}>{s}</option>)}
+              </select>
+            </Field>
+          </div>
+        </div>
+        <div className="flex justify-end gap-2 border-t border-gray-200 px-5 py-3">
+          <button type="button" onClick={onClose} className="rounded-md border border-gray-300 px-3 py-1.5 text-sm">Cancel</button>
+          <button
+            type="button"
+            onClick={submit}
+            disabled={submitting}
+            className="rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-indigo-700 disabled:opacity-50"
+          >
+            {submitting ? 'Saving…' : 'Create'}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+const inputClass = 'w-full rounded border border-gray-300 px-2 py-1 text-sm'
+
+function Field({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <label className="block text-sm">
+      <span className="mb-1 block text-xs font-medium text-gray-600">{label}</span>
+      {children}
+    </label>
+  )
+}
+
+function mapByID<T extends { id: number }>(items: T[]): Map<number, T> {
+  const m = new Map<number, T>()
+  for (const item of items) m.set(item.id, item)
+  return m
+}
+
+function errMsg(err: unknown): string {
+  if (err && typeof err === 'object' && 'response' in err) {
+    const r = (err as { response?: { data?: { error?: string } } }).response
+    if (r?.data?.error) return r.data.error
+  }
+  if (err instanceof Error) return err.message
+  return 'request failed'
 }

--- a/frontend/src/store/categoriesStore.ts
+++ b/frontend/src/store/categoriesStore.ts
@@ -1,0 +1,29 @@
+import { create } from 'zustand'
+import { listCategories } from '../api/categories'
+import type { Category } from '../types/category'
+
+type State = {
+  categories: Category[]
+  loaded: boolean
+  loading: boolean
+  error: string | null
+  fetch: () => Promise<void>
+}
+
+// Categories are seeded lookup data — cache once per session.
+export const useCategoriesStore = create<State>((set, get) => ({
+  categories: [],
+  loaded: false,
+  loading: false,
+  error: null,
+  fetch: async () => {
+    if (get().loaded || get().loading) return
+    set({ loading: true, error: null })
+    try {
+      const cats = await listCategories()
+      set({ categories: cats, loaded: true, loading: false })
+    } catch (err) {
+      set({ loading: false, error: err instanceof Error ? err.message : 'failed' })
+    }
+  },
+}))

--- a/frontend/src/store/transactionsStore.ts
+++ b/frontend/src/store/transactionsStore.ts
@@ -1,0 +1,136 @@
+import { create } from 'zustand'
+import {
+  createTransaction as apiCreate,
+  deleteTransaction as apiDelete,
+  listTransactions,
+  updateTransaction as apiUpdate,
+  type TransactionListFilter,
+} from '../api/transactions'
+import type {
+  CreateTransactionInput,
+  Transaction,
+  UpdateTransactionInput,
+} from '../types/transaction'
+
+type State = {
+  transactions: Transaction[]
+  total: number
+  loading: boolean
+  error: string | null
+  filter: TransactionListFilter
+  // Pagination: 0-based page; computed offset = page * pageSize.
+  page: number
+  pageSize: number
+
+  fetch: () => Promise<void>
+  setFilter: (f: TransactionListFilter) => void
+  setPage: (p: number) => void
+  create: (input: CreateTransactionInput) => Promise<Transaction>
+  // Optimistic update: applies locally, then PATCHes; reverts on failure.
+  setCategory: (id: number, categoryID: number | null) => Promise<void>
+  update: (id: number, input: UpdateTransactionInput) => Promise<Transaction>
+  remove: (id: number) => Promise<void>
+}
+
+const PAGE_SIZE = 50
+
+export const useTransactionsStore = create<State>((set, get) => ({
+  transactions: [],
+  total: 0,
+  loading: false,
+  error: null,
+  filter: {},
+  page: 0,
+  pageSize: PAGE_SIZE,
+
+  fetch: async () => {
+    const { filter, page, pageSize } = get()
+    set({ loading: true, error: null })
+    try {
+      const { items, total } = await listTransactions({
+        ...filter,
+        limit: pageSize,
+        offset: page * pageSize,
+      })
+      set({ transactions: items, total, loading: false })
+    } catch (err) {
+      set({ loading: false, error: errMsg(err) })
+    }
+  },
+
+  setFilter: (f) => {
+    // Reset to first page whenever filters change — pagination of stale results
+    // produces ghost rows.
+    set({ filter: f, page: 0 })
+    void get().fetch()
+  },
+
+  setPage: (p) => {
+    set({ page: Math.max(0, p) })
+    void get().fetch()
+  },
+
+  create: async (input) => {
+    set({ error: null })
+    try {
+      const t = await apiCreate(input)
+      // Refetch (server-side filter + ordering wins).
+      await get().fetch()
+      return t
+    } catch (err) {
+      set({ error: errMsg(err) })
+      throw err
+    }
+  },
+
+  setCategory: async (id, categoryID) => {
+    const before = get().transactions
+    // Optimistic update.
+    set({
+      transactions: before.map((t) => (t.id === id ? { ...t, category_id: categoryID } : t)),
+    })
+    try {
+      if (categoryID === null) {
+        await apiUpdate(id, { clear_category: true })
+      } else {
+        await apiUpdate(id, { category_id: categoryID })
+      }
+    } catch (err) {
+      // Revert.
+      set({ transactions: before, error: errMsg(err) })
+      throw err
+    }
+  },
+
+  update: async (id, input) => {
+    set({ error: null })
+    try {
+      const t = await apiUpdate(id, input)
+      set({ transactions: get().transactions.map((x) => (x.id === id ? t : x)) })
+      return t
+    } catch (err) {
+      set({ error: errMsg(err) })
+      throw err
+    }
+  },
+
+  remove: async (id) => {
+    set({ error: null })
+    try {
+      await apiDelete(id)
+      set({ transactions: get().transactions.filter((t) => t.id !== id) })
+    } catch (err) {
+      set({ error: errMsg(err) })
+      throw err
+    }
+  },
+}))
+
+function errMsg(err: unknown): string {
+  if (err && typeof err === 'object' && 'response' in err) {
+    const r = (err as { response?: { data?: { error?: string } } }).response
+    if (r?.data?.error) return r.data.error
+  }
+  if (err instanceof Error) return err.message
+  return 'request failed'
+}

--- a/frontend/src/types/category.ts
+++ b/frontend/src/types/category.ts
@@ -1,0 +1,11 @@
+export type Category = {
+  id: number
+  parent_id?: number | null
+  name: string
+  slug: string
+  icon?: string | null
+  color?: string | null
+  is_system: boolean
+  created_at: string
+  updated_at: string
+}

--- a/frontend/src/types/dashboard.ts
+++ b/frontend/src/types/dashboard.ts
@@ -1,0 +1,14 @@
+// DashboardSummary mirrors backend service.DashboardSummary. Money fields
+// are decimal strings; format via AmountDisplay.
+export type DashboardSummary = {
+  period: { key: string; from: string; to: string }
+  net_worth: string
+  income: string
+  spending: string
+  account_count: number
+  transaction_count: number
+  by_category: Array<{ category_id: number | null; name: string; amount: string }>
+}
+
+export const DASHBOARD_PERIODS = ['current_month', 'last_30d', 'ytd'] as const
+export type DashboardPeriod = (typeof DASHBOARD_PERIODS)[number]

--- a/frontend/src/types/transaction.ts
+++ b/frontend/src/types/transaction.ts
@@ -1,0 +1,56 @@
+// Transaction mirrors backend model.Transaction. Money fields are decimal
+// strings; format via AmountDisplay (never parse to Number).
+export type Transaction = {
+  id: number
+  user_id: number
+  account_id: number
+  category_id?: number | null
+  amount: string
+  currency: string
+  description?: string | null
+  description_clean?: string | null
+  merchant_name?: string | null
+  transaction_date: string  // YYYY-MM-DD (DATE column)
+  posted_date?: string | null
+  source: TransactionSource
+  external_id?: string | null
+  plaid_transaction_id?: string | null
+  categorization_method?: string | null
+  is_transfer: boolean
+  transfer_pair_id?: number | null
+  notes?: string | null
+  created_at: string
+  updated_at: string
+}
+
+export const TRANSACTION_SOURCES = ['manual', 'plaid', 'csv', 'pdf'] as const
+export type TransactionSource = (typeof TRANSACTION_SOURCES)[number]
+
+// CreateTransactionInput mirrors backend handler.createTransactionRequest.
+export type CreateTransactionInput = {
+  account_id: number
+  category_id?: number | null
+  amount: string
+  currency?: string
+  description?: string | null
+  merchant_name?: string | null
+  transaction_date: string  // YYYY-MM-DD accepted
+  posted_date?: string | null
+  source?: TransactionSource
+  notes?: string | null
+}
+
+// UpdateTransactionInput: sparse patch. `clear_category: true` with a null
+// `category_id` uncategorizes; a non-null `category_id` sets it; absent both
+// leaves the category alone.
+export type UpdateTransactionInput = {
+  category_id?: number | null
+  clear_category?: boolean
+  amount?: string
+  currency?: string
+  description?: string | null
+  merchant_name?: string | null
+  transaction_date?: string
+  posted_date?: string | null
+  notes?: string | null
+}


### PR DESCRIPTION
Closes #32.

## Summary

**Backend**
- `GET /categories` — thin `CategoryService` + handler for the frontend dropdown.

**Frontend**
- `types/{transaction,category,dashboard}.ts` mirror backend shapes. Money kept as decimal strings.
- `api/{transactions,categories,dashboard}.ts` wrap the endpoints.
- `store/transactionsStore.ts`: filter state, 50/page pagination, **optimistic** inline category change with revert-on-failure.
- `store/categoriesStore.ts`: session-cached lookup (categories are seeded; no need to refetch).
- `hooks/useDebounce.ts`: 300ms debounce on the search box.
- `pages/TransactionsPage.tsx`: filter bar (account / category / date range / search), table with **inline category dropdown** (PATCH on change), prev/next pagination, add-transaction modal.
- `pages/DashboardPage.tsx`: period switcher (current_month / last_30d / ytd), net-worth + income + spending cards, account/transaction counts, plain `<ul>` spending-by-category (Recharts comes later in M5 per ROADMAP).

## Test plan

- [x] `command go test ./...` green
- [x] `command make lint` clean
- [x] `pnpm build` (tsc + vite) green
- [x] `pnpm lint` clean
- [x] API smoke: list/create/PATCH/DELETE transactions + search + `category_id=null` + dashboard across all 3 periods + bogus period → 400
- [ ] Manual browser run-through: not performed (no browser available in this session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)