### PR TITLE
#18: PII contract test scaffolding

### DIFF
--- a/backend/internal/model/pii_isolation_test.go
+++ b/backend/internal/model/pii_isolation_test.go
@@ -1,0 +1,79 @@
+package model_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/shopspring/decimal"
+
+	"github.com/gregwym/offbook/backend/internal/model"
+	"github.com/gregwym/offbook/backend/internal/testutil"
+)
+
+// TestPIIScan_FlagsLeak inserts a transaction whose description contains a
+// known PII token and asserts the scanner flags it. Proves the scanner is
+// doing real work.
+func TestPIIScan_FlagsLeak(t *testing.T) {
+	g := openTestDB(t)
+	userID, acct := newTestAccount(t, g)
+
+	const token = "Greg_PII_Token_" // distinctive so it can't collide with seed data
+	desc := "Payment to " + token + "Smith"
+	tx := model.Transaction{
+		UserID:          userID,
+		AccountID:       acct.ID,
+		Amount:          decimal.RequireFromString("12.34"),
+		Currency:        "USD",
+		TransactionDate: time.Now().UTC().Truncate(24 * time.Hour),
+		Source:          "manual",
+		Description:     &desc,
+	}
+	if err := g.Create(&tx).Error; err != nil {
+		t.Fatalf("insert tx: %v", err)
+	}
+	t.Cleanup(func() { g.Unscoped().Delete(&model.Transaction{}, tx.ID) })
+
+	leaks, err := testutil.ScanForPIILeaks(t.Context(), g, []string{token}, testutil.DefaultPIIScanTargets())
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	var found bool
+	for _, l := range leaks {
+		if l.Table == "transactions" && l.Column == "description" && l.RowID == tx.ID && l.Token == token {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("scanner missed the planted leak; got: %+v", leaks)
+	}
+}
+
+// TestPIIScan_PassesWhenClean stores a PII token only in pii_store (where
+// it belongs) and asserts the scanner finds zero leaks across non-PII
+// tables. Proves the scanner is correctly scoped — it must not flag
+// pii_store itself.
+func TestPIIScan_PassesWhenClean(t *testing.T) {
+	g := openTestDB(t)
+	_, acct := newTestAccount(t, g)
+
+	const token = "Greg_PII_OnlyInStore_"
+	rec := model.PIIRecord{
+		EntityType: "account",
+		EntityID:   acct.ID,
+		FieldName:  "holder_name",
+		Value:      token + "Smith",
+	}
+	if err := g.Create(&rec).Error; err != nil {
+		t.Fatalf("insert pii_store: %v", err)
+	}
+	t.Cleanup(func() { g.Unscoped().Delete(&model.PIIRecord{}, rec.ID) })
+
+	leaks, err := testutil.ScanForPIILeaks(t.Context(), g, []string{token}, testutil.DefaultPIIScanTargets())
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if len(leaks) != 0 {
+		t.Fatalf("expected zero leaks when token lives only in pii_store, got: %+v", leaks)
+	}
+}

--- a/backend/internal/testutil/pii_scan.go
+++ b/backend/internal/testutil/pii_scan.go
@@ -1,0 +1,131 @@
+// Package testutil holds shared test helpers. The PII leak scanner is the
+// enforcement arm of .claude/rules/testing.md ("PII tests: verify pii_store
+// is the only table containing PII after any operation"). See ADR-0003
+// for the architectural intent.
+package testutil
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"testing"
+
+	"gorm.io/gorm"
+)
+
+// PIIScanTarget pairs a table with the text/JSONB columns on it that could
+// plausibly leak PII. JSONB columns are cast to text in the query so the
+// same ILIKE works uniformly.
+type PIIScanTarget struct {
+	Table   string
+	Columns []string
+}
+
+// DefaultPIIScanTargets enumerates the non-pii_store tables and columns
+// that could leak PII today. Add to this list whenever a new free-text
+// column lands on a domain table.
+func DefaultPIIScanTargets() []PIIScanTarget {
+	return []PIIScanTarget{
+		{Table: "accounts", Columns: []string{"name"}},
+		{Table: "transactions", Columns: []string{"description", "description_clean", "merchant_name", "notes"}},
+		{Table: "ai_messages", Columns: []string{"content", "context_snapshot"}},
+		{Table: "categories", Columns: []string{"name"}},
+	}
+}
+
+// PIILeak describes one match. Reported verbatim so failing tests point
+// directly at the offending row.
+type PIILeak struct {
+	Table  string
+	Column string
+	RowID  int64
+	Token  string
+}
+
+func (l PIILeak) String() string {
+	return fmt.Sprintf("%s.%s row id=%d matched %q", l.Table, l.Column, l.RowID, l.Token)
+}
+
+// ScanForPIILeaks runs a case-insensitive substring search across the
+// configured targets for each token. Returns every match (caller decides
+// whether to fail loud or summarize).
+//
+// Tokens are trimmed; empty tokens are skipped to avoid matching every row.
+// JSONB columns are cast via `::text` so the same ILIKE pattern works.
+func ScanForPIILeaks(ctx context.Context, db *gorm.DB, tokens []string, targets []PIIScanTarget) ([]PIILeak, error) {
+	cleanedTokens := make([]string, 0, len(tokens))
+	for _, t := range tokens {
+		t = strings.TrimSpace(t)
+		if t == "" {
+			continue
+		}
+		cleanedTokens = append(cleanedTokens, t)
+	}
+	if len(cleanedTokens) == 0 {
+		return nil, nil
+	}
+
+	var leaks []PIILeak
+	for _, target := range targets {
+		for _, col := range target.Columns {
+			for _, token := range cleanedTokens {
+				// `column::text` is a no-op for text/varchar and the
+				// correct cast for JSONB / other types. Quoting the
+				// identifiers protects against reserved words.
+				query := fmt.Sprintf(`SELECT id FROM %q WHERE %q::text ILIKE ?`, target.Table, col)
+				rows, err := db.WithContext(ctx).Raw(query, "%"+token+"%").Rows()
+				if err != nil {
+					return nil, fmt.Errorf("scan %s.%s for %q: %w", target.Table, col, token, err)
+				}
+				for rows.Next() {
+					var id int64
+					if scanErr := rows.Scan(&id); scanErr != nil {
+						_ = rows.Close()
+						return nil, fmt.Errorf("scan id from %s.%s: %w", target.Table, col, scanErr)
+					}
+					leaks = append(leaks, PIILeak{Table: target.Table, Column: col, RowID: id, Token: token})
+				}
+				if err := rows.Close(); err != nil {
+					return nil, fmt.Errorf("close rows for %s.%s: %w", target.Table, col, err)
+				}
+			}
+		}
+	}
+
+	// Stable order for deterministic failure messages.
+	sort.Slice(leaks, func(i, j int) bool {
+		if leaks[i].Table != leaks[j].Table {
+			return leaks[i].Table < leaks[j].Table
+		}
+		if leaks[i].Column != leaks[j].Column {
+			return leaks[i].Column < leaks[j].Column
+		}
+		if leaks[i].RowID != leaks[j].RowID {
+			return leaks[i].RowID < leaks[j].RowID
+		}
+		return leaks[i].Token < leaks[j].Token
+	})
+	return leaks, nil
+}
+
+// AssertNoPIILeak fails the test if any token from `tokens` appears in any
+// non-pii_store column listed by DefaultPIIScanTargets. Each match is
+// reported on its own line so an audit-style test surfaces every offender
+// in a single run, not one at a time.
+func AssertNoPIILeak(t *testing.T, db *gorm.DB, tokens []string) {
+	t.Helper()
+	leaks, err := ScanForPIILeaks(t.Context(), db, tokens, DefaultPIIScanTargets())
+	if err != nil {
+		t.Fatalf("pii scan failed: %v", err)
+	}
+	if len(leaks) == 0 {
+		return
+	}
+	lines := make([]string, 0, len(leaks)+1)
+	lines = append(lines, fmt.Sprintf("found %d PII leak(s) in non-pii_store tables:", len(leaks)))
+	for _, l := range leaks {
+		lines = append(lines, "  "+l.String())
+	}
+	t.Fatal(strings.Join(lines, "\n"))
+}


