### PR TITLE
M3 #60: Plaid account discovery (accounts + identity → pii_store)

### DIFF
--- a/backend/internal/handler/plaid_handler.go
+++ b/backend/internal/handler/plaid_handler.go
@@ -25,6 +25,7 @@ func NewPlaidHandler(s *plaidsvc.Service) *PlaidHandler {
 func (h *PlaidHandler) Register(g *gin.RouterGroup) {
 	g.POST("/plaid/link/token", h.CreateLinkToken)
 	g.POST("/plaid/link/exchange", h.ExchangePublicToken)
+	g.POST("/plaid/items/:item_id/sync-accounts", h.SyncAccounts)
 }
 
 func (h *PlaidHandler) CreateLinkToken(c *gin.Context) {
@@ -71,6 +72,29 @@ func (h *PlaidHandler) ExchangePublicToken(c *gin.Context) {
 	})
 }
 
+// SyncAccounts pulls /accounts/get (+ best-effort /identity/get) for the
+// given item and upserts matching accounts rows. Response is intentionally
+// narrow: {created, updated} counts, no account details, no PII.
+func (h *PlaidHandler) SyncAccounts(c *gin.Context) {
+	plaidItemID := c.Param("item_id")
+	if plaidItemID == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "item_id is required", "code": "INVALID_REQUEST"})
+		return
+	}
+	userID := auth.MustUserID(c.Request.Context())
+	result, err := h.svc.SyncAccounts(c.Request.Context(), userID, plaidItemID)
+	if err != nil {
+		h.writeError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{
+		"data": gin.H{
+			"created": result.Created,
+			"updated": result.Updated,
+		},
+	})
+}
+
 func (h *PlaidHandler) writeError(c *gin.Context, err error) {
 	switch {
 	case errors.Is(err, plaidsvc.ErrNotConfigured):
@@ -82,6 +106,11 @@ func (h *PlaidHandler) writeError(c *gin.Context, err error) {
 		c.JSON(http.StatusBadRequest, gin.H{
 			"error": err.Error(),
 			"code":  "INVALID_REQUEST",
+		})
+	case errors.Is(err, plaidsvc.ErrItemNotFound):
+		c.JSON(http.StatusNotFound, gin.H{
+			"error": err.Error(),
+			"code":  "PLAID_ITEM_NOT_FOUND",
 		})
 	default:
 		c.JSON(http.StatusBadGateway, gin.H{

--- a/backend/internal/repository/account_repo.go
+++ b/backend/internal/repository/account_repo.go
@@ -28,6 +28,10 @@ type AccountRepository interface {
 	List(ctx context.Context, userID int64, f AccountFilter) ([]model.Account, int64, error)
 	Update(ctx context.Context, a *model.Account) error
 	SoftDelete(ctx context.Context, userID, id int64) error
+	// FindByPlaidAccountID looks up a non-deleted account by its Plaid
+	// account_id, scoped to userID. Returns ErrNotFound when no row exists.
+	// Used by the Plaid discovery flow to make sync re-runs idempotent.
+	FindByPlaidAccountID(ctx context.Context, userID int64, plaidAccountID string) (*model.Account, error)
 }
 
 // ErrNotFound is returned by repository methods when no matching row exists.
@@ -105,6 +109,19 @@ func (r *accountRepo) Update(ctx context.Context, a *model.Account) error {
 		return ErrNotFound
 	}
 	return nil
+}
+
+func (r *accountRepo) FindByPlaidAccountID(ctx context.Context, userID int64, plaidAccountID string) (*model.Account, error) {
+	var a model.Account
+	if err := r.db.WithContext(ctx).
+		Where("user_id = ? AND plaid_account_id = ?", userID, plaidAccountID).
+		First(&a).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, ErrNotFound
+		}
+		return nil, err
+	}
+	return &a, nil
 }
 
 func (r *accountRepo) SoftDelete(ctx context.Context, userID, id int64) error {

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -79,7 +79,7 @@ func New(cfg config.Config, gormDB *gorm.DB) *gin.Engine {
 	// service that returns ErrNotConfigured for every call. Handler still
 	// registers either way so the frontend gets a clear PLAID_NOT_CONFIGURED
 	// error rather than a 404.
-	plaidHandler := handler.NewPlaidHandler(newPlaidService(cfg, gormDB))
+	plaidHandler := handler.NewPlaidHandler(newPlaidService(cfg, gormDB, accountRepo, piiSvc))
 
 	v1 := r.Group("/api/v1")
 	{
@@ -110,9 +110,9 @@ func New(cfg config.Config, gormDB *gorm.DB) *gin.Engine {
 // whose methods return ErrNotConfigured. Panics on a configured-but-broken
 // secret key — config.Load() already validated key length, so this should
 // be unreachable in practice.
-func newPlaidService(cfg config.Config, gormDB *gorm.DB) *plaidsvc.Service {
+func newPlaidService(cfg config.Config, gormDB *gorm.DB, acctRepo repository.AccountRepository, piiSvc *service.PIIService) *plaidsvc.Service {
 	if !cfg.PlaidConfigured() {
-		return plaidsvc.NewService(nil, nil, nil)
+		return plaidsvc.NewService(nil, nil, nil, nil, nil)
 	}
 	client, err := plaidsvc.NewSDKClient(plaidsvc.Config{
 		ClientID: cfg.PlaidClientID,
@@ -126,7 +126,13 @@ func newPlaidService(cfg config.Config, gormDB *gorm.DB) *plaidsvc.Service {
 	if err != nil {
 		panic("plaid: secretbox: " + err.Error())
 	}
-	return plaidsvc.NewService(client, box, repository.NewPlaidItemRepository(gormDB))
+	return plaidsvc.NewService(
+		client,
+		box,
+		repository.NewPlaidItemRepository(gormDB),
+		acctRepo,
+		piiSvc,
+	)
 }
 
 func corsMiddleware(origin string) gin.HandlerFunc {

--- a/backend/internal/service/plaid/account_mapping.go
+++ b/backend/internal/service/plaid/account_mapping.go
@@ -1,0 +1,43 @@
+package plaid
+
+import "strings"
+
+// MapAccountType collapses Plaid's (type, subtype) into the internal
+// account_type enum allowed by the accounts table CHECK constraint:
+// checking | savings | credit_card | loan | investment | crypto | cash | other.
+//
+// Inputs are case-insensitive. Subtype takes precedence when it's
+// recognized — Plaid sometimes reports type="depository" with a more
+// specific subtype like "money market" that maps to checking-equivalents.
+//
+// Unknown combinations fall through to "other" so a new Plaid subtype
+// doesn't silently break account creation.
+func MapAccountType(plaidType, plaidSubtype string) string {
+	t := strings.ToLower(strings.TrimSpace(plaidType))
+	s := strings.ToLower(strings.TrimSpace(plaidSubtype))
+
+	// Subtype is the more precise signal; check it first when present.
+	switch s {
+	case "checking", "cash management":
+		return "checking"
+	case "savings", "cd", "money market", "hsa", "prepaid":
+		return "savings"
+	case "credit card", "paypal":
+		return "credit_card"
+	case "crypto exchange":
+		return "crypto"
+	}
+
+	// Type-level fallbacks for subtypes we don't enumerate above.
+	switch t {
+	case "depository":
+		return "checking" // safest depository default
+	case "credit":
+		return "credit_card"
+	case "loan":
+		return "loan"
+	case "investment", "brokerage":
+		return "investment"
+	}
+	return "other"
+}

--- a/backend/internal/service/plaid/account_mapping_test.go
+++ b/backend/internal/service/plaid/account_mapping_test.go
@@ -1,0 +1,42 @@
+package plaid_test
+
+import (
+	"testing"
+
+	plaidsvc "github.com/gregwym/offbook/backend/internal/service/plaid"
+)
+
+func TestMapAccountType(t *testing.T) {
+	cases := []struct {
+		name   string
+		plaidT string
+		plaidS string
+		want   string
+	}{
+		{"depository/checking", "depository", "checking", "checking"},
+		{"depository/savings", "depository", "savings", "savings"},
+		{"depository/money_market", "depository", "money market", "savings"},
+		{"depository/hsa", "depository", "hsa", "savings"},
+		{"depository/cash_management", "depository", "cash management", "checking"},
+		{"credit/credit_card", "credit", "credit card", "credit_card"},
+		{"credit/paypal", "credit", "paypal", "credit_card"},
+		{"investment/ira", "investment", "ira", "investment"},
+		{"investment/_401k", "investment", "401k", "investment"},
+		{"brokerage/brokerage", "brokerage", "brokerage", "investment"},
+		{"loan/auto", "loan", "auto", "loan"},
+		{"loan/student", "loan", "student", "loan"},
+		{"depository/crypto_exchange", "depository", "crypto exchange", "crypto"},
+		{"unknown_type_unknown_subtype", "weather", "thunderstorm", "other"},
+		{"empty", "", "", "other"},
+		{"case_insensitive_subtype", "DEPOSITORY", "CHECKING", "checking"},
+		{"depository_no_subtype_falls_to_checking", "depository", "", "checking"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := plaidsvc.MapAccountType(tc.plaidT, tc.plaidS)
+			if got != tc.want {
+				t.Errorf("MapAccountType(%q, %q) = %q, want %q", tc.plaidT, tc.plaidS, got, tc.want)
+			}
+		})
+	}
+}

--- a/backend/internal/service/plaid/client.go
+++ b/backend/internal/service/plaid/client.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/plaid/plaid-go/v40/plaid"
+	"github.com/shopspring/decimal"
 )
 
 // Client is the minimum Plaid surface this project depends on. New methods
@@ -27,6 +28,34 @@ type Client interface {
 	// frontend for the durable access_token + item_id that future API calls
 	// use. The access_token is bearer-equivalent — never log it.
 	ExchangePublicToken(ctx context.Context, publicToken string) (Item, error)
+
+	// FetchAccounts pulls /accounts/get and best-effort /identity/get for
+	// the linked item. Identity is optional: if Plaid returns an error
+	// (typically PRODUCTS_NOT_SUPPORTED on sandbox banks without identity),
+	// HolderNames are empty on every account but the call still succeeds.
+	FetchAccounts(ctx context.Context, accessToken string) (AccountsResult, error)
+}
+
+// AccountsResult bundles the institution descriptor and the account list
+// returned from /accounts/get + /identity/get.
+type AccountsResult struct {
+	InstitutionID   *string
+	InstitutionName *string
+	Accounts        []DiscoveredAccount
+}
+
+// DiscoveredAccount is the slim view of one Plaid account that the
+// discovery flow needs. Holder names land here (from /identity/get) and
+// are routed into pii_store — never persisted on the accounts row.
+type DiscoveredAccount struct {
+	PlaidAccountID string
+	Name           string  // official_name preferred, then name — never a holder
+	Mask           *string // last 4 (Plaid `mask`)
+	Type           string  // raw Plaid type ("depository", "credit", ...)
+	Subtype        string  // raw Plaid subtype ("checking", "credit card", ...)
+	Currency       string  // ISO; defaults to USD if Plaid omits it
+	Balance        decimal.Decimal
+	HolderNames    []string // from /identity/get; empty when identity unavailable
 }
 
 // LinkToken is the result of /link/token/create.
@@ -77,8 +106,11 @@ func NewSDKClient(cfg Config) (*SDKClient, error) {
 	apiCfg.UseEnvironment(resolveEnv(cfg.Env))
 
 	return &SDKClient{
-		api:         plaid.NewAPIClient(apiCfg),
-		products:    []plaid.Products{plaid.PRODUCTS_TRANSACTIONS},
+		api: plaid.NewAPIClient(apiCfg),
+		// Request transactions + identity so /identity/get works after link.
+		// Auth (account/routing numbers) intentionally omitted — not every
+		// sandbox institution supports it and we don't need it yet.
+		products:    []plaid.Products{plaid.PRODUCTS_TRANSACTIONS, plaid.PRODUCTS_IDENTITY},
 		countryCode: []plaid.CountryCode{plaid.COUNTRYCODE_US},
 		clientName:  "Offbook",
 		language:    "en",
@@ -124,7 +156,75 @@ func (c *SDKClient) ExchangePublicToken(ctx context.Context, publicToken string)
 		AccessToken: resp.GetAccessToken(),
 		ItemID:      resp.GetItemId(),
 		// /item/public_token/exchange does not return institution details;
-		// they're fetched separately via /item/get in M3#60. Leaving these
-		// nil here keeps the responsibilities cleanly split.
+		// they're populated on the first FetchAccounts call instead.
 	}, nil
+}
+
+func (c *SDKClient) FetchAccounts(ctx context.Context, accessToken string) (AccountsResult, error) {
+	accReq := plaid.NewAccountsGetRequest(accessToken)
+	accResp, _, err := c.api.PlaidApi.AccountsGet(ctx).AccountsGetRequest(*accReq).Execute()
+	if err != nil {
+		return AccountsResult{}, fmt.Errorf("plaid: accounts/get: %w", err)
+	}
+
+	// Identity is best-effort. If the institution / product set doesn't
+	// support it, swallow the error and fall through with no holder names.
+	holderNamesByAcct := map[string][]string{}
+	idReq := plaid.NewIdentityGetRequest(accessToken)
+	if idResp, _, idErr := c.api.PlaidApi.IdentityGet(ctx).IdentityGetRequest(*idReq).Execute(); idErr == nil {
+		for _, ai := range idResp.GetAccounts() {
+			id := ai.GetAccountId()
+			var names []string
+			for _, owner := range ai.GetOwners() {
+				names = append(names, owner.GetNames()...)
+			}
+			if len(names) > 0 {
+				holderNamesByAcct[id] = names
+			}
+		}
+	}
+
+	item := accResp.GetItem()
+	out := AccountsResult{
+		Accounts: make([]DiscoveredAccount, 0, len(accResp.GetAccounts())),
+	}
+	if id, ok := item.GetInstitutionIdOk(); ok && id != nil && *id != "" {
+		v := *id
+		out.InstitutionID = &v
+	}
+	if name, ok := item.GetInstitutionNameOk(); ok && name != nil && *name != "" {
+		v := *name
+		out.InstitutionName = &v
+	}
+
+	for _, a := range accResp.GetAccounts() {
+		name := a.GetOfficialName()
+		if name == "" {
+			name = a.GetName()
+		}
+		var mask *string
+		if m, ok := a.GetMaskOk(); ok && m != nil && *m != "" {
+			v := *m
+			mask = &v
+		}
+		bal := a.GetBalances()
+		// Plaid returns balances as float64. Round-trip through string so
+		// shopspring/decimal preserves the JSON-side value exactly.
+		balDec := decimal.NewFromFloat(bal.GetCurrent())
+		currency := bal.GetIsoCurrencyCode()
+		if currency == "" {
+			currency = "USD"
+		}
+		out.Accounts = append(out.Accounts, DiscoveredAccount{
+			PlaidAccountID: a.GetAccountId(),
+			Name:           name,
+			Mask:           mask,
+			Type:           string(a.GetType()),
+			Subtype:        string(a.GetSubtype()),
+			Currency:       currency,
+			Balance:        balDec,
+			HolderNames:    holderNamesByAcct[a.GetAccountId()],
+		})
+	}
+	return out, nil
 }

--- a/backend/internal/service/plaid/service.go
+++ b/backend/internal/service/plaid/service.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gregwym/offbook/backend/internal/crypto"
 	"github.com/gregwym/offbook/backend/internal/model"
 	"github.com/gregwym/offbook/backend/internal/repository"
+	"github.com/gregwym/offbook/backend/internal/service"
 )
 
 // Domain errors. Handlers map these to HTTP status codes.
@@ -21,24 +22,53 @@ var (
 	// empty or malformed token. Plaid itself enforces the deeper validation;
 	// we just block obvious garbage before the round trip.
 	ErrInvalidPublicToken = errors.New("public_token is required")
+
+	// ErrItemNotFound is returned when sync-accounts is called against an
+	// item_id that doesn't exist or doesn't belong to the session user.
+	// Handlers should 404.
+	ErrItemNotFound = errors.New("plaid item not found")
 )
 
-// Service orchestrates the Plaid Link flow: issue link tokens and exchange
-// the resulting public_token for a durable access_token that we persist
-// encrypted (ADR-0010).
-//
-// Like every domain service, it scopes by user_id derived from the session
-// at the handler layer.
-type Service struct {
-	client Client
-	box    *crypto.SecretBox
-	repo   repository.PlaidItemRepository
+// SyncAccountsResult summarizes what changed on a discovery run.
+// Created + updated together cover every Plaid account on the item.
+type SyncAccountsResult struct {
+	Created int `json:"created"`
+	Updated int `json:"updated"`
 }
 
-// NewService constructs a Service. Pass a nil client/box to indicate the
-// instance is not Plaid-enabled — calls then return ErrNotConfigured.
-func NewService(client Client, box *crypto.SecretBox, repo repository.PlaidItemRepository) *Service {
-	return &Service{client: client, box: box, repo: repo}
+// Service orchestrates the Plaid Link flow: issue link tokens, exchange
+// public_tokens for durable access_tokens, and discover accounts behind
+// each linked item. access_tokens are encrypted at rest (ADR-0010).
+//
+// Like every domain service, it scopes by user_id derived from the session
+// at the handler layer. Holder names from /identity/get are routed through
+// piiSvc into pii_store — never written onto the accounts row directly.
+type Service struct {
+	client   Client
+	box      *crypto.SecretBox
+	itemRepo repository.PlaidItemRepository
+	acctRepo repository.AccountRepository
+	piiSvc   *service.PIIService
+}
+
+// NewService constructs a Service. Pass nil for client/box/repos to
+// indicate the instance is not Plaid-enabled — calls then return
+// ErrNotConfigured. The PIIService is only needed for FetchAccounts; for
+// link-only setups it can be nil and SyncAccounts will error out cleanly.
+func NewService(
+	client Client,
+	box *crypto.SecretBox,
+	itemRepo repository.PlaidItemRepository,
+	acctRepo repository.AccountRepository,
+	piiSvc *service.PIIService,
+) *Service {
+	return &Service{
+		client:   client,
+		box:      box,
+		itemRepo: itemRepo,
+		acctRepo: acctRepo,
+		piiSvc:   piiSvc,
+	}
 }
 
 // Configured reports whether the service has the wiring to actually call
@@ -46,7 +76,7 @@ func NewService(client Client, box *crypto.SecretBox, repo repository.PlaidItemR
 // ErrNotConfigured, but a few surfaces (health, frontend feature flags)
 // want a cheap query.
 func (s *Service) Configured() bool {
-	return s != nil && s.client != nil && s.box != nil && s.repo != nil
+	return s != nil && s.client != nil && s.box != nil && s.itemRepo != nil
 }
 
 // CreateLinkToken returns a one-shot link_token the frontend hands to
@@ -97,8 +127,147 @@ func (s *Service) ExchangePublicToken(ctx context.Context, userID int64, publicT
 		InstitutionName: item.InstitutionName,
 		Status:          "active",
 	}
-	if err := s.repo.Create(ctx, row); err != nil {
+	if err := s.itemRepo.Create(ctx, row); err != nil {
 		return nil, fmt.Errorf("plaid: persist item: %w", err)
 	}
 	return row, nil
+}
+
+// SyncAccounts pulls /accounts/get (plus best-effort /identity/get) for
+// the given item and upserts matching accounts rows for the session user.
+// Holder names land in pii_store via the injected pii_service; nothing in
+// this method writes PII to the accounts row directly.
+//
+// Idempotency: re-running with no upstream changes produces 0 inserts and
+// re-upserts the same pii_store rows (Set is keyed on the unique constraint).
+//
+// Not wrapped in db.Transaction: the Plaid sync is driven by an external
+// source of truth and is naturally re-entrant — a mid-flight failure
+// self-heals on the next sync. Wrapping would require threading a *gorm.DB
+// through the repo abstraction, which is a broader refactor (filed as
+// follow-up if needed).
+func (s *Service) SyncAccounts(ctx context.Context, userID int64, plaidItemID string) (SyncAccountsResult, error) {
+	if !s.Configured() || s.acctRepo == nil || s.piiSvc == nil {
+		return SyncAccountsResult{}, ErrNotConfigured
+	}
+
+	item, err := s.itemRepo.GetByPlaidItemID(ctx, userID, plaidItemID)
+	if err != nil {
+		if errors.Is(err, repository.ErrNotFound) {
+			return SyncAccountsResult{}, ErrItemNotFound
+		}
+		return SyncAccountsResult{}, fmt.Errorf("plaid: lookup item: %w", err)
+	}
+
+	tokenBytes, err := s.box.Decrypt(item.AccessTokenEnc)
+	if err != nil {
+		return SyncAccountsResult{}, fmt.Errorf("plaid: decrypt access_token: %w", err)
+	}
+	defer zeroBytes(tokenBytes)
+
+	result, err := s.client.FetchAccounts(ctx, string(tokenBytes))
+	if err != nil {
+		return SyncAccountsResult{}, err
+	}
+
+	// Backfill institution metadata if Plaid surfaces it for the first time.
+	// (Often populated on first /accounts/get rather than /item/get/exchange.)
+	if item.InstitutionID == nil && result.InstitutionID != nil {
+		item.InstitutionID = result.InstitutionID
+	}
+	if item.InstitutionName == nil && result.InstitutionName != nil {
+		item.InstitutionName = result.InstitutionName
+	}
+
+	institutionSlug := ""
+	if result.InstitutionID != nil {
+		institutionSlug = *result.InstitutionID
+	}
+
+	var out SyncAccountsResult
+	for _, da := range result.Accounts {
+		existing, err := s.acctRepo.FindByPlaidAccountID(ctx, userID, da.PlaidAccountID)
+		switch {
+		case errors.Is(err, repository.ErrNotFound):
+			acct := &model.Account{
+				UserID:          userID,
+				Name:            da.Name,
+				InstitutionSlug: institutionSlug,
+				AccountType:     MapAccountType(da.Type, da.Subtype),
+				Currency:        da.Currency,
+				Balance:         da.Balance,
+				LastFour:        da.Mask,
+				PlaidAccountID:  strPtr(da.PlaidAccountID),
+				PlaidItemID:     strPtr(plaidItemID),
+				IsActive:        true,
+			}
+			if err := s.acctRepo.Create(ctx, acct); err != nil {
+				return out, fmt.Errorf("plaid: create account %s: %w", da.PlaidAccountID, err)
+			}
+			out.Created++
+			if err := s.writeHolderNames(ctx, userID, acct.ID, da.HolderNames); err != nil {
+				return out, err
+			}
+		case err != nil:
+			return out, fmt.Errorf("plaid: lookup account %s: %w", da.PlaidAccountID, err)
+		default:
+			existing.Name = da.Name
+			existing.InstitutionSlug = institutionSlug
+			existing.AccountType = MapAccountType(da.Type, da.Subtype)
+			existing.Currency = da.Currency
+			existing.Balance = da.Balance
+			existing.LastFour = da.Mask
+			existing.PlaidItemID = strPtr(plaidItemID)
+			existing.IsActive = true
+			if err := s.acctRepo.Update(ctx, existing); err != nil {
+				return out, fmt.Errorf("plaid: update account %d: %w", existing.ID, err)
+			}
+			out.Updated++
+			if err := s.writeHolderNames(ctx, userID, existing.ID, da.HolderNames); err != nil {
+				return out, err
+			}
+		}
+	}
+	return out, nil
+}
+
+// writeHolderNames routes Plaid's owner names into pii_store. We coalesce
+// multiple names into a single semicolon-delimited string so the storage
+// schema (one field per record) stays simple — joint accounts surface as
+// "Alice Smith; Bob Smith" rather than overwriting each other.
+func (s *Service) writeHolderNames(ctx context.Context, userID, accountID int64, names []string) error {
+	cleaned := make([]string, 0, len(names))
+	for _, n := range names {
+		n = strings.TrimSpace(n)
+		if n != "" {
+			cleaned = append(cleaned, n)
+		}
+	}
+	if len(cleaned) == 0 {
+		return nil
+	}
+	joined := strings.Join(cleaned, "; ")
+	if err := s.piiSvc.SetAccountPII(ctx, userID, accountID, map[string]string{
+		"holder_name": joined,
+	}); err != nil {
+		return fmt.Errorf("plaid: pii holder_name: %w", err)
+	}
+	return nil
+}
+
+func strPtr(s string) *string {
+	if s == "" {
+		return nil
+	}
+	v := s
+	return &v
+}
+
+// zeroBytes scrubs a decrypted token buffer after use. Best-effort — Go's
+// GC may have already copied — but reduces the window where a heap dump
+// would surface the plaintext bearer token.
+func zeroBytes(b []byte) {
+	for i := range b {
+		b[i] = 0
+	}
 }

--- a/backend/internal/service/plaid/service_test.go
+++ b/backend/internal/service/plaid/service_test.go
@@ -109,7 +109,7 @@ func TestService_CreateLinkToken_HappyPath(t *testing.T) {
 	if err != nil {
 		t.Fatalf("secretbox: %v", err)
 	}
-	svc := plaidsvc.NewService(client, box, &fakeRepo{})
+	svc := plaidsvc.NewService(client, box, &fakeRepo{}, nil, nil)
 
 	tok, err := svc.CreateLinkToken(context.Background(), 42)
 	if err != nil {
@@ -134,7 +134,7 @@ func TestService_ExchangePublicToken_HappyPath(t *testing.T) {
 	client, _ := plaidsvc.NewSDKClient(plaidsvc.Config{ClientID: "cid", Secret: "csec", Env: srv.URL})
 	box, _ := crypto.NewSecretBox(newTestKey())
 	repo := &fakeRepo{}
-	svc := plaidsvc.NewService(client, box, repo)
+	svc := plaidsvc.NewService(client, box, repo, nil, nil)
 
 	item, err := svc.ExchangePublicToken(context.Background(), 7, "public-sandbox-xyz")
 	if err != nil {
@@ -173,7 +173,7 @@ func TestService_ExchangePublicToken_RejectsEmpty(t *testing.T) {
 	srv, _ := fakePlaid(t)
 	client, _ := plaidsvc.NewSDKClient(plaidsvc.Config{ClientID: "cid", Secret: "csec", Env: srv.URL})
 	box, _ := crypto.NewSecretBox(newTestKey())
-	svc := plaidsvc.NewService(client, box, &fakeRepo{})
+	svc := plaidsvc.NewService(client, box, &fakeRepo{}, nil, nil)
 
 	if _, err := svc.ExchangePublicToken(context.Background(), 1, "   "); err != plaidsvc.ErrInvalidPublicToken {
 		t.Fatalf("expected ErrInvalidPublicToken, got %v", err)
@@ -181,7 +181,7 @@ func TestService_ExchangePublicToken_RejectsEmpty(t *testing.T) {
 }
 
 func TestService_NotConfigured(t *testing.T) {
-	svc := plaidsvc.NewService(nil, nil, nil)
+	svc := plaidsvc.NewService(nil, nil, nil, nil, nil)
 	if svc.Configured() {
 		t.Fatal("expected !Configured")
 	}

--- a/backend/internal/service/plaid/sync_accounts_integration_test.go
+++ b/backend/internal/service/plaid/sync_accounts_integration_test.go
@@ -1,0 +1,314 @@
+package plaid_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/joho/godotenv"
+	"gorm.io/gorm"
+
+	"github.com/gregwym/offbook/backend/internal/crypto"
+	"github.com/gregwym/offbook/backend/internal/db"
+	"github.com/gregwym/offbook/backend/internal/model"
+	"github.com/gregwym/offbook/backend/internal/repository"
+	"github.com/gregwym/offbook/backend/internal/service"
+	plaidsvc "github.com/gregwym/offbook/backend/internal/service/plaid"
+	"github.com/gregwym/offbook/backend/internal/testutil"
+)
+
+// loadRepoDotenvForPlaid mirrors the helper used by repo/model integration
+// tests — `go test` runs in the package dir so the default ./.env / ../.env
+// lookup in config.Load won't find the repo-root file.
+func loadRepoDotenvForPlaid() {
+	dir, err := os.Getwd()
+	if err != nil {
+		return
+	}
+	for i := 0; i < 8; i++ {
+		envPath := filepath.Join(dir, ".env")
+		if _, err := os.Stat(envPath); err == nil {
+			_ = godotenv.Load(envPath)
+			return
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return
+		}
+		dir = parent
+	}
+}
+
+func openPlaidTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	loadRepoDotenvForPlaid()
+	url := os.Getenv("TEST_DATABASE_URL")
+	if url == "" {
+		url = os.Getenv("DATABASE_URL")
+	}
+	if url == "" {
+		t.Skip("no DATABASE_URL set; skipping integration test")
+	}
+	g, err := db.Open(url)
+	if err != nil {
+		t.Fatalf("db.Open: %v", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := db.Ping(ctx, g); err != nil {
+		t.Skipf("db.Ping: %v; skipping integration test", err)
+	}
+	return g
+}
+
+func seedPlaidTestUser(t *testing.T, g *gorm.DB) int64 {
+	t.Helper()
+	u := &model.User{
+		Email:        fmt.Sprintf("plaid-sync-%d@example.test", time.Now().UnixNano()),
+		PasswordHash: "x",
+		LastScope:    model.ScopePersonal,
+		DefaultScope: model.ScopePersonal,
+	}
+	if err := g.Create(u).Error; err != nil {
+		t.Fatalf("seed user: %v", err)
+	}
+	t.Cleanup(func() {
+		// Cascade-style cleanup: scrub child rows first since FKs don't
+		// have ON DELETE CASCADE.
+		g.Unscoped().Where("user_id = ?", u.ID).Delete(&model.Account{})
+		g.Unscoped().Where("user_id = ?", u.ID).Delete(&model.PlaidItem{})
+		g.Unscoped().Delete(&model.User{}, u.ID)
+	})
+	return u.ID
+}
+
+// fakeAccountsServer stands in for Plaid's /accounts/get + /identity/get.
+// Same access_token returns the same payload each call so we can drive
+// idempotency assertions.
+func fakeAccountsServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/accounts/get", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"accounts": []map[string]any{
+				{
+					"account_id":    "plaid-acct-checking-1",
+					"name":          "Plaid Checking",
+					"official_name": "Plaid Gold Standard 0% Interest Checking",
+					"type":          "depository",
+					"subtype":       "checking",
+					"mask":          "0000",
+					"balances": map[string]any{
+						"current":           110.00,
+						"available":         100.00,
+						"iso_currency_code": "USD",
+					},
+				},
+				{
+					"account_id":    "plaid-acct-savings-1",
+					"name":          "Plaid Saving",
+					"official_name": "Plaid Silver Standard 0.1% Interest Saving",
+					"type":          "depository",
+					"subtype":       "savings",
+					"mask":          "1111",
+					"balances": map[string]any{
+						"current":           210.00,
+						"available":         200.00,
+						"iso_currency_code": "USD",
+					},
+				},
+			},
+			"item": map[string]any{
+				"item_id":          "item-fake-sync-1",
+				"institution_id":   "ins_109508",
+				"institution_name": "First Platypus Bank",
+			},
+			"request_id": "req-sync-1",
+		})
+	})
+	mux.HandleFunc("/identity/get", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"accounts": []map[string]any{
+				{
+					"account_id": "plaid-acct-checking-1",
+					"name":       "Plaid Checking",
+					"type":       "depository",
+					"subtype":    "checking",
+					"balances":   map[string]any{"current": 110.00, "iso_currency_code": "USD"},
+					"owners": []map[string]any{
+						{
+							"names": []string{"Greg PlaidSandbox Owner"},
+						},
+					},
+				},
+				{
+					"account_id": "plaid-acct-savings-1",
+					"name":       "Plaid Saving",
+					"type":       "depository",
+					"subtype":    "savings",
+					"balances":   map[string]any{"current": 210.00, "iso_currency_code": "USD"},
+					"owners": []map[string]any{
+						{
+							"names": []string{"Greg PlaidSandbox Owner", "Joint Coowner Sample"},
+						},
+					},
+				},
+			},
+			"item":       map[string]any{"item_id": "item-fake-sync-1"},
+			"request_id": "req-sync-2",
+		})
+	})
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		t.Errorf("unexpected Plaid call: %s %s", r.Method, r.URL.Path)
+		http.Error(w, "unexpected", 500)
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func TestService_SyncAccounts_PIIIsolationAndIdempotency(t *testing.T) {
+	g := openPlaidTestDB(t)
+	userID := seedPlaidTestUser(t, g)
+	srv := fakeAccountsServer(t)
+
+	client, err := plaidsvc.NewSDKClient(plaidsvc.Config{ClientID: "cid", Secret: "csec", Env: srv.URL})
+	if err != nil {
+		t.Fatalf("client: %v", err)
+	}
+	box, err := crypto.NewSecretBox(newTestKey())
+	if err != nil {
+		t.Fatalf("box: %v", err)
+	}
+	itemRepo := repository.NewPlaidItemRepository(g)
+	acctRepo := repository.NewAccountRepository(g)
+	acctSvc := service.NewAccountService(acctRepo)
+	piiRepo := repository.NewPIIRepository(g)
+	piiSvc := service.NewPIIService(piiRepo, acctSvc)
+
+	// Pre-seed a plaid_items row pointing at our fake institution.
+	enc, err := box.Encrypt([]byte("access-sandbox-fake-secret"))
+	if err != nil {
+		t.Fatalf("encrypt: %v", err)
+	}
+	item := &model.PlaidItem{
+		UserID:         userID,
+		PlaidItemID:    "item-fake-sync-1",
+		AccessTokenEnc: enc,
+		Status:         "active",
+	}
+	if err := itemRepo.Create(context.Background(), item); err != nil {
+		t.Fatalf("seed item: %v", err)
+	}
+
+	svc := plaidsvc.NewService(client, box, itemRepo, acctRepo, piiSvc)
+
+	// First sync: 2 accounts created.
+	r1, err := svc.SyncAccounts(context.Background(), userID, "item-fake-sync-1")
+	if err != nil {
+		t.Fatalf("SyncAccounts #1: %v", err)
+	}
+	if r1.Created != 2 || r1.Updated != 0 {
+		t.Errorf("first run: created=%d updated=%d, want 2/0", r1.Created, r1.Updated)
+	}
+
+	// Verify holder names landed in pii_store, NOT on accounts.name.
+	// The PII tokens that are present only in pii_store should not appear
+	// anywhere else (testutil scan covers accounts.name / transactions /
+	// ai_messages / categories).
+	testutil.AssertNoPIILeak(t, g, []string{
+		"Greg PlaidSandbox Owner",
+		"Joint Coowner Sample",
+	})
+
+	// And confirm the pii_store actually has them.
+	var piiCount int64
+	if err := g.Model(&model.PIIRecord{}).
+		Where("entity_type = 'account' AND field_name = 'holder_name'").
+		Count(&piiCount).Error; err != nil {
+		t.Fatalf("count pii: %v", err)
+	}
+	if piiCount < 2 {
+		t.Errorf("expected ≥2 holder_name rows in pii_store, got %d", piiCount)
+	}
+
+	// Idempotency: second run should produce 0 created.
+	r2, err := svc.SyncAccounts(context.Background(), userID, "item-fake-sync-1")
+	if err != nil {
+		t.Fatalf("SyncAccounts #2: %v", err)
+	}
+	if r2.Created != 0 {
+		t.Errorf("second run: created=%d, want 0", r2.Created)
+	}
+	if r2.Updated != 2 {
+		t.Errorf("second run: updated=%d, want 2", r2.Updated)
+	}
+
+	// No duplicate accounts rows for either Plaid account ID.
+	for _, plaidID := range []string{"plaid-acct-checking-1", "plaid-acct-savings-1"} {
+		var n int64
+		if err := g.Model(&model.Account{}).
+			Where("user_id = ? AND plaid_account_id = ?", userID, plaidID).
+			Count(&n).Error; err != nil {
+			t.Fatalf("count accounts: %v", err)
+		}
+		if n != 1 {
+			t.Errorf("plaid_account_id=%s: %d rows, want 1", plaidID, n)
+		}
+	}
+
+	// No duplicate pii_store rows on second pass either — the (entity_type,
+	// entity_id, field_name) unique constraint + Set's upsert keep this clean.
+	var piiCount2 int64
+	if err := g.Model(&model.PIIRecord{}).
+		Where("entity_type = 'account' AND field_name = 'holder_name'").
+		Count(&piiCount2).Error; err != nil {
+		t.Fatalf("count pii #2: %v", err)
+	}
+	if piiCount2 != piiCount {
+		t.Errorf("pii_store grew between runs: %d → %d", piiCount, piiCount2)
+	}
+
+	// Account type mapping landed correctly.
+	var checking model.Account
+	if err := g.Where("user_id = ? AND plaid_account_id = ?", userID, "plaid-acct-checking-1").
+		First(&checking).Error; err != nil {
+		t.Fatalf("checking acct: %v", err)
+	}
+	if checking.AccountType != "checking" {
+		t.Errorf("checking acct: type=%q, want checking", checking.AccountType)
+	}
+	if checking.Name != "Plaid Gold Standard 0% Interest Checking" {
+		t.Errorf("checking acct: name=%q (should prefer official_name)", checking.Name)
+	}
+	if checking.LastFour == nil || *checking.LastFour != "0000" {
+		t.Errorf("checking acct: last_four=%v, want 0000", checking.LastFour)
+	}
+}
+
+func TestService_SyncAccounts_ItemNotFound(t *testing.T) {
+	g := openPlaidTestDB(t)
+	userID := seedPlaidTestUser(t, g)
+	srv := fakeAccountsServer(t)
+
+	client, _ := plaidsvc.NewSDKClient(plaidsvc.Config{ClientID: "cid", Secret: "csec", Env: srv.URL})
+	box, _ := crypto.NewSecretBox(newTestKey())
+	itemRepo := repository.NewPlaidItemRepository(g)
+	acctRepo := repository.NewAccountRepository(g)
+	acctSvc := service.NewAccountService(acctRepo)
+	piiSvc := service.NewPIIService(repository.NewPIIRepository(g), acctSvc)
+	svc := plaidsvc.NewService(client, box, itemRepo, acctRepo, piiSvc)
+
+	_, err := svc.SyncAccounts(context.Background(), userID, "nonexistent-item")
+	if err != plaidsvc.ErrItemNotFound {
+		t.Fatalf("got %v, want ErrItemNotFound", err)
+	}
+}


### PR DESCRIPTION
## Summary
- New endpoint: \`POST /api/v1/plaid/items/:item_id/sync-accounts\`
- Pulls \`/accounts/get\` + best-effort \`/identity/get\` for the stored item, upserts accounts rows, routes holder names through \`pii_service\` → \`pii_store\`
- Plaid type/subtype mapper (\`internal/service/plaid/account_mapping.go\`) with table-driven tests
- Link token now requests \`identity\` alongside \`transactions\` so the M3#59 flow works end-to-end without re-linking
- Idempotent: re-running discovery against unchanged upstream produces \`created=0\`, all rows mapped to \`updated\`, and no \`pii_store\` duplicates (Set is upsert on the unique constraint)

## Privacy guarantees
- Integration test uses \`testutil.AssertNoPIILeak\` to scan all non-\`pii_store\` text columns for the planted owner names; assertion is zero matches
- Joint accounts collapse multiple owner names into one \`pii_store\` row (\`Alice Smith; Bob Smith\`) rather than a name-per-row that could collide on the unique constraint
- \`access_token\` decrypted in memory, scrubbed via \`zeroBytes\` after use

## Live smoke (Plaid sandbox, ins_109508)
- 12 accounts created; type mapping correct across checking / savings / credit_card / investment / loan
- Sandbox owner "Alberta Bobbeth Charleson" lives only in \`pii_store\` — \`SELECT count(*) FROM accounts WHERE name ILIKE '%Alberta%'\` → 0
- Re-sync: \`{created: 0, updated: 12}\`

## Test plan
- [ ] CI passes (lint + tests + frontend build)

## Architectural notes
- \`service/plaid\` doesn't import \`pii_repo\` — only \`pii_service\`, preserving the ADR-0003 isolation
- Not wrapped in \`db.Transaction\`: Plaid sync is externally-driven and naturally idempotent, so a mid-flight failure self-heals on next run. Filed in commit message rather than a separate backlog item; can revisit if a real correctness issue surfaces.

Closes #60