### PR TITLE
Allow gofmt + goimports in Claude permissions

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -25,6 +25,8 @@
       "Bash(git rebase *)",
       "Bash(migrate *)",
       "Bash(golangci-lint *)",
+      "Bash(gofmt *)",
+      "Bash(goimports *)",
       "Bash(ls *)",
       "Bash(mkdir *)"
     ],


### PR DESCRIPTION
## Summary
- Add \`Bash(gofmt *)\` and \`Bash(goimports *)\` to \`.claude/settings.json\` allow list

## Why
While shipping #59, CI lint failed on an import-grouping issue that \`gofmt -w\` would fix in one shot — but each invocation triggered a permission prompt. Per user direction, allow these formatters automatically.

Closes #69