### PR TITLE
#20 #24: Scope soft-delete rule + document SkipDefaultTransaction

### DIFF
--- a/.claude/rules/database.md
+++ b/.claude/rules/database.md
@@ -8,7 +8,8 @@ paths:
 - All monetary columns: NUMERIC(30, 18). No FLOAT, no DOUBLE, no INTEGER cents.
 - Schema changes: ALWAYS via golang-migrate. Never manual SQL against the DB.
 - PII isolation: pii_store is the ONLY table for PII. Main tables use labels, not real names.
-- Soft deletes: deleted_at TIMESTAMPTZ. All queries exclude deleted rows by default.
+- Soft deletes apply to financial **domain** tables: `accounts`, `transactions`, `categories`, `budgets`, `savings_goals`, `categorization_rules`, `ai_threads`. Each has `deleted_at TIMESTAMPTZ`; queries exclude deleted rows by default (GORM `gorm.DeletedAt`). Append-only / audit / write-once tables (`investments`, `ai_messages`, `ingestion_jobs`, `pii_store`, `sessions`) hard-delete or never delete — see `docs/ARCHITECTURE.md` for the per-table rationale. Don't add `deleted_at` to a snapshot/audit table; soft-deleting a snapshot silently corrupts historical state.
+- Transactions: the GORM connection sets `SkipDefaultTransaction: true` (perf — skips the implicit per-write transaction). Single-row writes are fine; any service method that writes more than one row, or across more than one table, MUST wrap the work in `db.Transaction(func(tx *gorm.DB) error { ... })` so a mid-flight failure rolls back.
 - Timestamps: always TIMESTAMPTZ, never TIMESTAMP.
 - Indexes: add for any column used in WHERE, JOIN, or ORDER BY.
 - Tenancy: every user-owned domain table (accounts, transactions, budgets, savings_goals, investments, ai_threads, etc.) has `user_id BIGINT NOT NULL REFERENCES users(id)`. Cross-user reads go through the household aggregator (see ADR-0008), never directly across `user_id`.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -209,9 +209,22 @@ Query params: `?limit=50&offset=0`. Default limit: 50, max: 200.
 RFC3339 in JSON. `DATE` columns as `"2024-01-15"`. `TIMESTAMPTZ` as `"2024-01-15T10:30:00Z"`.
 
 ### Soft deletes
-All queries exclude `deleted_at IS NOT NULL` by default. GORM handles this via model embedding.
+Domain tables that carry `deleted_at TIMESTAMPTZ`: `accounts`, `transactions`, `categories`, `budgets`, `savings_goals`, `categorization_rules`, `ai_threads`. Queries exclude `deleted_at IS NOT NULL` by default (GORM `gorm.DeletedAt` embedding).
+
+Tables that do **not** carry `deleted_at` (by design):
+- `investments` — append-only snapshots; soft-deleting a snapshot silently corrupts historical state.
+- `ai_messages` — turn log; cascades on `ai_threads.deleted_at` via thread scoping.
+- `ingestion_jobs` — append-only audit trail.
+- `pii_store` — hard-delete only (right-to-forget semantics; see PII Isolation above).
+- `sessions` — short-lived auth state; hard-delete on signout/expiry.
+- `household_members` — uses `left_at` + `purged_at` for the grace-period lifecycle, not `deleted_at`. See [ADR-0007](ADR/0007-member-lifecycle.md).
+
+See also `.claude/rules/database.md`.
 
 ## Go Patterns
+
+### Transactions
+The GORM connection is opened with `SkipDefaultTransaction: true` (`backend/internal/db/db.go`) — single-row writes skip the implicit per-statement transaction for throughput. **Any service method that writes more than one row, or across more than one table, MUST wrap the work in `db.Transaction(func(tx *gorm.DB) error { ... })`** or torn updates become possible (e.g. account row created but its `pii_store` row fails to insert).
 
 ### Dependency injection
 ```go


### PR DESCRIPTION
## Summary

Two related rule/doc fixes bundled (both touch \`.claude/rules/database.md\` + \`docs/ARCHITECTURE.md\`):

**#20** — Soft-delete rule was absolute, but \`investments\`, \`ai_messages\`, \`ingestion_jobs\`, \`pii_store\`, \`sessions\`, and \`household_members\` intentionally don't carry \`deleted_at\`. New wording enumerates the domain tables that DO soft-delete and lists the exceptions with rationale.

**#24** — Documents the \`SkipDefaultTransaction: true\` GORM setting and the resulting requirement that multi-row writes wrap in \`db.Transaction(...)\`. Adds a Go Patterns subsection in \`ARCHITECTURE.md\`.

## Test plan
- [x] Doc-only — no code change, no build/test impact

Closes #20
Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)