### PR TITLE
#22: Drop dead MIGRATIONS_PATH ENV from Dockerfile

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -12,8 +12,7 @@ RUN apk add --no-cache ca-certificates tzdata && adduser -D -u 10001 app
 WORKDIR /app
 COPY --from=build /out/server /app/server
 COPY migrations /app/migrations
-ENV MIGRATIONS_PATH=/app/migrations \
-    PORT=8000
+ENV PORT=8000
 USER app
 EXPOSE 8000
 ENTRYPOINT ["/app/server"]


### PR DESCRIPTION
## Summary
- Removes the `MIGRATIONS_PATH=/app/migrations` line from `backend/Dockerfile`'s `ENV` block (keeps `PORT=8000`).
- docker-compose already sets the same path explicitly, so the Dockerfile value was always shadowed at runtime.
- Outside compose, the config default `"migrations"` resolves correctly against `WORKDIR=/app`.

## Test plan
- [x] `docker-compose.yml` still pins `MIGRATIONS_PATH: /app/migrations` (compose env wins)
- [ ] `docker compose up` applies all migrations against a fresh DB

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)