### PR DESCRIPTION
## Summary
Adds a reusable PII leak-scan helper plus a demo test, so any future test can assert that after an operation no PII tokens leaked into non-\`pii_store\` tables.

- \`backend/internal/testutil/pii_scan.go\`:
  - \`ScanForPIILeaks(ctx, db, tokens, targets)\` — case-insensitive substring search across configured columns. Returns each match as \`PIILeak{Table, Column, RowID, Token}\` so failures point at the offending row.
  - \`AssertNoPIILeak(t, db, tokens)\` — \`t.Fatal\`-on-leak wrapper.
  - \`DefaultPIIScanTargets()\` — current allowlist: \`accounts.name\`, \`transactions.{description,description_clean,merchant_name,notes}\`, \`ai_messages.{content,context_snapshot}\`, \`categories.name\`. JSONB column is cast via \`::text\` so the same ILIKE works.

- \`backend/internal/model/pii_isolation_test.go\`:
  - \`TestPIIScan_FlagsLeak\` plants a token in \`transactions.description\` and asserts the scanner flags it.
  - \`TestPIIScan_PassesWhenClean\` stores the token only in \`pii_store\` and asserts zero leaks elsewhere — proving the scanner ignores \`pii_store\` itself.

Both tests reuse \`openTestDB\` / \`newTestAccount\` from \`decimal_precision_test.go\`, so they skip cleanly when \`DATABASE_URL\` is unreachable (same pattern as existing integration tests).

## Test plan
- [x] \`go build ./...\` passes
- [x] \`go test ./internal/testutil/... ./internal/model/...\` passes
- [x] \`golangci-lint run\` clean

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)