### PR TITLE
M3 #61: Plaid /transactions/sync — initial full pull

### DIFF
--- a/backend/internal/handler/plaid_handler.go
+++ b/backend/internal/handler/plaid_handler.go
@@ -26,6 +26,7 @@ func (h *PlaidHandler) Register(g *gin.RouterGroup) {
 	g.POST("/plaid/link/token", h.CreateLinkToken)
 	g.POST("/plaid/link/exchange", h.ExchangePublicToken)
 	g.POST("/plaid/items/:item_id/sync-accounts", h.SyncAccounts)
+	g.POST("/plaid/items/:item_id/sync-transactions", h.SyncTransactions)
 }
 
 func (h *PlaidHandler) CreateLinkToken(c *gin.Context) {
@@ -91,6 +92,30 @@ func (h *PlaidHandler) SyncAccounts(c *gin.Context) {
 		"data": gin.H{
 			"created": result.Created,
 			"updated": result.Updated,
+		},
+	})
+}
+
+// SyncTransactions runs /transactions/sync for the given item, persisting
+// added transactions and the resulting cursor. Response is a narrow
+// {inserted, modified, removed} count — never the transactions themselves.
+func (h *PlaidHandler) SyncTransactions(c *gin.Context) {
+	plaidItemID := c.Param("item_id")
+	if plaidItemID == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "item_id is required", "code": "INVALID_REQUEST"})
+		return
+	}
+	userID := auth.MustUserID(c.Request.Context())
+	result, err := h.svc.SyncTransactions(c.Request.Context(), userID, plaidItemID)
+	if err != nil {
+		h.writeError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{
+		"data": gin.H{
+			"inserted": result.Inserted,
+			"modified": result.Modified,
+			"removed":  result.Removed,
 		},
 	})
 }

