### PR TITLE
#21: ADR-0009 — PII orphan-cleanup policy

### DIFF
--- a/backend/internal/service/pii_service.go
+++ b/backend/internal/service/pii_service.go
@@ -57,9 +57,9 @@ func (s *PIIService) GetAccountPII(ctx context.Context, userID, accountID int64)
 // SetAccountPII upserts the provided fields. Ownership is enforced via the
 // same transitive check as GetAccountPII.
 //
-// NOTE: per ADR #21 (backlog) the orphan-cleanup policy for PII on account
-// soft-delete is not yet decided. Today, soft-deleting an account leaves
-// PII rows behind. Revisit once #21 lands.
+// Per ADR-0009, soft-delete preserves PII; rows are only removed by hard
+// purge. The transitive check above already prevents soft-deleted accounts'
+// PII from being read or written through this service.
 func (s *PIIService) SetAccountPII(ctx context.Context, userID, accountID int64, fields map[string]string) error {
 	if _, err := s.accSvc.Get(ctx, userID, accountID); err != nil {
 		return err

--- a/docs/ADR/0009-pii-orphan-cleanup-policy.md
+++ b/docs/ADR/0009-pii-orphan-cleanup-policy.md
@@ -1,0 +1,36 @@
+# ADR 0009: PII Orphan-Cleanup Policy on Soft-Delete
+
+## Status
+Accepted
+
+## Context
+`pii_store` has no foreign keys to any other table by design (PII isolation, see [ADR-0003](0003-pii-isolation-table.md)). When an `account` or `transaction` is soft-deleted (`deleted_at IS NOT NULL`), nothing automatically touches its `pii_store` rows. A policy is required: do PII rows live as long as their owning entity's *row*, or as long as its *logical lifecycle*?
+
+The choice has downstream consequences for `pii_service` API surface, soft-delete restore flows, and the GDPR/right-to-forget story.
+
+## Decision
+**Soft-delete preserves PII.** Only a hard purge (`Unscoped().Delete()`) removes PII rows.
+
+- Soft-deleting an account or transaction is reversible (`gorm.DeletedAt` is exactly this contract). Restoring a soft-deleted account without its holder name / account number would leave the user with a half-empty record.
+- PII follows the entity's **logical** lifecycle, not its row lifecycle. A row marked `deleted_at` is in the "trash" — not yet gone.
+- Hard purge (when explicitly invoked, e.g. by a right-to-forget endpoint or scheduled purge job) is what removes the underlying entity rows AND their PII atomically.
+
+## Rationale
+- **UX coherence**: restore-from-trash that resurrects only half the record is worse than not restoring at all.
+- **Right-to-forget remains achievable**: it requires hard purge, which was always the only acceptable answer for actual GDPR erasure (soft-delete does not satisfy "erased").
+- **Minimal blast radius from a soft-delete bug**: an accidental soft-delete is recoverable. Under Policy B, an accidental soft-delete would silently destroy PII with no recovery path.
+- **Aligns with the household grace period model** ([ADR-0007](0007-member-lifecycle.md)): membership uses `left_at` + `purged_at` for exactly this reason — soft state vs. terminal state are different.
+
+## Consequences
+- `pii_service` does **not** wire into account/transaction soft-delete paths. No `DeleteByEntity(entityType, entityID)` on the service.
+- A future hard-purge runner (analogous to `cmd/household-purge`) MUST delete from `pii_store` in the same transaction as the entity hard-delete. Track as a follow-up issue when the first hard-purge surface lands (M3+ when `accounts.deleted_at` flows from real user actions).
+- Privacy story in marketing/docs must be honest: "PII is removed when you purge the trash, not when you delete an account."
+- The transitive-ownership check in `pii_service.GetAccountPII` already calls `accSvc.Get` which filters out soft-deleted accounts — so a soft-deleted account's PII is **unreachable** through the API even though the rows linger. This is the desired property: invisible by default, recoverable on restore, gone on purge.
+
+## Alternatives Considered
+- **Policy B — purge PII on soft-delete**: rejected for the UX coherence reason above. PII minimization is a real value but is better served by an explicit hard-purge UX than by aliasing it onto "delete this account".
+- **Cascade via FK from `pii_store`**: rejected because it breaks the PII isolation invariant ([ADR-0003](0003-pii-isolation-table.md)) — `pii_store` is intentionally unjoinable.
+- **Background sweeper that nukes orphaned PII**: rejected as adding complexity for a problem that doesn't exist under Policy A. Orphans only arise from hard-purge bugs; the right fix is to make hard-purge atomic, not to mop up after it.
+
+## Follow-up
+File a tracking issue when the first hard-purge surface lands (account permanent-delete UX, scheduled trash auto-purge, or right-to-forget endpoint) to ensure `pii_repo.DeleteAll(entityType, entityID)` is called inside the same transaction as the entity hard-delete.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -140,6 +140,7 @@ UNIQUE (entity_type, entity_id, field_name)
 - The household aggregator (`service/household/`) CANNOT access PII
 - Frontend accesses PII via explicit `/accounts/:id/pii` endpoint — deliberate, auditable
 - Ownership of a `pii_store` row is transitive through `entity_id`: PII belongs to whichever user owns the referenced account/transaction. `pii_service.go` must check the entity's `user_id` matches the session before returning the row.
+- **Orphan-cleanup policy:** soft-delete on an account/transaction **preserves** its PII rows ([ADR-0009](ADR/0009-pii-orphan-cleanup-policy.md)). Soft-deleted entities are unreachable through the API (the transitive ownership check rejects them), but their PII survives until a hard purge. Hard purge MUST delete `pii_store` rows in the same transaction as the entity hard-delete.
 
 ### What goes in pii_store vs main tables
 


### PR DESCRIPTION
## Summary
Chose **Policy A** — soft-delete **preserves** PII; only hard purge removes \`pii_store\` rows. ADR-0009 documents the decision, rationale (UX coherence, bounded soft-delete blast radius), consequences, and alternatives.

The transitive ownership check in \`pii_service.GetAccountPII\` already filters out soft-deleted accounts, so a soft-deleted account's PII is unreachable through the API even though the rows linger — exactly the desired property: invisible by default, recoverable on restore, gone on hard purge.

- New ADR \`docs/ADR/0009-pii-orphan-cleanup-policy.md\`
- \`docs/ARCHITECTURE.md\` "PII Isolation" cross-refs the new ADR
- \`pii_service.go\` comment updated from "TODO per backlog #21" to a concrete ADR-0009 reference

## Follow-up
Tracked in the ADR: when the first hard-purge surface lands, file an issue to wire \`pii_repo.DeleteAll(entityType, entityID)\` into the same transaction.

## Test plan
- [x] Doc + comment only — no test impact

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)