### PR TITLE
#25: GitHub Actions CI (lint + tests + frontend build)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,23 +15,16 @@ jobs:
   backend-lint:
     name: Backend lint (golangci-lint)
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: backend
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
-        with:
-          go-version-file: backend/go.mod
-          cache-dependency-path: backend/go.sum
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@v8
-        with:
-          # The repo's .golangci.yml uses the v2 schema, which requires
-          # golangci-lint v2.x. Pin minor here so a v3 release doesn't
-          # silently regress.
-          version: v2.5.0
-          working-directory: backend
+      # The official golangci-lint-action pins a binary release that is
+      # frequently behind on Go toolchain support — the v2.5.0 binary
+      # was built with Go 1.25 and refuses to lint a Go 1.26 module
+      # ("language version used to build golangci-lint is lower").
+      # The Docker image keeps pace and is the same surface `make lint`
+      # uses locally, so CI and dev see identical results.
+      - name: golangci-lint (docker)
+        run: docker run --rm -v "$PWD/backend":/app -w /app golangci/golangci-lint:latest-alpine golangci-lint run ./...
 
   backend-test:
     name: Backend test (go test against Postgres)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,9 +25,12 @@ jobs:
           go-version-file: backend/go.mod
           cache-dependency-path: backend/go.sum
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v8
         with:
-          version: latest
+          # The repo's .golangci.yml uses the v2 schema, which requires
+          # golangci-lint v2.x. Pin minor here so a v3 release doesn't
+          # silently regress.
+          version: v2.5.0
           working-directory: backend
 
   backend-test:
@@ -63,7 +66,9 @@ jobs:
       - name: go vet
         run: go vet ./...
       - name: go test
-        run: go test -race ./...
+        # -p 1 serializes package execution. Integration tests share one
+        # DATABASE_URL, so parallel packages step on each other's rows.
+        run: go test -race -p 1 ./...
 
   frontend-build:
     name: Frontend build (pnpm build)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,89 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+# Cancel in-progress runs when a new commit lands on the same ref —
+# saves runner minutes on rapid pushes.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  backend-lint:
+    name: Backend lint (golangci-lint)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: backend/go.mod
+          cache-dependency-path: backend/go.sum
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: latest
+          working-directory: backend
+
+  backend-test:
+    name: Backend test (go test against Postgres)
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: offbook
+          POSTGRES_PASSWORD: offbook
+          POSTGRES_DB: offbook
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U offbook"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+    env:
+      DATABASE_URL: postgres://offbook:offbook@localhost:5432/offbook?sslmode=disable
+    defaults:
+      run:
+        working-directory: backend
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: backend/go.mod
+          cache-dependency-path: backend/go.sum
+      - name: Apply migrations
+        run: go run ./cmd/migrate up
+      - name: go vet
+        run: go vet ./...
+      - name: go test
+        run: go test -race ./...
+
+  frontend-build:
+    name: Frontend build (pnpm build)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: frontend/pnpm-lock.yaml
+      - name: Install
+        run: pnpm install --frozen-lockfile
+      - name: Lint
+        run: pnpm lint
+      - name: Build
+        run: pnpm build


### PR DESCRIPTION
## Summary
Three jobs on \`push\` to \`main\` and every \`pull_request\` (concurrency-grouped — a new push on the same ref cancels the prior run):

- **backend-lint** — \`golangci-lint\` v2 via the official action against \`backend/\`.
- **backend-test** — \`postgres:16-alpine\` as a service container; runs the in-repo migrate runner (\`go run ./cmd/migrate up\`) then \`go vet\` + \`go test -race ./...\`. \`DATABASE_URL\` points at the service container so existing integration tests (\`decimal_precision_test\`, \`pii_isolation_test\`) actually exercise Postgres instead of skipping.
- **frontend-build** — \`pnpm install --frozen-lockfile\` → \`pnpm lint\` → \`pnpm build\`.

Verified locally: \`pnpm lint\` and \`pnpm build\` both clean.

## Branch protection (out-of-repo)
Branch protection rules live in GitHub repo settings, not the repo. After the first successful run, configure \"Require status checks to pass before merging\" with these three checks required:
- \`Backend lint (golangci-lint)\`
- \`Backend test (go test against Postgres)\`
- \`Frontend build (pnpm build)\`

The autonomous self-merge workflow remains the merge surface; CI becomes the gate it must wait on.

## Test plan
- [x] \`pnpm lint\` + \`pnpm build\` pass locally
- [x] \`golangci-lint run\` clean locally
- [x] \`go test ./...\` passes locally
- [ ] First CI run on this PR turns green

Closes #25
Closes #9 (duplicate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)