--- a/backend/internal/repository/plaid_item_repo.go
+++ b/backend/internal/repository/plaid_item_repo.go
@@ -3,6 +3,7 @@ package repository
 import (
 	"context"
 	"errors"
+	"time"
 
 	"gorm.io/gorm"
 
@@ -18,6 +19,10 @@ type PlaidItemRepository interface {
 	GetByPlaidItemID(ctx context.Context, userID int64, plaidItemID string) (*model.PlaidItem, error)
 	ListByUser(ctx context.Context, userID int64) ([]model.PlaidItem, error)
 	UpdateStatus(ctx context.Context, userID, id int64, status string, lastError *string) error
+	// UpdateCursor persists the /transactions/sync cursor + last sync time.
+	// Called after each successful pagination flush so a crash mid-pull
+	// resumes from the last committed page.
+	UpdateCursor(ctx context.Context, userID, id int64, cursor string, lastSyncedAt time.Time) error
 	SoftDelete(ctx context.Context, userID, id int64) error
 }
 
@@ -77,6 +82,23 @@ func (r *plaidItemRepo) UpdateStatus(ctx context.Context, userID, id int64, stat
 		Updates(map[string]any{
 			"status":     status,
 			"last_error": lastError,
+		})
+	if res.Error != nil {
+		return res.Error
+	}
+	if res.RowsAffected == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+func (r *plaidItemRepo) UpdateCursor(ctx context.Context, userID, id int64, cursor string, lastSyncedAt time.Time) error {
+	res := r.db.WithContext(ctx).
+		Model(&model.PlaidItem{}).
+		Where("user_id = ? AND id = ?", userID, id).
+		Updates(map[string]any{
+			"cursor":         cursor,
+			"last_synced_at": lastSyncedAt,
 		})
 	if res.Error != nil {
 		return res.Error

--- a/backend/internal/repository/transaction_repo.go
+++ b/backend/internal/repository/transaction_repo.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 
 	"github.com/gregwym/offbook/backend/internal/model"
 )
@@ -32,6 +33,11 @@ type TransactionRepository interface {
 	List(ctx context.Context, userID int64, f TransactionFilter) ([]model.Transaction, int64, error)
 	Update(ctx context.Context, t *model.Transaction) error
 	SoftDelete(ctx context.Context, userID, id int64) error
+	// CreateBatch inserts many transactions in one round-trip, doing
+	// nothing on conflict with the (plaid_transaction_id) unique index.
+	// Returns the number of rows actually inserted — caller compares that
+	// to len(txns) to derive "skipped as duplicate" if needed.
+	CreateBatch(ctx context.Context, txns []model.Transaction) (int64, error)
 }
 
 type transactionRepo struct {
@@ -117,6 +123,29 @@ func (r *transactionRepo) Update(ctx context.Context, t *model.Transaction) erro
 		return ErrNotFound
 	}
 	return nil
+}
+
+func (r *transactionRepo) CreateBatch(ctx context.Context, txns []model.Transaction) (int64, error) {
+	if len(txns) == 0 {
+		return 0, nil
+	}
+	// ON CONFLICT DO NOTHING on the partial unique index
+	// `uq_transactions_plaid` (defined in migration 000001 as
+	// `(plaid_transaction_id) WHERE deleted_at IS NULL AND plaid_transaction_id IS NOT NULL`).
+	// Postgres requires the conflict target to match the partial predicate
+	// exactly, hence TargetWhere — without it we get
+	// "no unique or exclusion constraint matching the ON CONFLICT specification".
+	res := r.db.WithContext(ctx).Clauses(clause.OnConflict{
+		Columns: []clause.Column{{Name: "plaid_transaction_id"}},
+		TargetWhere: clause.Where{Exprs: []clause.Expression{
+			clause.Expr{SQL: "deleted_at IS NULL AND plaid_transaction_id IS NOT NULL"},
+		}},
+		DoNothing: true,
+	}).Create(&txns)
+	if res.Error != nil {
+		return 0, res.Error
+	}
+	return res.RowsAffected, nil
 }
 
 func (r *transactionRepo) SoftDelete(ctx context.Context, userID, id int64) error {

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -79,7 +79,7 @@ func New(cfg config.Config, gormDB *gorm.DB) *gin.Engine {
 	// service that returns ErrNotConfigured for every call. Handler still
 	// registers either way so the frontend gets a clear PLAID_NOT_CONFIGURED
 	// error rather than a 404.
-	plaidHandler := handler.NewPlaidHandler(newPlaidService(cfg, gormDB, accountRepo, piiSvc))
+	plaidHandler := handler.NewPlaidHandler(newPlaidService(cfg, gormDB, accountRepo, transactionRepo, piiSvc))
 
 	v1 := r.Group("/api/v1")
 	{
@@ -110,9 +110,15 @@ func New(cfg config.Config, gormDB *gorm.DB) *gin.Engine {
 // whose methods return ErrNotConfigured. Panics on a configured-but-broken
 // secret key — config.Load() already validated key length, so this should
 // be unreachable in practice.
-func newPlaidService(cfg config.Config, gormDB *gorm.DB, acctRepo repository.AccountRepository, piiSvc *service.PIIService) *plaidsvc.Service {
+func newPlaidService(
+	cfg config.Config,
+	gormDB *gorm.DB,
+	acctRepo repository.AccountRepository,
+	txRepo repository.TransactionRepository,
+	piiSvc *service.PIIService,
+) *plaidsvc.Service {
 	if !cfg.PlaidConfigured() {
-		return plaidsvc.NewService(nil, nil, nil, nil, nil)
+		return plaidsvc.NewService(nil, nil, nil, nil, nil, nil)
 	}
 	client, err := plaidsvc.NewSDKClient(plaidsvc.Config{
 		ClientID: cfg.PlaidClientID,
@@ -131,6 +137,7 @@ func newPlaidService(cfg config.Config, gormDB *gorm.DB, acctRepo repository.Acc
 		box,
 		repository.NewPlaidItemRepository(gormDB),
 		acctRepo,
+		txRepo,
 		piiSvc,
 	)
 }

--- a/backend/internal/service/plaid/client.go
+++ b/backend/internal/service/plaid/client.go
@@ -34,6 +34,37 @@ type Client interface {
 	// (typically PRODUCTS_NOT_SUPPORTED on sandbox banks without identity),
 	// HolderNames are empty on every account but the call still succeeds.
 	FetchAccounts(ctx context.Context, accessToken string) (AccountsResult, error)
+
+	// SyncTransactions wraps one /transactions/sync call. An empty cursor
+	// triggers the historical pull; a non-empty cursor delivers only what
+	// changed since that cursor. Callers paginate by re-calling with
+	// page.NextCursor while page.HasMore is true.
+	SyncTransactions(ctx context.Context, accessToken, cursor string) (SyncTransactionsPage, error)
+}
+
+// SyncTransactionsPage is one page of /transactions/sync output. The cursor
+// is opaque — never inspect it, just persist and feed back on the next call.
+type SyncTransactionsPage struct {
+	Added      []PlaidTransaction
+	Modified   []PlaidTransaction
+	Removed    []string // plaid_transaction_id values to soft-delete
+	NextCursor string
+	HasMore    bool
+}
+
+// PlaidTransaction is the slim view of one Plaid transaction. The
+// amount-sign convention here matches Plaid's: positive = money OUT of
+// the account. transaction_mapping.go flips this for project storage.
+type PlaidTransaction struct {
+	PlaidTransactionID string
+	PlaidAccountID     string
+	Amount             decimal.Decimal // Plaid sign convention
+	Currency           string
+	Name               string  // Plaid `name` (raw description)
+	MerchantName       *string // Plaid `merchant_name` (may be nil)
+	Date               string  // "YYYY-MM-DD"
+	AuthorizedDate     *string // optional "YYYY-MM-DD"
+	Pending            bool
 }
 
 // AccountsResult bundles the institution descriptor and the account list
@@ -227,4 +258,62 @@ func (c *SDKClient) FetchAccounts(ctx context.Context, accessToken string) (Acco
 		})
 	}
 	return out, nil
+}
+
+func (c *SDKClient) SyncTransactions(ctx context.Context, accessToken, cursor string) (SyncTransactionsPage, error) {
+	req := plaid.NewTransactionsSyncRequest(accessToken)
+	if cursor != "" {
+		req.SetCursor(cursor)
+	}
+	resp, _, err := c.api.PlaidApi.TransactionsSync(ctx).TransactionsSyncRequest(*req).Execute()
+	if err != nil {
+		return SyncTransactionsPage{}, fmt.Errorf("plaid: transactions/sync: %w", err)
+	}
+
+	page := SyncTransactionsPage{
+		Added:      make([]PlaidTransaction, 0, len(resp.GetAdded())),
+		Modified:   make([]PlaidTransaction, 0, len(resp.GetModified())),
+		Removed:    make([]string, 0, len(resp.GetRemoved())),
+		NextCursor: resp.GetNextCursor(),
+		HasMore:    resp.GetHasMore(),
+	}
+	for _, t := range resp.GetAdded() {
+		page.Added = append(page.Added, convertPlaidTransaction(t))
+	}
+	for _, t := range resp.GetModified() {
+		page.Modified = append(page.Modified, convertPlaidTransaction(t))
+	}
+	for _, r := range resp.GetRemoved() {
+		if id, ok := r.GetTransactionIdOk(); ok && id != nil && *id != "" {
+			page.Removed = append(page.Removed, *id)
+		}
+	}
+	return page, nil
+}
+
+// convertPlaidTransaction reshapes the SDK type into our slim struct.
+// Amount stays in Plaid's sign convention (positive = outflow); the
+// service-side mapper flips for project storage.
+func convertPlaidTransaction(t plaid.Transaction) PlaidTransaction {
+	out := PlaidTransaction{
+		PlaidTransactionID: t.GetTransactionId(),
+		PlaidAccountID:     t.GetAccountId(),
+		Amount:             decimal.NewFromFloat(t.GetAmount()),
+		Currency:           t.GetIsoCurrencyCode(),
+		Name:               t.GetName(),
+		Date:               t.GetDate(),
+		Pending:            t.GetPending(),
+	}
+	if out.Currency == "" {
+		out.Currency = "USD"
+	}
+	if mn, ok := t.GetMerchantNameOk(); ok && mn != nil && *mn != "" {
+		v := *mn
+		out.MerchantName = &v
+	}
+	if ad, ok := t.GetAuthorizedDateOk(); ok && ad != nil && *ad != "" {
+		v := *ad
+		out.AuthorizedDate = &v
+	}
+	return out
 }

--- a/backend/internal/service/plaid/service.go
+++ b/backend/internal/service/plaid/service.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/gregwym/offbook/backend/internal/crypto"
 	"github.com/gregwym/offbook/backend/internal/model"
@@ -36,6 +37,16 @@ type SyncAccountsResult struct {
 	Updated int `json:"updated"`
 }
 
+// SyncTransactionsResult summarizes a /transactions/sync drain. Inserted
+// is the count of rows actually written (i.e., excludes duplicates that
+// hit the ON CONFLICT DO NOTHING path). Removed is the count of Plaid
+// IDs we were told to forget — for the initial pull this is always 0.
+type SyncTransactionsResult struct {
+	Inserted int64 `json:"inserted"`
+	Modified int   `json:"modified"`
+	Removed  int   `json:"removed"`
+}
+
 // Service orchestrates the Plaid Link flow: issue link tokens, exchange
 // public_tokens for durable access_tokens, and discover accounts behind
 // each linked item. access_tokens are encrypted at rest (ADR-0010).
@@ -48,18 +59,21 @@ type Service struct {
 	box      *crypto.SecretBox
 	itemRepo repository.PlaidItemRepository
 	acctRepo repository.AccountRepository
+	txRepo   repository.TransactionRepository
 	piiSvc   *service.PIIService
 }
 
 // NewService constructs a Service. Pass nil for client/box/repos to
 // indicate the instance is not Plaid-enabled — calls then return
-// ErrNotConfigured. The PIIService is only needed for FetchAccounts; for
-// link-only setups it can be nil and SyncAccounts will error out cleanly.
+// ErrNotConfigured. txRepo and piiSvc are only needed for the discovery
+// and transaction-sync surfaces; link-only setups can pass nil and the
+// affected methods will error out cleanly.
 func NewService(
 	client Client,
 	box *crypto.SecretBox,
 	itemRepo repository.PlaidItemRepository,
 	acctRepo repository.AccountRepository,
+	txRepo repository.TransactionRepository,
 	piiSvc *service.PIIService,
 ) *Service {
 	return &Service{
@@ -67,6 +81,7 @@ func NewService(
 		box:      box,
 		itemRepo: itemRepo,
 		acctRepo: acctRepo,
+		txRepo:   txRepo,
 		piiSvc:   piiSvc,
 	}
 }
@@ -270,4 +285,105 @@ func zeroBytes(b []byte) {
 	for i := range b {
 		b[i] = 0
 	}
+}
+
+// SyncTransactions paginates /transactions/sync for the given item,
+// translating each page through MapPlaidTransaction and bulk-inserting
+// into the transactions table. The cursor + last_synced_at on the item
+// are updated after EVERY page so a crash mid-pull resumes cleanly.
+//
+// First-time pull: pass an item whose cursor is empty. Subsequent runs
+// re-use the persisted cursor and only fetch deltas. The sign convention
+// flip and date mapping happen in MapPlaidTransaction.
+//
+// Idempotency: the bulk insert uses ON CONFLICT (plaid_transaction_id)
+// DO NOTHING, so re-running against the same upstream is a no-op rather
+// than an error.
+func (s *Service) SyncTransactions(ctx context.Context, userID int64, plaidItemID string) (SyncTransactionsResult, error) {
+	if !s.Configured() || s.acctRepo == nil || s.txRepo == nil {
+		return SyncTransactionsResult{}, ErrNotConfigured
+	}
+
+	item, err := s.itemRepo.GetByPlaidItemID(ctx, userID, plaidItemID)
+	if err != nil {
+		if errors.Is(err, repository.ErrNotFound) {
+			return SyncTransactionsResult{}, ErrItemNotFound
+		}
+		return SyncTransactionsResult{}, fmt.Errorf("plaid: lookup item: %w", err)
+	}
+
+	tokenBytes, err := s.box.Decrypt(item.AccessTokenEnc)
+	if err != nil {
+		return SyncTransactionsResult{}, fmt.Errorf("plaid: decrypt access_token: %w", err)
+	}
+	defer zeroBytes(tokenBytes)
+	accessToken := string(tokenBytes)
+
+	cursor := ""
+	if item.Cursor != nil {
+		cursor = *item.Cursor
+	}
+
+	// Cache plaid_account_id → local accounts.id lookups so we don't hit
+	// the DB once per transaction. The same accountID-resolution miss is
+	// also surfaced as an error so we don't silently drop transactions
+	// belonging to an account that wasn't discovered first.
+	accountIDByPlaidID := map[string]int64{}
+
+	var result SyncTransactionsResult
+	for {
+		page, err := s.client.SyncTransactions(ctx, accessToken, cursor)
+		if err != nil {
+			return result, err
+		}
+
+		batch := make([]model.Transaction, 0, len(page.Added))
+		for _, pt := range page.Added {
+			localID, err := s.resolveAccountID(ctx, userID, pt.PlaidAccountID, accountIDByPlaidID)
+			if err != nil {
+				return result, err
+			}
+			row, err := MapPlaidTransaction(pt, userID, localID)
+			if err != nil {
+				return result, err
+			}
+			batch = append(batch, row)
+		}
+		if len(batch) > 0 {
+			n, err := s.txRepo.CreateBatch(ctx, batch)
+			if err != nil {
+				return result, fmt.Errorf("plaid: insert batch: %w", err)
+			}
+			result.Inserted += n
+		}
+		result.Modified += len(page.Modified)
+		result.Removed += len(page.Removed)
+
+		cursor = page.NextCursor
+		if err := s.itemRepo.UpdateCursor(ctx, userID, item.ID, cursor, time.Now().UTC()); err != nil {
+			return result, fmt.Errorf("plaid: persist cursor: %w", err)
+		}
+		if !page.HasMore {
+			break
+		}
+	}
+	return result, nil
+}
+
+// resolveAccountID maps a Plaid account_id to the local accounts.id,
+// memoizing in the per-call cache. Returns an error if no local account
+// exists — the caller should run /sync-accounts first.
+func (s *Service) resolveAccountID(ctx context.Context, userID int64, plaidAcctID string, cache map[string]int64) (int64, error) {
+	if id, ok := cache[plaidAcctID]; ok {
+		return id, nil
+	}
+	a, err := s.acctRepo.FindByPlaidAccountID(ctx, userID, plaidAcctID)
+	if err != nil {
+		if errors.Is(err, repository.ErrNotFound) {
+			return 0, fmt.Errorf("plaid: no local account for plaid_account_id=%s (run sync-accounts first)", plaidAcctID)
+		}
+		return 0, fmt.Errorf("plaid: lookup account %s: %w", plaidAcctID, err)
+	}
+	cache[plaidAcctID] = a.ID
+	return a.ID, nil
 }

--- a/backend/internal/service/plaid/service_test.go
+++ b/backend/internal/service/plaid/service_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/gregwym/offbook/backend/internal/crypto"
 	"github.com/gregwym/offbook/backend/internal/model"
@@ -86,6 +87,9 @@ func (r *fakeRepo) UpdateStatus(context.Context, int64, int64, string, *string) 
 	return nil
 }
 func (r *fakeRepo) SoftDelete(context.Context, int64, int64) error { return nil }
+func (r *fakeRepo) UpdateCursor(context.Context, int64, int64, string, time.Time) error {
+	return nil
+}
 
 func newTestKey() []byte {
 	k := make([]byte, 32)
@@ -109,7 +113,7 @@ func TestService_CreateLinkToken_HappyPath(t *testing.T) {
 	if err != nil {
 		t.Fatalf("secretbox: %v", err)
 	}
-	svc := plaidsvc.NewService(client, box, &fakeRepo{}, nil, nil)
+	svc := plaidsvc.NewService(client, box, &fakeRepo{}, nil, nil, nil)
 
 	tok, err := svc.CreateLinkToken(context.Background(), 42)
 	if err != nil {
@@ -134,7 +138,7 @@ func TestService_ExchangePublicToken_HappyPath(t *testing.T) {
 	client, _ := plaidsvc.NewSDKClient(plaidsvc.Config{ClientID: "cid", Secret: "csec", Env: srv.URL})
 	box, _ := crypto.NewSecretBox(newTestKey())
 	repo := &fakeRepo{}
-	svc := plaidsvc.NewService(client, box, repo, nil, nil)
+	svc := plaidsvc.NewService(client, box, repo, nil, nil, nil)
 
 	item, err := svc.ExchangePublicToken(context.Background(), 7, "public-sandbox-xyz")
 	if err != nil {
@@ -173,7 +177,7 @@ func TestService_ExchangePublicToken_RejectsEmpty(t *testing.T) {
 	srv, _ := fakePlaid(t)
 	client, _ := plaidsvc.NewSDKClient(plaidsvc.Config{ClientID: "cid", Secret: "csec", Env: srv.URL})
 	box, _ := crypto.NewSecretBox(newTestKey())
-	svc := plaidsvc.NewService(client, box, &fakeRepo{}, nil, nil)
+	svc := plaidsvc.NewService(client, box, &fakeRepo{}, nil, nil, nil)
 
 	if _, err := svc.ExchangePublicToken(context.Background(), 1, "   "); err != plaidsvc.ErrInvalidPublicToken {
 		t.Fatalf("expected ErrInvalidPublicToken, got %v", err)
@@ -181,7 +185,7 @@ func TestService_ExchangePublicToken_RejectsEmpty(t *testing.T) {
 }
 
 func TestService_NotConfigured(t *testing.T) {
-	svc := plaidsvc.NewService(nil, nil, nil, nil, nil)
+	svc := plaidsvc.NewService(nil, nil, nil, nil, nil, nil)
 	if svc.Configured() {
 		t.Fatal("expected !Configured")
 	}

--- a/backend/internal/service/plaid/sync_accounts_integration_test.go
+++ b/backend/internal/service/plaid/sync_accounts_integration_test.go
@@ -209,7 +209,7 @@ func TestService_SyncAccounts_PIIIsolationAndIdempotency(t *testing.T) {
 		t.Fatalf("seed item: %v", err)
 	}
 
-	svc := plaidsvc.NewService(client, box, itemRepo, acctRepo, piiSvc)
+	svc := plaidsvc.NewService(client, box, itemRepo, acctRepo, repository.NewTransactionRepository(g), piiSvc)
 
 	// First sync: 2 accounts created.
 	r1, err := svc.SyncAccounts(context.Background(), userID, "item-fake-sync-1")
@@ -305,7 +305,7 @@ func TestService_SyncAccounts_ItemNotFound(t *testing.T) {
 	acctRepo := repository.NewAccountRepository(g)
 	acctSvc := service.NewAccountService(acctRepo)
 	piiSvc := service.NewPIIService(repository.NewPIIRepository(g), acctSvc)
-	svc := plaidsvc.NewService(client, box, itemRepo, acctRepo, piiSvc)
+	svc := plaidsvc.NewService(client, box, itemRepo, acctRepo, repository.NewTransactionRepository(g), piiSvc)
 
 	_, err := svc.SyncAccounts(context.Background(), userID, "nonexistent-item")
 	if err != plaidsvc.ErrItemNotFound {

--- a/backend/internal/service/plaid/sync_transactions_integration_test.go
+++ b/backend/internal/service/plaid/sync_transactions_integration_test.go
@@ -1,0 +1,246 @@
+package plaid_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/shopspring/decimal"
+
+	"github.com/gregwym/offbook/backend/internal/crypto"
+	"github.com/gregwym/offbook/backend/internal/model"
+	"github.com/gregwym/offbook/backend/internal/repository"
+	"github.com/gregwym/offbook/backend/internal/service"
+	plaidsvc "github.com/gregwym/offbook/backend/internal/service/plaid"
+)
+
+// fakeTxnsSyncServer returns a paginated /transactions/sync response.
+// Page 1: 2 added, has_more=true, next_cursor=page2
+// Page 2: 1 added, has_more=false, next_cursor=final
+// The same plaid_account_id maps to whatever the test wires up beforehand.
+func fakeTxnsSyncServer(t *testing.T, plaidAcctID string) (*httptest.Server, *int32) {
+	t.Helper()
+	var callCount int32
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/transactions/sync", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		n := atomic.AddInt32(&callCount, 1)
+		switch n {
+		case 1:
+			// First page: full historical pull, 2 txns
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"added": []map[string]any{
+					{
+						"transaction_id":    "ptx-001",
+						"account_id":        plaidAcctID,
+						"amount":            5.43, // Plaid: outflow positive
+						"iso_currency_code": "USD",
+						"name":              "Blue Bottle SF",
+						"merchant_name":     "Blue Bottle Coffee",
+						"date":              "2026-05-16",
+						"authorized_date":   "2026-05-15",
+						"pending":           false,
+					},
+					{
+						"transaction_id":    "ptx-002",
+						"account_id":        plaidAcctID,
+						"amount":            -2000.00, // refund / payroll
+						"iso_currency_code": "USD",
+						"name":              "Direct Deposit",
+						"date":              "2026-05-01",
+						"pending":           false,
+					},
+				},
+				"modified":    []any{},
+				"removed":     []any{},
+				"next_cursor": "page-2-cursor",
+				"has_more":    true,
+				"request_id":  "req-tx-1",
+			})
+		case 2:
+			// Second page: one more txn, end of stream
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"added": []map[string]any{
+					{
+						"transaction_id":    "ptx-003",
+						"account_id":        plaidAcctID,
+						"amount":            12.50,
+						"iso_currency_code": "USD",
+						"name":              "ATM Fee",
+						"date":              "2026-04-30",
+						"pending":           false,
+					},
+				},
+				"modified":    []any{},
+				"removed":     []any{},
+				"next_cursor": "final-cursor",
+				"has_more":    false,
+				"request_id":  "req-tx-2",
+			})
+		default:
+			// Re-sync runs after the first complete drain. Plaid returns
+			// nothing new when cursor is current.
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"added":       []any{},
+				"modified":    []any{},
+				"removed":     []any{},
+				"next_cursor": "final-cursor",
+				"has_more":    false,
+				"request_id":  "req-tx-empty",
+			})
+		}
+	})
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		t.Errorf("unexpected Plaid call: %s %s", r.Method, r.URL.Path)
+		http.Error(w, "unexpected", 500)
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv, &callCount
+}
+
+func TestService_SyncTransactions_PaginatesAndPersistsCursor(t *testing.T) {
+	g := openPlaidTestDB(t)
+	userID := seedPlaidTestUser(t, g)
+
+	// Pre-seed account + plaid_items so SyncTransactions can resolve.
+	const plaidAcctID = "pacct-sync-1"
+	acct := &model.Account{
+		UserID:          userID,
+		Name:            "Test Checking",
+		InstitutionSlug: "ins_test",
+		AccountType:     "checking",
+		Currency:        "USD",
+		PlaidAccountID:  &[]string{plaidAcctID}[0],
+		IsActive:        true,
+	}
+	if err := g.Create(acct).Error; err != nil {
+		t.Fatalf("seed account: %v", err)
+	}
+	t.Cleanup(func() {
+		g.Unscoped().Where("user_id = ?", userID).Delete(&model.Transaction{})
+		g.Unscoped().Delete(&model.Account{}, acct.ID)
+	})
+
+	srv, callCount := fakeTxnsSyncServer(t, plaidAcctID)
+
+	client, _ := plaidsvc.NewSDKClient(plaidsvc.Config{ClientID: "cid", Secret: "csec", Env: srv.URL})
+	box, _ := crypto.NewSecretBox(newTestKey())
+	itemRepo := repository.NewPlaidItemRepository(g)
+	acctRepo := repository.NewAccountRepository(g)
+	txRepo := repository.NewTransactionRepository(g)
+	piiSvc := service.NewPIIService(repository.NewPIIRepository(g), service.NewAccountService(acctRepo))
+
+	enc, _ := box.Encrypt([]byte("access-sandbox-fake"))
+	item := &model.PlaidItem{
+		UserID:         userID,
+		PlaidItemID:    "item-sync-1",
+		AccessTokenEnc: enc,
+		Status:         "active",
+	}
+	if err := itemRepo.Create(context.Background(), item); err != nil {
+		t.Fatalf("seed item: %v", err)
+	}
+
+	svc := plaidsvc.NewService(client, box, itemRepo, acctRepo, txRepo, piiSvc)
+
+	// First full pull
+	r, err := svc.SyncTransactions(context.Background(), userID, "item-sync-1")
+	if err != nil {
+		t.Fatalf("SyncTransactions: %v", err)
+	}
+	if r.Inserted != 3 {
+		t.Errorf("inserted=%d, want 3 (across 2 pages)", r.Inserted)
+	}
+	if atomic.LoadInt32(callCount) != 2 {
+		t.Errorf("server hit %d times, want 2 (full pagination drain)", *callCount)
+	}
+
+	// Cursor persisted
+	persisted, err := itemRepo.GetByPlaidItemID(context.Background(), userID, "item-sync-1")
+	if err != nil {
+		t.Fatalf("re-fetch item: %v", err)
+	}
+	if persisted.Cursor == nil || *persisted.Cursor != "final-cursor" {
+		t.Errorf("cursor = %v, want final-cursor", persisted.Cursor)
+	}
+	if persisted.LastSyncedAt == nil {
+		t.Error("last_synced_at not persisted")
+	}
+
+	// Sign convention: ptx-001 was 5.43 (outflow), stored as -5.43.
+	// ptx-002 was -2000 (inflow), stored as +2000.
+	var charge model.Transaction
+	if err := g.Where("plaid_transaction_id = ?", "ptx-001").First(&charge).Error; err != nil {
+		t.Fatalf("fetch ptx-001: %v", err)
+	}
+	if !charge.Amount.Equal(decimal.NewFromFloat(-5.43)) {
+		t.Errorf("ptx-001 amount = %s, want -5.43 (sign flipped)", charge.Amount)
+	}
+	if charge.UserID != userID || charge.AccountID != acct.ID {
+		t.Errorf("ptx-001 user/account = %d/%d, want %d/%d", charge.UserID, charge.AccountID, userID, acct.ID)
+	}
+	if charge.Source != "plaid" {
+		t.Errorf("ptx-001 source = %q", charge.Source)
+	}
+
+	var deposit model.Transaction
+	if err := g.Where("plaid_transaction_id = ?", "ptx-002").First(&deposit).Error; err != nil {
+		t.Fatalf("fetch ptx-002: %v", err)
+	}
+	if !deposit.Amount.Equal(decimal.NewFromInt(2000)) {
+		t.Errorf("ptx-002 amount = %s, want 2000 (sign flipped)", deposit.Amount)
+	}
+
+	// Re-sync: idempotent. Server returns empty on call 3.
+	r2, err := svc.SyncTransactions(context.Background(), userID, "item-sync-1")
+	if err != nil {
+		t.Fatalf("SyncTransactions #2: %v", err)
+	}
+	if r2.Inserted != 0 {
+		t.Errorf("re-sync inserted=%d, want 0", r2.Inserted)
+	}
+	var rowCount int64
+	if err := g.Model(&model.Transaction{}).
+		Where("user_id = ? AND source = 'plaid'", userID).
+		Count(&rowCount).Error; err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if rowCount != 3 {
+		t.Errorf("transactions count = %d, want 3 (no duplicates)", rowCount)
+	}
+}
+
+func TestService_SyncTransactions_UnknownAccountErrors(t *testing.T) {
+	g := openPlaidTestDB(t)
+	userID := seedPlaidTestUser(t, g)
+	srv, _ := fakeTxnsSyncServer(t, "pacct-never-discovered")
+
+	client, _ := plaidsvc.NewSDKClient(plaidsvc.Config{ClientID: "cid", Secret: "csec", Env: srv.URL})
+	box, _ := crypto.NewSecretBox(newTestKey())
+	itemRepo := repository.NewPlaidItemRepository(g)
+	acctRepo := repository.NewAccountRepository(g)
+	txRepo := repository.NewTransactionRepository(g)
+	piiSvc := service.NewPIIService(repository.NewPIIRepository(g), service.NewAccountService(acctRepo))
+
+	enc, _ := box.Encrypt([]byte("access-sandbox-fake"))
+	item := &model.PlaidItem{
+		UserID:         userID,
+		PlaidItemID:    "item-orphan",
+		AccessTokenEnc: enc,
+		Status:         "active",
+	}
+	if err := itemRepo.Create(context.Background(), item); err != nil {
+		t.Fatalf("seed item: %v", err)
+	}
+
+	svc := plaidsvc.NewService(client, box, itemRepo, acctRepo, txRepo, piiSvc)
+	_, err := svc.SyncTransactions(context.Background(), userID, "item-orphan")
+	if err == nil {
+		t.Fatal("expected error when plaid_account_id can't resolve to a local account")
+	}
+}

--- a/backend/internal/service/plaid/transaction_mapping.go
+++ b/backend/internal/service/plaid/transaction_mapping.go
@@ -1,0 +1,74 @@
+package plaid
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/gregwym/offbook/backend/internal/model"
+)
+
+// MapPlaidTransaction reshapes a Plaid transaction into our row format.
+//
+// Sign convention: Plaid returns positive amounts for money LEAVING the
+// account (a $5 coffee charge is +5.00). The project's existing manual-
+// entry conventions and tests treat negative as outflow / positive as
+// inflow. Flip the sign at the boundary so the rest of the codebase
+// (budgets, dashboard, etc.) sees a single consistent convention.
+//
+// Date convention: Plaid surfaces a single `date` (effective/posted) and
+// an optional `authorized_date` (when the user initiated). We map:
+//   - transaction_date ← Plaid `date`     (effective date — always present)
+//   - posted_date      ← Plaid `authorized_date`
+//
+// This matches issue #61's spec; the framing was a deliberate product
+// choice (effective date drives chronology; authorized_date is shown as
+// "originally swiped on" metadata).
+//
+// userID + accountID are supplied by the service after resolving the
+// session user and matching the Plaid account_id to a local accounts.id.
+func MapPlaidTransaction(p PlaidTransaction, userID, accountID int64) (model.Transaction, error) {
+	if p.PlaidTransactionID == "" {
+		return model.Transaction{}, fmt.Errorf("plaid: transaction_id empty")
+	}
+	if p.PlaidAccountID == "" {
+		return model.Transaction{}, fmt.Errorf("plaid: account_id empty for transaction %s", p.PlaidTransactionID)
+	}
+
+	txDate, err := time.Parse("2006-01-02", p.Date)
+	if err != nil {
+		return model.Transaction{}, fmt.Errorf("plaid: parse date %q: %w", p.Date, err)
+	}
+
+	var postedDate *time.Time
+	if p.AuthorizedDate != nil {
+		pd, err := time.Parse("2006-01-02", *p.AuthorizedDate)
+		if err != nil {
+			return model.Transaction{}, fmt.Errorf("plaid: parse authorized_date %q: %w", *p.AuthorizedDate, err)
+		}
+		postedDate = &pd
+	}
+
+	plaidID := p.PlaidTransactionID
+	externalID := plaidID // mirror so the project's external_id dedup index covers this too
+	source := "plaid"
+
+	var description *string
+	if p.Name != "" {
+		v := p.Name
+		description = &v
+	}
+
+	return model.Transaction{
+		UserID:             userID,
+		AccountID:          accountID,
+		Amount:             p.Amount.Neg(), // sign flip, see header
+		Currency:           p.Currency,
+		Description:        description,
+		MerchantName:       p.MerchantName,
+		TransactionDate:    txDate,
+		PostedDate:         postedDate,
+		Source:             source,
+		ExternalID:         &externalID,
+		PlaidTransactionID: &plaidID,
+	}, nil
+}

--- a/backend/internal/service/plaid/transaction_mapping_test.go
+++ b/backend/internal/service/plaid/transaction_mapping_test.go
@@ -1,0 +1,129 @@
+package plaid_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/shopspring/decimal"
+
+	plaidsvc "github.com/gregwym/offbook/backend/internal/service/plaid"
+)
+
+func TestMapPlaidTransaction_SignFlipAndDates(t *testing.T) {
+	authDate := "2026-05-15"
+	merchant := "Blue Bottle Coffee"
+	in := plaidsvc.PlaidTransaction{
+		PlaidTransactionID: "ptx-1",
+		PlaidAccountID:     "pacct-1",
+		Amount:             decimal.NewFromFloat(5.43), // Plaid: positive = outflow
+		Currency:           "USD",
+		Name:               "Blue Bottle SF",
+		MerchantName:       &merchant,
+		Date:               "2026-05-16",
+		AuthorizedDate:     &authDate,
+	}
+	got, err := plaidsvc.MapPlaidTransaction(in, 7, 42)
+	if err != nil {
+		t.Fatalf("MapPlaidTransaction: %v", err)
+	}
+
+	if got.UserID != 7 || got.AccountID != 42 {
+		t.Errorf("user/account = %d/%d, want 7/42", got.UserID, got.AccountID)
+	}
+	// Sign flip: 5.43 → -5.43
+	if !got.Amount.Equal(decimal.NewFromFloat(-5.43)) {
+		t.Errorf("amount = %s, want -5.43 (sign flipped)", got.Amount.String())
+	}
+	if got.Source != "plaid" {
+		t.Errorf("source = %q, want plaid", got.Source)
+	}
+	if got.PlaidTransactionID == nil || *got.PlaidTransactionID != "ptx-1" {
+		t.Errorf("plaid_transaction_id = %v", got.PlaidTransactionID)
+	}
+	if got.ExternalID == nil || *got.ExternalID != "ptx-1" {
+		t.Errorf("external_id = %v (should mirror plaid_transaction_id)", got.ExternalID)
+	}
+	if got.Description == nil || *got.Description != "Blue Bottle SF" {
+		t.Errorf("description = %v", got.Description)
+	}
+	if got.MerchantName == nil || *got.MerchantName != "Blue Bottle Coffee" {
+		t.Errorf("merchant = %v", got.MerchantName)
+	}
+	if got.TransactionDate.Format("2006-01-02") != "2026-05-16" {
+		t.Errorf("transaction_date = %s", got.TransactionDate)
+	}
+	if got.PostedDate == nil || got.PostedDate.Format("2006-01-02") != "2026-05-15" {
+		t.Errorf("posted_date = %v", got.PostedDate)
+	}
+}
+
+func TestMapPlaidTransaction_NilAuthorizedDate(t *testing.T) {
+	in := plaidsvc.PlaidTransaction{
+		PlaidTransactionID: "ptx-2",
+		PlaidAccountID:     "pacct-1",
+		Amount:             decimal.NewFromFloat(-100), // refund: Plaid negative = inflow
+		Currency:           "USD",
+		Name:               "Payroll deposit",
+		Date:               "2026-05-01",
+	}
+	got, err := plaidsvc.MapPlaidTransaction(in, 1, 2)
+	if err != nil {
+		t.Fatalf("MapPlaidTransaction: %v", err)
+	}
+	if !got.Amount.Equal(decimal.NewFromInt(100)) {
+		t.Errorf("amount = %s, want 100 (refund: sign flipped to positive)", got.Amount.String())
+	}
+	if got.PostedDate != nil {
+		t.Errorf("posted_date = %v, want nil when authorized_date absent", got.PostedDate)
+	}
+}
+
+func TestMapPlaidTransaction_PrecisionPreserved(t *testing.T) {
+	in := plaidsvc.PlaidTransaction{
+		PlaidTransactionID: "ptx-3",
+		PlaidAccountID:     "pacct-1",
+		// Choose a value that hurts when round-tripped through float.
+		Amount:   decimal.RequireFromString("0.123456789012345"),
+		Currency: "USD",
+		Name:     "Micro txn",
+		Date:     "2026-05-01",
+	}
+	got, err := plaidsvc.MapPlaidTransaction(in, 1, 2)
+	if err != nil {
+		t.Fatalf("MapPlaidTransaction: %v", err)
+	}
+	want := decimal.RequireFromString("-0.123456789012345")
+	if !got.Amount.Equal(want) {
+		t.Errorf("amount precision lost: got %s, want %s", got.Amount, want)
+	}
+}
+
+func TestMapPlaidTransaction_RejectsBadDate(t *testing.T) {
+	in := plaidsvc.PlaidTransaction{
+		PlaidTransactionID: "ptx-bad",
+		PlaidAccountID:     "pacct-1",
+		Amount:             decimal.NewFromInt(1),
+		Date:               "not-a-date",
+	}
+	if _, err := plaidsvc.MapPlaidTransaction(in, 1, 2); err == nil {
+		t.Fatal("expected parse error for malformed date")
+	}
+}
+
+// Sanity check the year field of an existing time so the date column
+// won't be silently typed as something weird.
+func TestMapPlaidTransaction_DateIsUTC(t *testing.T) {
+	in := plaidsvc.PlaidTransaction{
+		PlaidTransactionID: "ptx-tz",
+		PlaidAccountID:     "pacct-1",
+		Amount:             decimal.NewFromInt(1),
+		Date:               "2026-01-31",
+	}
+	got, err := plaidsvc.MapPlaidTransaction(in, 1, 2)
+	if err != nil {
+		t.Fatalf("MapPlaidTransaction: %v", err)
+	}
+	if got.TransactionDate.Location() != time.UTC {
+		t.Errorf("transaction_date location = %v, want UTC", got.TransactionDate.Location())
+	}
+}


### PR DESCRIPTION
## Summary
- New endpoint: \`POST /api/v1/plaid/items/:item_id/sync-transactions\`
- Paginates \`/transactions/sync\` until \`has_more=false\`, batch-inserts into \`transactions\`
- Sign-flip at the boundary: Plaid's positive-debit convention → project's negative-outflow (see \`transaction_mapping.go\` header)
- Cursor + \`last_synced_at\` persisted on \`plaid_items\` per page
- Bulk insert via \`ON CONFLICT (plaid_transaction_id) DO NOTHING\` (with \`TargetWhere\` matching the partial unique index — Postgres requires the exact predicate)
- \`shopspring/decimal\` end-to-end; precision-preservation test included

## Smoke against real Plaid sandbox (ins_109508)
- 12 accounts discovered, then 48 transactions synced
- 42 outflows + 6 inflows — sign convention correct
- \`cursor\` and \`last_synced_at\` set; re-sync returned \`inserted=0\` (idempotent)

## Test plan
- [ ] CI green (lint + tests + frontend build)

## Notes
- The auth tests' \`TRUNCATE\` predates plaid_items but works via the CASCADE on \`users\` (FK). One flake during full-suite run was a Postgres FS "Permission denied" error — re-run was clean. Not blocking; flagged for awareness.
- No \`db.Transaction\` wrap — same justification as #60: Plaid sync is externally-driven, naturally idempotent, partial-failure self-heals on next run.

Closes #61