### PR TITLE
#19: Wrap /health in the standard response envelope

### DIFF
--- a/.claude/rules/go-backend.md
+++ b/.claude/rules/go-backend.md
@@ -5,6 +5,7 @@ paths:
 
 # Go Backend Rules
 - Handlers: parse request → call service → return JSON. No business logic in handlers.
+- Response envelope: every handler wraps. Success-list → `{"data": [...], "total": N}`; success-single → `{"data": {...}}`; error → `{"error": "...", "code": "..."}`. No bare-object responses, including infra/health.
 - Services: receive repository interfaces as constructor args. Never instantiate DB directly.
 - Repositories: GORM calls only. Return domain models, not GORM-specific types.
 - Money: shopspring/decimal everywhere. Never float64 for monetary values.

--- a/backend/internal/handler/health.go
+++ b/backend/internal/handler/health.go
@@ -25,9 +25,13 @@ func (h *HealthHandler) Get(c *gin.Context) {
 
 	if h.db != nil {
 		if err := db.Ping(ctx, h.db); err != nil {
-			c.JSON(http.StatusServiceUnavailable, gin.H{"status": "down", "db": err.Error()})
+			c.JSON(http.StatusServiceUnavailable, gin.H{
+				"data":  gin.H{"status": "down", "db": err.Error()},
+				"error": "database unreachable",
+				"code":  "DB_UNAVAILABLE",
+			})
 			return
 		}
 	}
-	c.JSON(http.StatusOK, gin.H{"status": "ok"})
+	c.JSON(http.StatusOK, gin.H{"data": gin.H{"status": "ok"}})
 }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -191,6 +191,8 @@ Otherwise re-importing a previously-deleted transaction fails.
 All routes under `/api/v1/`.
 
 ### Response format
+**Every** JSON response from the backend wraps. No bare-object responses, including infra/health endpoints — this keeps the frontend `ApiList<T>` / `ApiItem<T>` / `ApiError` typing uniform and avoids per-route special cases.
+
 ```json
 // Success (list)
 {"data": [...], "total": 42}
@@ -201,6 +203,8 @@ All routes under `/api/v1/`.
 // Error
 {"error": "Human-readable message", "code": "MACHINE_READABLE_CODE"}
 ```
+
+`/api/v1/health` returns `{"data": {"status": "ok"}}` on success and `{"data": {"status": "down", "db": "..."}, "error": "...", "code": "DB_UNAVAILABLE"}` on failure. Liveness probes that only care about HTTP status (e.g. `curl -sf`) keep working; consumers that parse the body get the envelope.
 
 ### Pagination
 Query params: `?limit=50&offset=0`. Default limit: 50, max: 200.


### PR DESCRIPTION
## Summary
Picked policy **B** (everything wraps) — \`/api/v1/health\` now returns \`{\"data\":{\"status\":\"ok\"}}\` instead of bare \`{\"status\":\"ok\"}\`. Failure case also gets the standard \`error\`/\`code\` fields alongside \`data\`.

Rationale: keeps frontend \`ApiList<T>\` / \`ApiItem<T>\` / \`ApiError\` parsing uniform — no per-route special cases.

- \`docs/ARCHITECTURE.md\` §Response format: documents the policy and shows the health example.
- \`.claude/rules/go-backend.md\`: one-liner so new handlers don't drift.

Liveness probes (\`curl -sf\`, \`wget -qO-\`, docker-compose healthcheck) only check HTTP status — body shape change is safe.

## Test plan
- [x] \`go build ./...\` passes
- [ ] \`make smoke\` returns HTTP 200 (curl-based check unaffected)

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)