### PR TITLE
M3 #62: Plaid /transactions/sync — incremental (modified/removed + atomic cursor)

### DIFF
--- a/backend/internal/repository/transaction_repo.go
+++ b/backend/internal/repository/transaction_repo.go
@@ -38,6 +38,20 @@ type TransactionRepository interface {
 	// Returns the number of rows actually inserted — caller compares that
 	// to len(txns) to derive "skipped as duplicate" if needed.
 	CreateBatch(ctx context.Context, txns []model.Transaction) (int64, error)
+	// UpdateByPlaidTransactionID overwrites a row keyed by user_id +
+	// plaid_transaction_id. The caller supplies the post-merge row; this
+	// repo does not enforce field-level merge semantics — see
+	// plaid.MergePlaidUpdate for the policy.
+	// Returns ErrNotFound if no matching row exists (e.g. a `modified`
+	// for a transaction we never saw because it was added+modified+removed
+	// across syncs).
+	UpdateByPlaidTransactionID(ctx context.Context, userID int64, plaidTxnID string, merged model.Transaction) error
+	// SoftDeleteByPlaidTransactionID flips deleted_at for a transaction
+	// matched by user_id + plaid_transaction_id. Returns ErrNotFound when
+	// no live row exists. Idempotent: re-applying on an already-deleted
+	// row returns ErrNotFound (because the soft-delete partial index
+	// hides the row from the scope).
+	SoftDeleteByPlaidTransactionID(ctx context.Context, userID int64, plaidTxnID string) error
 }
 
 type transactionRepo struct {
@@ -146,6 +160,48 @@ func (r *transactionRepo) CreateBatch(ctx context.Context, txns []model.Transact
 		return 0, res.Error
 	}
 	return res.RowsAffected, nil
+}
+
+func (r *transactionRepo) UpdateByPlaidTransactionID(ctx context.Context, userID int64, plaidTxnID string, merged model.Transaction) error {
+	// Save() needs the row's ID populated to issue an UPDATE rather than
+	// an INSERT; callers should be passing the merged row from a prior
+	// read so ID is set. Defensive: re-resolve if it isn't.
+	if merged.ID == 0 {
+		var existing model.Transaction
+		if err := r.db.WithContext(ctx).
+			Where("user_id = ? AND plaid_transaction_id = ?", userID, plaidTxnID).
+			First(&existing).Error; err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				return ErrNotFound
+			}
+			return err
+		}
+		merged.ID = existing.ID
+		merged.CreatedAt = existing.CreatedAt
+	}
+	res := r.db.WithContext(ctx).
+		Where("user_id = ? AND plaid_transaction_id = ?", userID, plaidTxnID).
+		Save(&merged)
+	if res.Error != nil {
+		return res.Error
+	}
+	if res.RowsAffected == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+func (r *transactionRepo) SoftDeleteByPlaidTransactionID(ctx context.Context, userID int64, plaidTxnID string) error {
+	res := r.db.WithContext(ctx).
+		Where("user_id = ? AND plaid_transaction_id = ?", userID, plaidTxnID).
+		Delete(&model.Transaction{})
+	if res.Error != nil {
+		return res.Error
+	}
+	if res.RowsAffected == 0 {
+		return ErrNotFound
+	}
+	return nil
 }
 
 func (r *transactionRepo) SoftDelete(ctx context.Context, userID, id int64) error {

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -118,7 +118,7 @@ func newPlaidService(
 	piiSvc *service.PIIService,
 ) *plaidsvc.Service {
 	if !cfg.PlaidConfigured() {
-		return plaidsvc.NewService(nil, nil, nil, nil, nil, nil)
+		return plaidsvc.NewService(nil, nil, nil, nil, nil, nil, nil)
 	}
 	client, err := plaidsvc.NewSDKClient(plaidsvc.Config{
 		ClientID: cfg.PlaidClientID,
@@ -139,6 +139,7 @@ func newPlaidService(
 		acctRepo,
 		txRepo,
 		piiSvc,
+		gormDB,
 	)
 }
 

--- a/backend/internal/service/plaid/merge_update_test.go
+++ b/backend/internal/service/plaid/merge_update_test.go
@@ -1,0 +1,123 @@
+package plaid_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/shopspring/decimal"
+
+	"github.com/gregwym/offbook/backend/internal/model"
+	plaidsvc "github.com/gregwym/offbook/backend/internal/service/plaid"
+)
+
+func TestMergePlaidUpdate_PendingToPosted(t *testing.T) {
+	// Existing pending row: user has already categorized it and added a note.
+	categoryID := int64(42)
+	notes := "Date night with Sam"
+	existing := model.Transaction{
+		ID:                 999,
+		UserID:             7,
+		AccountID:          11,
+		Amount:             decimal.NewFromFloat(-50.00), // initial pending amount
+		Currency:           "USD",
+		Description:        ptr("Restaurant pending"),
+		TransactionDate:    mustDate("2026-05-10"),
+		Source:             "plaid",
+		PlaidTransactionID: ptr("ptx-1"),
+		CategoryID:         &categoryID,
+		Notes:              &notes,
+		IsTransfer:         false,
+	}
+
+	// Plaid now reports the cleared amount and a different merchant name.
+	auth := "2026-05-10"
+	merchant := "Tartine SF"
+	incoming := plaidsvc.PlaidTransaction{
+		PlaidTransactionID: "ptx-1",
+		PlaidAccountID:     "pacct-1",
+		Amount:             decimal.NewFromFloat(52.13), // posted (Plaid +ve = outflow)
+		Currency:           "USD",
+		Name:               "TARTINE BAKERY",
+		MerchantName:       &merchant,
+		Date:               "2026-05-11", // settled date
+		AuthorizedDate:     &auth,
+	}
+
+	merged, err := plaidsvc.MergePlaidUpdate(existing, incoming, 11)
+	if err != nil {
+		t.Fatalf("MergePlaidUpdate: %v", err)
+	}
+
+	// Plaid fields overwritten.
+	if !merged.Amount.Equal(decimal.NewFromFloat(-52.13)) {
+		t.Errorf("amount = %s, want -52.13 (sign-flipped from 52.13)", merged.Amount)
+	}
+	if merged.Description == nil || *merged.Description != "TARTINE BAKERY" {
+		t.Errorf("description = %v, want TARTINE BAKERY", merged.Description)
+	}
+	if merged.MerchantName == nil || *merged.MerchantName != "Tartine SF" {
+		t.Errorf("merchant = %v", merged.MerchantName)
+	}
+	if merged.TransactionDate.Format("2006-01-02") != "2026-05-11" {
+		t.Errorf("transaction_date = %s", merged.TransactionDate)
+	}
+	if merged.PostedDate == nil || merged.PostedDate.Format("2006-01-02") != "2026-05-10" {
+		t.Errorf("posted_date = %v", merged.PostedDate)
+	}
+
+	// User-edited fields preserved.
+	if merged.CategoryID == nil || *merged.CategoryID != 42 {
+		t.Errorf("category_id = %v, want 42 (preserved)", merged.CategoryID)
+	}
+	if merged.Notes == nil || *merged.Notes != "Date night with Sam" {
+		t.Errorf("notes = %v, want preserved", merged.Notes)
+	}
+	// Identity fields preserved.
+	if merged.ID != 999 || merged.UserID != 7 {
+		t.Errorf("identity fields rewritten: id=%d user=%d", merged.ID, merged.UserID)
+	}
+}
+
+func TestMergePlaidUpdate_NilFieldsClearable(t *testing.T) {
+	// Edge case: existing row has a merchant_name, Plaid removes it
+	// (their data refresh dropped it). We want the merged row to also
+	// drop the merchant_name — Plaid is authoritative for that field.
+	prior := "Old Merchant"
+	existing := model.Transaction{
+		ID:                 1,
+		UserID:             1,
+		AccountID:          1,
+		Amount:             decimal.NewFromFloat(-1),
+		Currency:           "USD",
+		MerchantName:       &prior,
+		TransactionDate:    mustDate("2026-05-10"),
+		Source:             "plaid",
+		PlaidTransactionID: ptr("ptx-x"),
+	}
+	incoming := plaidsvc.PlaidTransaction{
+		PlaidTransactionID: "ptx-x",
+		PlaidAccountID:     "pacct-1",
+		Amount:             decimal.NewFromFloat(1),
+		Currency:           "USD",
+		Name:               "X",
+		Date:               "2026-05-10",
+		// MerchantName intentionally nil
+	}
+	merged, err := plaidsvc.MergePlaidUpdate(existing, incoming, 1)
+	if err != nil {
+		t.Fatalf("MergePlaidUpdate: %v", err)
+	}
+	if merged.MerchantName != nil {
+		t.Errorf("merchant_name = %v, want nil (Plaid is authoritative)", merged.MerchantName)
+	}
+}
+
+func ptr[T any](v T) *T { return &v }
+
+func mustDate(s string) time.Time {
+	t, err := time.Parse("2006-01-02", s)
+	if err != nil {
+		panic(err)
+	}
+	return t
+}

--- a/backend/internal/service/plaid/service.go
+++ b/backend/internal/service/plaid/service.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"time"
 
+	"gorm.io/gorm"
+
 	"github.com/gregwym/offbook/backend/internal/crypto"
 	"github.com/gregwym/offbook/backend/internal/model"
 	"github.com/gregwym/offbook/backend/internal/repository"
@@ -61,13 +63,21 @@ type Service struct {
 	acctRepo repository.AccountRepository
 	txRepo   repository.TransactionRepository
 	piiSvc   *service.PIIService
+	// db is a deliberate exception to the "services don't see *gorm.DB"
+	// guideline. SyncTransactions needs a single atomic wrap across
+	// transactions + plaid_items updates per ADR-N/A (per-item sync is
+	// all-or-nothing — see issue #62 spec) and the repo abstraction
+	// doesn't currently expose a unit-of-work surface. Inside the
+	// transaction callback we construct fresh tx-bound repo instances
+	// so all writes hit the same transaction.
+	db *gorm.DB
 }
 
 // NewService constructs a Service. Pass nil for client/box/repos to
 // indicate the instance is not Plaid-enabled — calls then return
-// ErrNotConfigured. txRepo and piiSvc are only needed for the discovery
-// and transaction-sync surfaces; link-only setups can pass nil and the
-// affected methods will error out cleanly.
+// ErrNotConfigured. txRepo, piiSvc, and db are only needed for the
+// discovery and transaction-sync surfaces; link-only setups can pass nil
+// and the affected methods will error out cleanly.
 func NewService(
 	client Client,
 	box *crypto.SecretBox,
@@ -75,6 +85,7 @@ func NewService(
 	acctRepo repository.AccountRepository,
 	txRepo repository.TransactionRepository,
 	piiSvc *service.PIIService,
+	db *gorm.DB,
 ) *Service {
 	return &Service{
 		client:   client,
@@ -83,6 +94,7 @@ func NewService(
 		acctRepo: acctRepo,
 		txRepo:   txRepo,
 		piiSvc:   piiSvc,
+		db:       db,
 	}
 }
 
@@ -287,20 +299,23 @@ func zeroBytes(b []byte) {
 	}
 }
 
-// SyncTransactions paginates /transactions/sync for the given item,
-// translating each page through MapPlaidTransaction and bulk-inserting
-// into the transactions table. The cursor + last_synced_at on the item
-// are updated after EVERY page so a crash mid-pull resumes cleanly.
+// SyncTransactions runs /transactions/sync for the given item. Works
+// identically for the first-time historical pull (empty cursor) and for
+// incremental refreshes (persisted cursor) — the same Plaid endpoint
+// covers both via the cursor handshake.
 //
-// First-time pull: pass an item whose cursor is empty. Subsequent runs
-// re-use the persisted cursor and only fetch deltas. The sign convention
-// flip and date mapping happen in MapPlaidTransaction.
+// Per #62, the entire per-item sync is wrapped in one db.Transaction:
+//   - all pages are drained from Plaid first (no DB writes)
+//   - then `added` rows are inserted, `modified` rows merged into existing
+//     rows (preserving user-edited category_id / notes), and `removed`
+//     rows soft-deleted
+//   - cursor + last_synced_at advance ONLY if all of the above succeed
 //
-// Idempotency: the bulk insert uses ON CONFLICT (plaid_transaction_id)
-// DO NOTHING, so re-running against the same upstream is a no-op rather
-// than an error.
+// If anything in the DB phase fails, the cursor stays put and next run
+// re-fetches the same delta — safe because added uses ON CONFLICT DO
+// NOTHING and modified/removed are idempotent on plaid_transaction_id.
 func (s *Service) SyncTransactions(ctx context.Context, userID int64, plaidItemID string) (SyncTransactionsResult, error) {
-	if !s.Configured() || s.acctRepo == nil || s.txRepo == nil {
+	if !s.Configured() || s.acctRepo == nil || s.txRepo == nil || s.db == nil {
 		return SyncTransactionsResult{}, ErrNotConfigured
 	}
 
@@ -324,60 +339,137 @@ func (s *Service) SyncTransactions(ctx context.Context, userID int64, plaidItemI
 		cursor = *item.Cursor
 	}
 
-	// Cache plaid_account_id → local accounts.id lookups so we don't hit
-	// the DB once per transaction. The same accountID-resolution miss is
-	// also surfaced as an error so we don't silently drop transactions
-	// belonging to an account that wasn't discovered first.
-	accountIDByPlaidID := map[string]int64{}
-
-	var result SyncTransactionsResult
+	// Phase 1: drain every page from Plaid into memory. No DB writes
+	// happen here so a Plaid failure can't leave the DB half-updated.
+	var added, modified []PlaidTransaction
+	var removed []string
 	for {
 		page, err := s.client.SyncTransactions(ctx, accessToken, cursor)
 		if err != nil {
-			return result, err
+			return SyncTransactionsResult{}, err
 		}
-
-		batch := make([]model.Transaction, 0, len(page.Added))
-		for _, pt := range page.Added {
-			localID, err := s.resolveAccountID(ctx, userID, pt.PlaidAccountID, accountIDByPlaidID)
-			if err != nil {
-				return result, err
-			}
-			row, err := MapPlaidTransaction(pt, userID, localID)
-			if err != nil {
-				return result, err
-			}
-			batch = append(batch, row)
-		}
-		if len(batch) > 0 {
-			n, err := s.txRepo.CreateBatch(ctx, batch)
-			if err != nil {
-				return result, fmt.Errorf("plaid: insert batch: %w", err)
-			}
-			result.Inserted += n
-		}
-		result.Modified += len(page.Modified)
-		result.Removed += len(page.Removed)
-
+		added = append(added, page.Added...)
+		modified = append(modified, page.Modified...)
+		removed = append(removed, page.Removed...)
 		cursor = page.NextCursor
-		if err := s.itemRepo.UpdateCursor(ctx, userID, item.ID, cursor, time.Now().UTC()); err != nil {
-			return result, fmt.Errorf("plaid: persist cursor: %w", err)
-		}
 		if !page.HasMore {
 			break
 		}
+	}
+
+	var result SyncTransactionsResult
+	// Phase 2: one transaction for all writes. Tx-bound repos so every
+	// statement hits the same Postgres transaction; rollback on any error
+	// reverts the entire sync including the cursor advance.
+	err = s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		txRepo := repository.NewTransactionRepository(tx)
+		itemRepo := repository.NewPlaidItemRepository(tx)
+		acctRepo := repository.NewAccountRepository(tx)
+		accountIDCache := map[string]int64{}
+
+		// Inserts (uses ON CONFLICT DO NOTHING — defense in depth on top
+		// of the partial unique index).
+		if len(added) > 0 {
+			batch := make([]model.Transaction, 0, len(added))
+			for _, pt := range added {
+				localID, err := resolveAccountID(ctx, acctRepo, userID, pt.PlaidAccountID, accountIDCache)
+				if err != nil {
+					return err
+				}
+				row, err := MapPlaidTransaction(pt, userID, localID)
+				if err != nil {
+					return err
+				}
+				batch = append(batch, row)
+			}
+			n, err := txRepo.CreateBatch(ctx, batch)
+			if err != nil {
+				return fmt.Errorf("plaid: insert batch: %w", err)
+			}
+			result.Inserted = n
+		}
+
+		// Modifications: merge with the existing row so user-edited
+		// fields survive.
+		for _, pt := range modified {
+			localID, err := resolveAccountID(ctx, acctRepo, userID, pt.PlaidAccountID, accountIDCache)
+			if err != nil {
+				return err
+			}
+			var existing model.Transaction
+			err = tx.WithContext(ctx).
+				Where("user_id = ? AND plaid_transaction_id = ?", userID, pt.PlaidTransactionID).
+				First(&existing).Error
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				// Plaid sent a `modified` for something we never
+				// recorded. Treat as a fresh insert so we don't lose it.
+				row, mapErr := MapPlaidTransaction(pt, userID, localID)
+				if mapErr != nil {
+					return mapErr
+				}
+				if _, batchErr := txRepo.CreateBatch(ctx, []model.Transaction{row}); batchErr != nil {
+					return fmt.Errorf("plaid: insert modified-as-new: %w", batchErr)
+				}
+				result.Inserted++
+				continue
+			}
+			if err != nil {
+				return fmt.Errorf("plaid: read existing for modify: %w", err)
+			}
+			merged, err := MergePlaidUpdate(existing, pt, localID)
+			if err != nil {
+				return err
+			}
+			if err := txRepo.UpdateByPlaidTransactionID(ctx, userID, pt.PlaidTransactionID, merged); err != nil {
+				return fmt.Errorf("plaid: update modified: %w", err)
+			}
+			result.Modified++
+		}
+
+		// Removals: soft-delete. ErrNotFound is benign (already deleted
+		// or never seen) and shouldn't roll back the transaction.
+		for _, ptxID := range removed {
+			err := txRepo.SoftDeleteByPlaidTransactionID(ctx, userID, ptxID)
+			switch {
+			case errors.Is(err, repository.ErrNotFound):
+				// Already gone — count it anyway so the response number
+				// matches what Plaid asked us to forget.
+				result.Removed++
+			case err != nil:
+				return fmt.Errorf("plaid: soft-delete removed: %w", err)
+			default:
+				result.Removed++
+			}
+		}
+
+		// Cursor advance — final write inside the same transaction.
+		if err := itemRepo.UpdateCursor(ctx, userID, item.ID, cursor, time.Now().UTC()); err != nil {
+			return fmt.Errorf("plaid: persist cursor: %w", err)
+		}
+		return nil
+	})
+	if err != nil {
+		return SyncTransactionsResult{}, err
 	}
 	return result, nil
 }
 
 // resolveAccountID maps a Plaid account_id to the local accounts.id,
-// memoizing in the per-call cache. Returns an error if no local account
-// exists — the caller should run /sync-accounts first.
-func (s *Service) resolveAccountID(ctx context.Context, userID int64, plaidAcctID string, cache map[string]int64) (int64, error) {
+// memoizing in a per-call cache. Returns an error if no local account
+// exists — the caller should run /sync-accounts first. Operates against
+// the supplied AccountRepository so transactional callers can pass a
+// tx-bound instance.
+func resolveAccountID(
+	ctx context.Context,
+	repo repository.AccountRepository,
+	userID int64,
+	plaidAcctID string,
+	cache map[string]int64,
+) (int64, error) {
 	if id, ok := cache[plaidAcctID]; ok {
 		return id, nil
 	}
-	a, err := s.acctRepo.FindByPlaidAccountID(ctx, userID, plaidAcctID)
+	a, err := repo.FindByPlaidAccountID(ctx, userID, plaidAcctID)
 	if err != nil {
 		if errors.Is(err, repository.ErrNotFound) {
 			return 0, fmt.Errorf("plaid: no local account for plaid_account_id=%s (run sync-accounts first)", plaidAcctID)

--- a/backend/internal/service/plaid/service_test.go
+++ b/backend/internal/service/plaid/service_test.go
@@ -113,7 +113,7 @@ func TestService_CreateLinkToken_HappyPath(t *testing.T) {
 	if err != nil {
 		t.Fatalf("secretbox: %v", err)
 	}
-	svc := plaidsvc.NewService(client, box, &fakeRepo{}, nil, nil, nil)
+	svc := plaidsvc.NewService(client, box, &fakeRepo{}, nil, nil, nil, nil)
 
 	tok, err := svc.CreateLinkToken(context.Background(), 42)
 	if err != nil {
@@ -138,7 +138,7 @@ func TestService_ExchangePublicToken_HappyPath(t *testing.T) {
 	client, _ := plaidsvc.NewSDKClient(plaidsvc.Config{ClientID: "cid", Secret: "csec", Env: srv.URL})
 	box, _ := crypto.NewSecretBox(newTestKey())
 	repo := &fakeRepo{}
-	svc := plaidsvc.NewService(client, box, repo, nil, nil, nil)
+	svc := plaidsvc.NewService(client, box, repo, nil, nil, nil, nil)
 
 	item, err := svc.ExchangePublicToken(context.Background(), 7, "public-sandbox-xyz")
 	if err != nil {
@@ -177,7 +177,7 @@ func TestService_ExchangePublicToken_RejectsEmpty(t *testing.T) {
 	srv, _ := fakePlaid(t)
 	client, _ := plaidsvc.NewSDKClient(plaidsvc.Config{ClientID: "cid", Secret: "csec", Env: srv.URL})
 	box, _ := crypto.NewSecretBox(newTestKey())
-	svc := plaidsvc.NewService(client, box, &fakeRepo{}, nil, nil, nil)
+	svc := plaidsvc.NewService(client, box, &fakeRepo{}, nil, nil, nil, nil)
 
 	if _, err := svc.ExchangePublicToken(context.Background(), 1, "   "); err != plaidsvc.ErrInvalidPublicToken {
 		t.Fatalf("expected ErrInvalidPublicToken, got %v", err)
@@ -185,7 +185,7 @@ func TestService_ExchangePublicToken_RejectsEmpty(t *testing.T) {
 }
 
 func TestService_NotConfigured(t *testing.T) {
-	svc := plaidsvc.NewService(nil, nil, nil, nil, nil, nil)
+	svc := plaidsvc.NewService(nil, nil, nil, nil, nil, nil, nil)
 	if svc.Configured() {
 		t.Fatal("expected !Configured")
 	}

--- a/backend/internal/service/plaid/sync_accounts_integration_test.go
+++ b/backend/internal/service/plaid/sync_accounts_integration_test.go
@@ -209,7 +209,7 @@ func TestService_SyncAccounts_PIIIsolationAndIdempotency(t *testing.T) {
 		t.Fatalf("seed item: %v", err)
 	}
 
-	svc := plaidsvc.NewService(client, box, itemRepo, acctRepo, repository.NewTransactionRepository(g), piiSvc)
+	svc := plaidsvc.NewService(client, box, itemRepo, acctRepo, repository.NewTransactionRepository(g), piiSvc, g)
 
 	// First sync: 2 accounts created.
 	r1, err := svc.SyncAccounts(context.Background(), userID, "item-fake-sync-1")
@@ -305,7 +305,7 @@ func TestService_SyncAccounts_ItemNotFound(t *testing.T) {
 	acctRepo := repository.NewAccountRepository(g)
 	acctSvc := service.NewAccountService(acctRepo)
 	piiSvc := service.NewPIIService(repository.NewPIIRepository(g), acctSvc)
-	svc := plaidsvc.NewService(client, box, itemRepo, acctRepo, repository.NewTransactionRepository(g), piiSvc)
+	svc := plaidsvc.NewService(client, box, itemRepo, acctRepo, repository.NewTransactionRepository(g), piiSvc, g)
 
 	_, err := svc.SyncAccounts(context.Background(), userID, "nonexistent-item")
 	if err != plaidsvc.ErrItemNotFound {

--- a/backend/internal/service/plaid/sync_transactions_incremental_test.go
+++ b/backend/internal/service/plaid/sync_transactions_incremental_test.go
@@ -1,0 +1,360 @@
+package plaid_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/shopspring/decimal"
+
+	"github.com/gregwym/offbook/backend/internal/crypto"
+	"github.com/gregwym/offbook/backend/internal/model"
+	"github.com/gregwym/offbook/backend/internal/repository"
+	"github.com/gregwym/offbook/backend/internal/service"
+	plaidsvc "github.com/gregwym/offbook/backend/internal/service/plaid"
+)
+
+// fakeIncrementalServer responds to /transactions/sync with a single page
+// containing 1 added / 1 modified / 1 removed. Asserts that the request
+// body carries the persisted cursor (so we know incremental mode kicked in).
+func fakeIncrementalServer(t *testing.T, plaidAcctID, modifiedTxnID, removedTxnID, expectCursor string) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/transactions/sync", func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		if got, _ := body["cursor"].(string); got != expectCursor {
+			t.Errorf("incremental sync cursor = %q, want %q", got, expectCursor)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"added": []map[string]any{
+				{
+					"transaction_id":    "ptx-new-1",
+					"account_id":        plaidAcctID,
+					"amount":            7.77,
+					"iso_currency_code": "USD",
+					"name":              "Fresh Charge",
+					"date":              "2026-05-17",
+					"pending":           false,
+				},
+			},
+			"modified": []map[string]any{
+				{
+					"transaction_id":    modifiedTxnID,
+					"account_id":        plaidAcctID,
+					"amount":            55.55, // changed from prior amount
+					"iso_currency_code": "USD",
+					"name":              "Updated description",
+					"date":              "2026-05-12",
+					"pending":           false,
+				},
+			},
+			"removed": []map[string]any{
+				{"transaction_id": removedTxnID},
+			},
+			"next_cursor": "incremental-next-cursor",
+			"has_more":    false,
+			"request_id":  "req-incr",
+		})
+	})
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		t.Errorf("unexpected Plaid call: %s %s", r.Method, r.URL.Path)
+		http.Error(w, "unexpected", 500)
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func TestService_SyncTransactions_IncrementalAddedModifiedRemoved(t *testing.T) {
+	g := openPlaidTestDB(t)
+	userID := seedPlaidTestUser(t, g)
+	const plaidAcctID = "pacct-incr-1"
+	const priorCursor = "cursor-from-prior-sync"
+
+	// Pre-seed an account and three existing Plaid-sourced transactions.
+	// One will be modified (with a user-set category_id + notes that must
+	// survive), one will be removed (soft-deleted), one is untouched.
+	acct := &model.Account{
+		UserID:          userID,
+		Name:            "Test Account",
+		InstitutionSlug: "ins_test",
+		AccountType:     "checking",
+		Currency:        "USD",
+		PlaidAccountID:  &[]string{plaidAcctID}[0],
+		IsActive:        true,
+	}
+	if err := g.Create(acct).Error; err != nil {
+		t.Fatalf("seed account: %v", err)
+	}
+
+	// Seed a category for the "user already categorized" case.
+	cat := &model.Category{Name: "TestCat-Incr", Slug: "test-cat-incr"}
+	if err := g.Create(cat).Error; err != nil {
+		t.Fatalf("seed category: %v", err)
+	}
+
+	priorAmount := decimal.NewFromFloat(-50.00)
+	categoryID := cat.ID
+	priorNotes := "User note that must survive"
+	modified := &model.Transaction{
+		UserID:             userID,
+		AccountID:          acct.ID,
+		Amount:             priorAmount,
+		Currency:           "USD",
+		Description:        ptr("Pending charge"),
+		TransactionDate:    mustDate("2026-05-10"),
+		Source:             "plaid",
+		PlaidTransactionID: ptr("ptx-to-modify"),
+		ExternalID:         ptr("ptx-to-modify"),
+		CategoryID:         &categoryID,
+		Notes:              &priorNotes,
+	}
+	removed := &model.Transaction{
+		UserID:             userID,
+		AccountID:          acct.ID,
+		Amount:             decimal.NewFromFloat(-10.00),
+		Currency:           "USD",
+		Description:        ptr("Will be removed"),
+		TransactionDate:    mustDate("2026-05-09"),
+		Source:             "plaid",
+		PlaidTransactionID: ptr("ptx-to-remove"),
+		ExternalID:         ptr("ptx-to-remove"),
+	}
+	untouched := &model.Transaction{
+		UserID:             userID,
+		AccountID:          acct.ID,
+		Amount:             decimal.NewFromFloat(-1.00),
+		Currency:           "USD",
+		Description:        ptr("Survives"),
+		TransactionDate:    mustDate("2026-05-08"),
+		Source:             "plaid",
+		PlaidTransactionID: ptr("ptx-untouched"),
+		ExternalID:         ptr("ptx-untouched"),
+	}
+	for _, row := range []*model.Transaction{modified, removed, untouched} {
+		if err := g.Create(row).Error; err != nil {
+			t.Fatalf("seed tx: %v", err)
+		}
+	}
+	t.Cleanup(func() {
+		g.Unscoped().Where("user_id = ?", userID).Delete(&model.Transaction{})
+		g.Unscoped().Delete(&model.Account{}, acct.ID)
+		g.Unscoped().Delete(&model.Category{}, cat.ID)
+	})
+
+	// Pre-seed plaid_items with a stored cursor so the request body carries it.
+	box, _ := crypto.NewSecretBox(newTestKey())
+	enc, _ := box.Encrypt([]byte("access-sandbox-fake"))
+	cursorVal := priorCursor
+	item := &model.PlaidItem{
+		UserID:         userID,
+		PlaidItemID:    "item-incr-1",
+		AccessTokenEnc: enc,
+		Status:         "active",
+		Cursor:         &cursorVal,
+	}
+	if err := g.Create(item).Error; err != nil {
+		t.Fatalf("seed item: %v", err)
+	}
+
+	srv := fakeIncrementalServer(t, plaidAcctID, "ptx-to-modify", "ptx-to-remove", priorCursor)
+	client, _ := plaidsvc.NewSDKClient(plaidsvc.Config{ClientID: "cid", Secret: "csec", Env: srv.URL})
+	itemRepo := repository.NewPlaidItemRepository(g)
+	acctRepo := repository.NewAccountRepository(g)
+	txRepo := repository.NewTransactionRepository(g)
+	piiSvc := service.NewPIIService(repository.NewPIIRepository(g), service.NewAccountService(acctRepo))
+	svc := plaidsvc.NewService(client, box, itemRepo, acctRepo, txRepo, piiSvc, g)
+
+	r, err := svc.SyncTransactions(context.Background(), userID, "item-incr-1")
+	if err != nil {
+		t.Fatalf("SyncTransactions: %v", err)
+	}
+	if r.Inserted != 1 || r.Modified != 1 || r.Removed != 1 {
+		t.Errorf("inserted=%d modified=%d removed=%d, want 1/1/1", r.Inserted, r.Modified, r.Removed)
+	}
+
+	// Added: brand-new row exists.
+	var added model.Transaction
+	if err := g.Where("plaid_transaction_id = ?", "ptx-new-1").First(&added).Error; err != nil {
+		t.Fatalf("fetch added: %v", err)
+	}
+	if !added.Amount.Equal(decimal.NewFromFloat(-7.77)) {
+		t.Errorf("added amount = %s, want -7.77", added.Amount)
+	}
+
+	// Modified: amount updated; user-set category_id + notes preserved.
+	var afterMod model.Transaction
+	if err := g.Where("plaid_transaction_id = ?", "ptx-to-modify").First(&afterMod).Error; err != nil {
+		t.Fatalf("fetch modified: %v", err)
+	}
+	if !afterMod.Amount.Equal(decimal.NewFromFloat(-55.55)) {
+		t.Errorf("modified amount = %s, want -55.55 (Plaid-owned, should update)", afterMod.Amount)
+	}
+	if afterMod.CategoryID == nil || *afterMod.CategoryID != cat.ID {
+		t.Errorf("modified category_id = %v, want %d (user-edited, must survive)", afterMod.CategoryID, cat.ID)
+	}
+	if afterMod.Notes == nil || *afterMod.Notes != "User note that must survive" {
+		t.Errorf("modified notes = %v, want preserved", afterMod.Notes)
+	}
+	if afterMod.Description == nil || *afterMod.Description != "Updated description" {
+		t.Errorf("modified description = %v, want Plaid update", afterMod.Description)
+	}
+
+	// Removed: soft-deleted, not gone from the table.
+	var rmCount int64
+	if err := g.Unscoped().Model(&model.Transaction{}).
+		Where("plaid_transaction_id = ?", "ptx-to-remove").Count(&rmCount).Error; err != nil {
+		t.Fatalf("count removed: %v", err)
+	}
+	if rmCount != 1 {
+		t.Errorf("removed row count (unscoped) = %d, want 1 (soft-delete preserves)", rmCount)
+	}
+	// And the scoped query excludes it.
+	var scoped int64
+	if err := g.Model(&model.Transaction{}).
+		Where("plaid_transaction_id = ?", "ptx-to-remove").Count(&scoped).Error; err != nil {
+		t.Fatalf("scoped count: %v", err)
+	}
+	if scoped != 0 {
+		t.Errorf("removed row count (scoped) = %d, want 0", scoped)
+	}
+
+	// Untouched: still there, unchanged.
+	var u model.Transaction
+	if err := g.Where("plaid_transaction_id = ?", "ptx-untouched").First(&u).Error; err != nil {
+		t.Fatalf("fetch untouched: %v", err)
+	}
+	if !u.Amount.Equal(decimal.NewFromFloat(-1)) {
+		t.Errorf("untouched amount = %s, want -1", u.Amount)
+	}
+
+	// Cursor advanced exactly once to the value returned with has_more=false.
+	persisted, err := itemRepo.GetByPlaidItemID(context.Background(), userID, "item-incr-1")
+	if err != nil {
+		t.Fatalf("fetch item: %v", err)
+	}
+	if persisted.Cursor == nil || *persisted.Cursor != "incremental-next-cursor" {
+		t.Errorf("cursor = %v, want incremental-next-cursor", persisted.Cursor)
+	}
+}
+
+func TestService_SyncTransactions_TenantIsolation(t *testing.T) {
+	g := openPlaidTestDB(t)
+	userA := seedPlaidTestUser(t, g)
+	userB := seedPlaidTestUser(t, g)
+
+	// Both users have a Plaid account on the SAME upstream institution
+	// (different IDs locally; same Plaid account_id namespace would be a
+	// realistic two-user-of-same-bank scenario). Pre-seed one transaction
+	// for user B that must NOT be touched.
+	const plaidAcctIDA = "pacct-A"
+	const plaidAcctIDB = "pacct-B"
+	acctA := &model.Account{UserID: userA, Name: "A acct", InstitutionSlug: "ins_test", AccountType: "checking", Currency: "USD", PlaidAccountID: ptr(plaidAcctIDA), IsActive: true}
+	acctB := &model.Account{UserID: userB, Name: "B acct", InstitutionSlug: "ins_test", AccountType: "checking", Currency: "USD", PlaidAccountID: ptr(plaidAcctIDB), IsActive: true}
+	if err := g.Create(acctA).Error; err != nil {
+		t.Fatalf("seed A: %v", err)
+	}
+	if err := g.Create(acctB).Error; err != nil {
+		t.Fatalf("seed B: %v", err)
+	}
+	bTxn := &model.Transaction{
+		UserID: userB, AccountID: acctB.ID,
+		Amount: decimal.NewFromFloat(-99), Currency: "USD",
+		Description: ptr("B's private tx"), TransactionDate: mustDate("2026-05-01"),
+		Source: "plaid", PlaidTransactionID: ptr("ptx-B-only"), ExternalID: ptr("ptx-B-only"),
+	}
+	if err := g.Create(bTxn).Error; err != nil {
+		t.Fatalf("seed B tx: %v", err)
+	}
+	bItemCursor := "B-cursor-untouched"
+	bItem := &model.PlaidItem{UserID: userB, PlaidItemID: "item-B", AccessTokenEnc: []byte("dummy-not-used"), Status: "active", Cursor: &bItemCursor}
+	if err := g.Create(bItem).Error; err != nil {
+		t.Fatalf("seed B item: %v", err)
+	}
+
+	t.Cleanup(func() {
+		for _, uid := range []int64{userA, userB} {
+			g.Unscoped().Where("user_id = ?", uid).Delete(&model.Transaction{})
+			g.Unscoped().Where("user_id = ?", uid).Delete(&model.Account{})
+			g.Unscoped().Where("user_id = ?", uid).Delete(&model.PlaidItem{})
+		}
+	})
+
+	// User A's item gets a fresh sync that ADDS one txn for A's account.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/transactions/sync" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+			http.Error(w, "", 500)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"added": []map[string]any{
+				{
+					"transaction_id":    "ptx-A-1",
+					"account_id":        plaidAcctIDA,
+					"amount":            10.00,
+					"iso_currency_code": "USD",
+					"name":              "A's coffee",
+					"date":              "2026-05-15",
+					"pending":           false,
+				},
+			},
+			"modified":    []any{},
+			"removed":     []any{},
+			"next_cursor": "A-new-cursor",
+			"has_more":    false,
+			"request_id":  "req-iso",
+		})
+	}))
+	t.Cleanup(srv.Close)
+
+	client, _ := plaidsvc.NewSDKClient(plaidsvc.Config{ClientID: "cid", Secret: "csec", Env: srv.URL})
+	box, _ := crypto.NewSecretBox(newTestKey())
+	enc, _ := box.Encrypt([]byte("access-sandbox-A"))
+	aItem := &model.PlaidItem{UserID: userA, PlaidItemID: "item-A", AccessTokenEnc: enc, Status: "active"}
+	if err := g.Create(aItem).Error; err != nil {
+		t.Fatalf("seed A item: %v", err)
+	}
+
+	itemRepo := repository.NewPlaidItemRepository(g)
+	acctRepo := repository.NewAccountRepository(g)
+	txRepo := repository.NewTransactionRepository(g)
+	piiSvc := service.NewPIIService(repository.NewPIIRepository(g), service.NewAccountService(acctRepo))
+	svc := plaidsvc.NewService(client, box, itemRepo, acctRepo, txRepo, piiSvc, g)
+
+	if _, err := svc.SyncTransactions(context.Background(), userA, "item-A"); err != nil {
+		t.Fatalf("Sync user A: %v", err)
+	}
+
+	// User B's transaction must still be there and unchanged.
+	var bAfter model.Transaction
+	if err := g.Where("plaid_transaction_id = ?", "ptx-B-only").First(&bAfter).Error; err != nil {
+		t.Fatalf("B tx after A sync: %v", err)
+	}
+	if bAfter.UserID != userB {
+		t.Errorf("B tx user_id corrupted: got %d, want %d", bAfter.UserID, userB)
+	}
+
+	// B's plaid_items cursor must NOT have advanced.
+	bItemAfter, err := itemRepo.GetByPlaidItemID(context.Background(), userB, "item-B")
+	if err != nil {
+		t.Fatalf("B item after A sync: %v", err)
+	}
+	if bItemAfter.Cursor == nil || *bItemAfter.Cursor != "B-cursor-untouched" {
+		t.Errorf("B cursor = %v, want B-cursor-untouched (untouched by A's sync)", bItemAfter.Cursor)
+	}
+
+	// A's new transaction did land.
+	var aTx model.Transaction
+	if err := g.Where("plaid_transaction_id = ?", "ptx-A-1").First(&aTx).Error; err != nil {
+		t.Fatalf("A tx not inserted: %v", err)
+	}
+	if aTx.UserID != userA {
+		t.Errorf("A tx user_id = %d, want %d", aTx.UserID, userA)
+	}
+}

--- a/backend/internal/service/plaid/sync_transactions_integration_test.go
+++ b/backend/internal/service/plaid/sync_transactions_integration_test.go
@@ -146,7 +146,7 @@ func TestService_SyncTransactions_PaginatesAndPersistsCursor(t *testing.T) {
 		t.Fatalf("seed item: %v", err)
 	}
 
-	svc := plaidsvc.NewService(client, box, itemRepo, acctRepo, txRepo, piiSvc)
+	svc := plaidsvc.NewService(client, box, itemRepo, acctRepo, txRepo, piiSvc, g)
 
 	// First full pull
 	r, err := svc.SyncTransactions(context.Background(), userID, "item-sync-1")
@@ -238,7 +238,7 @@ func TestService_SyncTransactions_UnknownAccountErrors(t *testing.T) {
 		t.Fatalf("seed item: %v", err)
 	}
 
-	svc := plaidsvc.NewService(client, box, itemRepo, acctRepo, txRepo, piiSvc)
+	svc := plaidsvc.NewService(client, box, itemRepo, acctRepo, txRepo, piiSvc, g)
 	_, err := svc.SyncTransactions(context.Background(), userID, "item-orphan")
 	if err == nil {
 		t.Fatal("expected error when plaid_account_id can't resolve to a local account")

--- a/backend/internal/service/plaid/transaction_mapping.go
+++ b/backend/internal/service/plaid/transaction_mapping.go
@@ -72,3 +72,39 @@ func MapPlaidTransaction(p PlaidTransaction, userID, accountID int64) (model.Tra
 		PlaidTransactionID: &plaidID,
 	}, nil
 }
+
+// MergePlaidUpdate overlays an incoming /transactions/sync `modified` entry
+// onto the existing row. Plaid-controlled fields (amount, description,
+// merchant_name, posted_date, transaction_date) are taken from the new
+// payload; user-edited fields (notes, category_id, is_transfer, transfer
+// pairing) are preserved untouched.
+//
+// This is what makes "pending → posted" transitions safe: Plaid updates the
+// amount and posted_date when a hold clears, but the user's categorization
+// and notes survive.
+//
+// The function is pure — it returns the merged row without writing. Caller
+// passes the result to the repo's update method. accountID is supplied
+// (rather than re-derived) so the merge stays independent of repo state.
+func MergePlaidUpdate(existing model.Transaction, incoming PlaidTransaction, accountID int64) (model.Transaction, error) {
+	mapped, err := MapPlaidTransaction(incoming, existing.UserID, accountID)
+	if err != nil {
+		return model.Transaction{}, err
+	}
+	merged := existing
+	// Plaid-owned fields — overwrite.
+	merged.AccountID = accountID
+	merged.Amount = mapped.Amount
+	merged.Currency = mapped.Currency
+	merged.Description = mapped.Description
+	merged.MerchantName = mapped.MerchantName
+	merged.TransactionDate = mapped.TransactionDate
+	merged.PostedDate = mapped.PostedDate
+	// User-edited fields — preserve. Intentionally not enumerated as
+	// "deny-list overlay" because the safer default for unknown future
+	// fields is "leave it alone".
+	//   existing.Notes, existing.CategoryID, existing.IsTransfer,
+	//   existing.TransferPairID, existing.CategorizationMethod
+	// remain on `merged`.
+	return merged, nil
+}


### PR DESCRIPTION
## Summary
- Same \`/sync-transactions\` handler now exercises the full incremental shape: \`added\`, \`modified\`, \`removed\`
- New \`MergePlaidUpdate\` pure helper preserves user-edited \`notes\`, \`category_id\`, \`is_transfer\` while letting Plaid overwrite amount/description/merchant/dates
- Entire per-item sync wrapped in one \`db.Transaction\` — cursor advance is atomic with the writes, so a mid-flight failure rolls back and the next run safely re-fetches the same delta
- \`modified\` for an unseen transaction falls through to insert so we never drop data Plaid asks us to track

## Tests
- \`merge_update_test\`: pending → posted scenario asserts user fields survive; nil merchant_name from Plaid clears the existing value (Plaid is authoritative for that field)
- \`sync_transactions_incremental_test\`: 1 added / 1 modified / 1 removed against a fake that **verifies the request body carries the persisted cursor**. Asserts \`category_id\` + \`notes\` preserved on the modified row, removed row soft-deleted (still in unscoped count, hidden from scoped queries), untouched row unchanged, cursor advances exactly once.
- \`TenantIsolation\` test: two users, separate plaid_items. Syncing user A leaves user B's transactions and cursor untouched.

## Smoke (real Plaid sandbox, ins_109508)
- First sync after Plaid catch-up: 48 inserted
- Re-sync: \`{inserted:0, modified:0, removed:0}\`, cursor advanced, \`last_synced_at\` recent

## Architectural notes
- The Service struct now holds a \`*gorm.DB\` (deliberate exception to "services don't see *gorm.DB") used **only** for the transaction wrap. Inside the callback we construct fresh tx-bound repos so all writes hit the same Postgres transaction. Comment in code explains the trade-off.
- One transient \`Permission denied\` flake on the auth tests during full-suite run — Postgres data volume is at 94% disk on the local Docker setup. CI runners have ample disk; clean re-run passed.

Closes #62