### PR TITLE
M3 #63: user-scope Plaid dedup index + resurrect-on-resurface

### DIFF
--- a/backend/internal/repository/transaction_repo.go
+++ b/backend/internal/repository/transaction_repo.go
@@ -52,6 +52,18 @@ type TransactionRepository interface {
 	// row returns ErrNotFound (because the soft-delete partial index
 	// hides the row from the scope).
 	SoftDeleteByPlaidTransactionID(ctx context.Context, userID int64, plaidTxnID string) error
+	// FindSoftDeletedByPlaidTransactionIDs returns rows whose deleted_at IS
+	// NOT NULL and whose (user_id, plaid_transaction_id) matches one of the
+	// supplied IDs. Used by the Plaid sync path to detect a re-surfaced
+	// transaction that the user (or a prior sync) had previously soft-deleted
+	// — instead of inserting a duplicate, the service resurrects the row.
+	// Empty input → nil, nil.
+	FindSoftDeletedByPlaidTransactionIDs(ctx context.Context, userID int64, plaidTxnIDs []string) ([]model.Transaction, error)
+	// ResurrectByPlaidTransactionID clears deleted_at on a soft-deleted row
+	// and overlays the merged fields. Returns ErrNotFound when no row exists
+	// (live or soft-deleted) for the key. The caller is expected to pass a
+	// row produced by plaid.MergePlaidUpdate so user-edited fields survive.
+	ResurrectByPlaidTransactionID(ctx context.Context, userID int64, plaidTxnID string, merged model.Transaction) error
 }
 
 type transactionRepo struct {
@@ -144,13 +156,21 @@ func (r *transactionRepo) CreateBatch(ctx context.Context, txns []model.Transact
 		return 0, nil
 	}
 	// ON CONFLICT DO NOTHING on the partial unique index
-	// `uq_transactions_plaid` (defined in migration 000001 as
-	// `(plaid_transaction_id) WHERE deleted_at IS NULL AND plaid_transaction_id IS NOT NULL`).
-	// Postgres requires the conflict target to match the partial predicate
-	// exactly, hence TargetWhere — without it we get
-	// "no unique or exclusion constraint matching the ON CONFLICT specification".
+	// `uq_transactions_user_plaid` (migration 000004 — user-scoped per #63):
+	//   (user_id, plaid_transaction_id)
+	//   WHERE deleted_at IS NULL AND plaid_transaction_id IS NOT NULL
+	// Postgres requires the conflict target's columns AND its partial
+	// predicate to match the index exactly, hence TargetWhere — without
+	// it we get "no unique or exclusion constraint matching the ON CONFLICT
+	// specification".
+	//
+	// Note: this only catches LIVE duplicates. A soft-deleted row with the
+	// same (user_id, plaid_transaction_id) sits outside the partial index,
+	// so a naive re-insert WOULD create a second row. The Plaid service's
+	// resurrect-on-resurface pass (see plaid.Service.SyncTransactions)
+	// handles that case by undeleting the existing row instead of inserting.
 	res := r.db.WithContext(ctx).Clauses(clause.OnConflict{
-		Columns: []clause.Column{{Name: "plaid_transaction_id"}},
+		Columns: []clause.Column{{Name: "user_id"}, {Name: "plaid_transaction_id"}},
 		TargetWhere: clause.Where{Exprs: []clause.Expression{
 			clause.Expr{SQL: "deleted_at IS NULL AND plaid_transaction_id IS NOT NULL"},
 		}},
@@ -195,6 +215,47 @@ func (r *transactionRepo) SoftDeleteByPlaidTransactionID(ctx context.Context, us
 	res := r.db.WithContext(ctx).
 		Where("user_id = ? AND plaid_transaction_id = ?", userID, plaidTxnID).
 		Delete(&model.Transaction{})
+	if res.Error != nil {
+		return res.Error
+	}
+	if res.RowsAffected == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+func (r *transactionRepo) FindSoftDeletedByPlaidTransactionIDs(ctx context.Context, userID int64, plaidTxnIDs []string) ([]model.Transaction, error) {
+	if len(plaidTxnIDs) == 0 {
+		return nil, nil
+	}
+	var out []model.Transaction
+	if err := r.db.WithContext(ctx).Unscoped().
+		Where("user_id = ? AND plaid_transaction_id IN ? AND deleted_at IS NOT NULL", userID, plaidTxnIDs).
+		Find(&out).Error; err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (r *transactionRepo) ResurrectByPlaidTransactionID(ctx context.Context, userID int64, plaidTxnID string, merged model.Transaction) error {
+	// Locate the existing row Unscoped so we capture its ID + created_at
+	// even though deleted_at is set. Then Save() with DeletedAt zeroed to
+	// flip it back to live.
+	var existing model.Transaction
+	if err := r.db.WithContext(ctx).Unscoped().
+		Where("user_id = ? AND plaid_transaction_id = ?", userID, plaidTxnID).
+		First(&existing).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return ErrNotFound
+		}
+		return err
+	}
+	merged.ID = existing.ID
+	merged.CreatedAt = existing.CreatedAt
+	merged.DeletedAt = gorm.DeletedAt{} // clear soft-delete on the way out
+	res := r.db.WithContext(ctx).Unscoped().
+		Where("user_id = ? AND plaid_transaction_id = ?", userID, plaidTxnID).
+		Save(&merged)
 	if res.Error != nil {
 		return res.Error
 	}

--- a/backend/internal/service/plaid/dedup_test.go
+++ b/backend/internal/service/plaid/dedup_test.go
@@ -1,0 +1,290 @@
+package plaid_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/shopspring/decimal"
+
+	"github.com/gregwym/offbook/backend/internal/crypto"
+	"github.com/gregwym/offbook/backend/internal/model"
+	"github.com/gregwym/offbook/backend/internal/repository"
+	"github.com/gregwym/offbook/backend/internal/service"
+	plaidsvc "github.com/gregwym/offbook/backend/internal/service/plaid"
+)
+
+// fakeFixedPayloadServer always returns the same /transactions/sync payload
+// for the FIRST drain (page 1 has 2 txns, has_more=false), and an empty
+// delta for every subsequent call regardless of cursor. That mimics what
+// Plaid does once a cursor catches up — a stable end-state we can run a
+// re-sync against.
+//
+// Note for #63: the cursor advances after the first drain, so a re-sync
+// (call #2) goes through the "no new changes" path. But the dedup guarantee
+// we actually want to assert is "if Plaid ever replays the same payload
+// (cursor reset, account re-link, etc.), we don't double up." So we make
+// the server ignore the cursor and replay the payload whenever the caller
+// sends an empty cursor — and we drive that by manually clearing the cursor
+// in the DB between syncs.
+func fakeFixedPayloadServer(t *testing.T, plaidAcctID string) (*httptest.Server, *int32) {
+	t.Helper()
+	var calls int32
+	mux := http.NewServeMux()
+	mux.HandleFunc("/transactions/sync", func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"added": []map[string]any{
+				{
+					"transaction_id":    "ptx-dedup-1",
+					"account_id":        plaidAcctID,
+					"amount":            3.14,
+					"iso_currency_code": "USD",
+					"name":              "Stable charge A",
+					"date":              "2026-05-10",
+					"pending":           false,
+				},
+				{
+					"transaction_id":    "ptx-dedup-2",
+					"account_id":        plaidAcctID,
+					"amount":            -100.00, // inflow
+					"iso_currency_code": "USD",
+					"name":              "Stable deposit B",
+					"date":              "2026-05-11",
+					"pending":           false,
+				},
+			},
+			"modified":    []any{},
+			"removed":     []any{},
+			"next_cursor": "stable-cursor",
+			"has_more":    false,
+			"request_id":  "req-dedup",
+		})
+	})
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		t.Errorf("unexpected Plaid call: %s %s", r.Method, r.URL.Path)
+		http.Error(w, "unexpected", 500)
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv, &calls
+}
+
+func TestPlaidSync_NoDuplicatesOnReSync(t *testing.T) {
+	g := openPlaidTestDB(t)
+	userID := seedPlaidTestUser(t, g)
+	const plaidAcctID = "pacct-dedup-1"
+
+	acct := &model.Account{
+		UserID: userID, Name: "Dedup Acct", InstitutionSlug: "ins_test",
+		AccountType: "checking", Currency: "USD",
+		PlaidAccountID: ptr(plaidAcctID), IsActive: true,
+	}
+	if err := g.Create(acct).Error; err != nil {
+		t.Fatalf("seed account: %v", err)
+	}
+	t.Cleanup(func() {
+		g.Unscoped().Where("user_id = ?", userID).Delete(&model.Transaction{})
+		g.Unscoped().Delete(&model.Account{}, acct.ID)
+	})
+
+	srv, _ := fakeFixedPayloadServer(t, plaidAcctID)
+	client, _ := plaidsvc.NewSDKClient(plaidsvc.Config{ClientID: "cid", Secret: "csec", Env: srv.URL})
+	box, _ := crypto.NewSecretBox(newTestKey())
+	itemRepo := repository.NewPlaidItemRepository(g)
+	acctRepo := repository.NewAccountRepository(g)
+	txRepo := repository.NewTransactionRepository(g)
+	piiSvc := service.NewPIIService(repository.NewPIIRepository(g), service.NewAccountService(acctRepo))
+
+	enc, _ := box.Encrypt([]byte("access-sandbox-fake"))
+	item := &model.PlaidItem{UserID: userID, PlaidItemID: "item-dedup", AccessTokenEnc: enc, Status: "active"}
+	if err := itemRepo.Create(context.Background(), item); err != nil {
+		t.Fatalf("seed item: %v", err)
+	}
+
+	svc := plaidsvc.NewService(client, box, itemRepo, acctRepo, txRepo, piiSvc, g)
+
+	// First sync: 2 inserts.
+	r1, err := svc.SyncTransactions(context.Background(), userID, "item-dedup")
+	if err != nil {
+		t.Fatalf("sync #1: %v", err)
+	}
+	if r1.Inserted != 2 {
+		t.Errorf("sync #1: inserted=%d, want 2", r1.Inserted)
+	}
+
+	// Simulate a cursor reset (account re-link, Plaid item recovery, etc.)
+	// by clearing the persisted cursor. Without dedup the same payload
+	// would now insert 2 more rows.
+	if err := g.Model(&model.PlaidItem{}).
+		Where("id = ?", item.ID).
+		Update("cursor", nil).Error; err != nil {
+		t.Fatalf("reset cursor: %v", err)
+	}
+
+	r2, err := svc.SyncTransactions(context.Background(), userID, "item-dedup")
+	if err != nil {
+		t.Fatalf("sync #2: %v", err)
+	}
+	if r2.Inserted != 0 {
+		t.Errorf("sync #2: inserted=%d, want 0 (ON CONFLICT DO NOTHING)", r2.Inserted)
+	}
+	if r2.Resurrected != 0 {
+		t.Errorf("sync #2: resurrected=%d, want 0 (rows are still live)", r2.Resurrected)
+	}
+
+	// Count: still exactly 2.
+	var n int64
+	if err := g.Model(&model.Transaction{}).
+		Where("user_id = ? AND source = 'plaid'", userID).Count(&n).Error; err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if n != 2 {
+		t.Errorf("transactions count = %d, want 2 (no duplicates)", n)
+	}
+
+	// Same IDs, in case anyone replaces ON CONFLICT with INSERT.
+	for _, ptxID := range []string{"ptx-dedup-1", "ptx-dedup-2"} {
+		var c int64
+		if err := g.Model(&model.Transaction{}).
+			Where("plaid_transaction_id = ?", ptxID).Count(&c).Error; err != nil {
+			t.Fatalf("count %s: %v", ptxID, err)
+		}
+		if c != 1 {
+			t.Errorf("%s: %d rows, want 1", ptxID, c)
+		}
+	}
+}
+
+// TestPlaidSync_SoftDeletedReSurfaces verifies the resurrect-in-place
+// behavior documented in #63: if the user (or a prior /removed entry)
+// soft-deleted a Plaid-imported row and Plaid later replays the same
+// transaction_id in `added`, we clear deleted_at on the existing row
+// rather than insert a duplicate. The choice is restore-over-insert
+// because a Plaid row has no PII and is unambiguously the same financial
+// event — silently splitting it into two rows would corrupt history.
+//
+// User-edited fields (notes, category_id) must survive the resurrect.
+func TestPlaidSync_SoftDeletedReSurfaces(t *testing.T) {
+	g := openPlaidTestDB(t)
+	userID := seedPlaidTestUser(t, g)
+	const plaidAcctID = "pacct-resurface-1"
+
+	acct := &model.Account{
+		UserID: userID, Name: "Resurface Acct", InstitutionSlug: "ins_test",
+		AccountType: "checking", Currency: "USD",
+		PlaidAccountID: ptr(plaidAcctID), IsActive: true,
+	}
+	if err := g.Create(acct).Error; err != nil {
+		t.Fatalf("seed account: %v", err)
+	}
+
+	cat := &model.Category{Name: "ResurrectCat", Slug: "resurrect-cat"}
+	if err := g.Create(cat).Error; err != nil {
+		t.Fatalf("seed cat: %v", err)
+	}
+
+	// Seed a Plaid-sourced row, then soft-delete it. Carries user-set
+	// notes + category that the resurrect path must preserve.
+	priorNotes := "Notes attached by user before deletion"
+	categoryID := cat.ID
+	original := &model.Transaction{
+		UserID:             userID,
+		AccountID:          acct.ID,
+		Amount:             decimal.NewFromFloat(-3.14),
+		Currency:           "USD",
+		Description:        ptr("Stable charge A"),
+		TransactionDate:    mustDate("2026-05-10"),
+		Source:             "plaid",
+		PlaidTransactionID: ptr("ptx-dedup-1"),
+		ExternalID:         ptr("ptx-dedup-1"),
+		CategoryID:         &categoryID,
+		Notes:              &priorNotes,
+	}
+	if err := g.Create(original).Error; err != nil {
+		t.Fatalf("seed original: %v", err)
+	}
+	originalID := original.ID
+	// Soft-delete via the repo path so we exercise the same code path the
+	// user would.
+	txRepo := repository.NewTransactionRepository(g)
+	if err := txRepo.SoftDelete(context.Background(), userID, originalID); err != nil {
+		t.Fatalf("soft-delete: %v", err)
+	}
+
+	t.Cleanup(func() {
+		g.Unscoped().Where("user_id = ?", userID).Delete(&model.Transaction{})
+		g.Unscoped().Delete(&model.Account{}, acct.ID)
+		g.Unscoped().Delete(&model.Category{}, cat.ID)
+	})
+
+	// Re-sync: payload includes the soft-deleted row's plaid_transaction_id.
+	srv, _ := fakeFixedPayloadServer(t, plaidAcctID)
+	client, _ := plaidsvc.NewSDKClient(plaidsvc.Config{ClientID: "cid", Secret: "csec", Env: srv.URL})
+	box, _ := crypto.NewSecretBox(newTestKey())
+	itemRepo := repository.NewPlaidItemRepository(g)
+	acctRepo := repository.NewAccountRepository(g)
+	piiSvc := service.NewPIIService(repository.NewPIIRepository(g), service.NewAccountService(acctRepo))
+
+	enc, _ := box.Encrypt([]byte("access-sandbox-fake"))
+	item := &model.PlaidItem{UserID: userID, PlaidItemID: "item-resurface", AccessTokenEnc: enc, Status: "active"}
+	if err := itemRepo.Create(context.Background(), item); err != nil {
+		t.Fatalf("seed item: %v", err)
+	}
+
+	svc := plaidsvc.NewService(client, box, itemRepo, acctRepo, txRepo, piiSvc, g)
+
+	r, err := svc.SyncTransactions(context.Background(), userID, "item-resurface")
+	if err != nil {
+		t.Fatalf("sync: %v", err)
+	}
+	if r.Resurrected != 1 {
+		t.Errorf("resurrected=%d, want 1 (ptx-dedup-1 was soft-deleted, payload re-added it)", r.Resurrected)
+	}
+	if r.Inserted != 1 {
+		t.Errorf("inserted=%d, want 1 (only ptx-dedup-2 was new)", r.Inserted)
+	}
+
+	// Total rows for this account (unscoped + scoped) == 2: the resurrected
+	// row + the new one. NOT 3 (would mean we duplicated rather than
+	// restored).
+	var unscoped int64
+	if err := g.Unscoped().Model(&model.Transaction{}).
+		Where("user_id = ?", userID).Count(&unscoped).Error; err != nil {
+		t.Fatalf("count unscoped: %v", err)
+	}
+	if unscoped != 2 {
+		t.Errorf("unscoped row count = %d, want 2 (resurrect, not duplicate)", unscoped)
+	}
+
+	// The resurrected row is the SAME id as before — proves restore-in-place.
+	var restored model.Transaction
+	if err := g.Where("plaid_transaction_id = ?", "ptx-dedup-1").First(&restored).Error; err != nil {
+		t.Fatalf("fetch restored: %v", err)
+	}
+	if restored.ID != originalID {
+		t.Errorf("restored.ID = %d, want %d (same row, undeleted)", restored.ID, originalID)
+	}
+	if !restored.DeletedAt.Time.IsZero() && restored.DeletedAt.Valid {
+		t.Errorf("restored.DeletedAt still set: %+v", restored.DeletedAt)
+	}
+
+	// User-edited fields survived the resurrect.
+	if restored.Notes == nil || *restored.Notes != priorNotes {
+		t.Errorf("restored notes = %v, want preserved", restored.Notes)
+	}
+	if restored.CategoryID == nil || *restored.CategoryID != cat.ID {
+		t.Errorf("restored category_id = %v, want %d", restored.CategoryID, cat.ID)
+	}
+
+	// Plaid-owned fields reflect the current payload (amount/description
+	// re-applied — even if upstream Plaid hadn't changed them, the merge
+	// is a no-op).
+	if !restored.Amount.Equal(decimal.NewFromFloat(-3.14)) {
+		t.Errorf("restored amount = %s, want -3.14", restored.Amount)
+	}
+}

--- a/backend/internal/service/plaid/service.go
+++ b/backend/internal/service/plaid/service.go
@@ -41,12 +41,16 @@ type SyncAccountsResult struct {
 
 // SyncTransactionsResult summarizes a /transactions/sync drain. Inserted
 // is the count of rows actually written (i.e., excludes duplicates that
-// hit the ON CONFLICT DO NOTHING path). Removed is the count of Plaid
-// IDs we were told to forget — for the initial pull this is always 0.
+// hit the ON CONFLICT DO NOTHING path). Resurrected counts `added` rows
+// whose plaid_transaction_id matched a previously-soft-deleted local row —
+// they are undeleted in place rather than inserted as duplicates (see #63).
+// Removed is the count of Plaid IDs we were told to forget — for the
+// initial pull this is always 0.
 type SyncTransactionsResult struct {
-	Inserted int64 `json:"inserted"`
-	Modified int   `json:"modified"`
-	Removed  int   `json:"removed"`
+	Inserted    int64 `json:"inserted"`
+	Resurrected int   `json:"resurrected"`
+	Modified    int   `json:"modified"`
+	Removed     int   `json:"removed"`
 }
 
 // Service orchestrates the Plaid Link flow: issue link tokens, exchange
@@ -367,11 +371,57 @@ func (s *Service) SyncTransactions(ctx context.Context, userID int64, plaidItemI
 		acctRepo := repository.NewAccountRepository(tx)
 		accountIDCache := map[string]int64{}
 
-		// Inserts (uses ON CONFLICT DO NOTHING — defense in depth on top
-		// of the partial unique index).
+		// Inserts. Two cases per `added`:
+		//   1. plaid_transaction_id matches a soft-deleted local row →
+		//      resurrect (clear deleted_at + overlay via MergePlaidUpdate
+		//      so user-edited notes/category survive the round-trip).
+		//   2. otherwise → batch insert with ON CONFLICT DO NOTHING.
+		// The resurrect pass is what gives #63 its "re-sync of a previously
+		// deleted Plaid row restores in place" guarantee — without it, the
+		// partial unique index (which excludes deleted rows) would silently
+		// let a duplicate land.
 		if len(added) > 0 {
-			batch := make([]model.Transaction, 0, len(added))
+			plaidIDs := make([]string, 0, len(added))
+			addedByPlaidID := make(map[string]PlaidTransaction, len(added))
 			for _, pt := range added {
+				plaidIDs = append(plaidIDs, pt.PlaidTransactionID)
+				addedByPlaidID[pt.PlaidTransactionID] = pt
+			}
+
+			deleted, err := txRepo.FindSoftDeletedByPlaidTransactionIDs(ctx, userID, plaidIDs)
+			if err != nil {
+				return fmt.Errorf("plaid: lookup soft-deleted for resurrect: %w", err)
+			}
+			resurrectedIDs := make(map[string]struct{}, len(deleted))
+			for _, existing := range deleted {
+				if existing.PlaidTransactionID == nil {
+					continue
+				}
+				ptxID := *existing.PlaidTransactionID
+				incoming, ok := addedByPlaidID[ptxID]
+				if !ok {
+					continue
+				}
+				localID, err := resolveAccountID(ctx, acctRepo, userID, incoming.PlaidAccountID, accountIDCache)
+				if err != nil {
+					return err
+				}
+				merged, err := MergePlaidUpdate(existing, incoming, localID)
+				if err != nil {
+					return err
+				}
+				if err := txRepo.ResurrectByPlaidTransactionID(ctx, userID, ptxID, merged); err != nil {
+					return fmt.Errorf("plaid: resurrect %s: %w", ptxID, err)
+				}
+				resurrectedIDs[ptxID] = struct{}{}
+				result.Resurrected++
+			}
+
+			batch := make([]model.Transaction, 0, len(added)-len(resurrectedIDs))
+			for _, pt := range added {
+				if _, done := resurrectedIDs[pt.PlaidTransactionID]; done {
+					continue
+				}
 				localID, err := resolveAccountID(ctx, acctRepo, userID, pt.PlaidAccountID, accountIDCache)
 				if err != nil {
 					return err
@@ -382,11 +432,13 @@ func (s *Service) SyncTransactions(ctx context.Context, userID int64, plaidItemI
 				}
 				batch = append(batch, row)
 			}
-			n, err := txRepo.CreateBatch(ctx, batch)
-			if err != nil {
-				return fmt.Errorf("plaid: insert batch: %w", err)
+			if len(batch) > 0 {
+				n, err := txRepo.CreateBatch(ctx, batch)
+				if err != nil {
+					return fmt.Errorf("plaid: insert batch: %w", err)
+				}
+				result.Inserted = n
 			}
-			result.Inserted = n
 		}
 
 		// Modifications: merge with the existing row so user-edited

--- a/backend/internal/service/plaid/service_test.go
+++ b/backend/internal/service/plaid/service_test.go
@@ -91,6 +91,9 @@ func (r *fakeRepo) UpdateCursor(context.Context, int64, int64, string, time.Time
 	return nil
 }
 
+// (fakeRepo implements PlaidItemRepository — the transaction-repo methods
+// added in #62 / #63 live on a separate interface and aren't exercised here.)
+
 func newTestKey() []byte {
 	k := make([]byte, 32)
 	for i := range k {

--- a/backend/migrations/000004_plaid_dedup_user_scoped.down.sql
+++ b/backend/migrations/000004_plaid_dedup_user_scoped.down.sql
@@ -1,0 +1,5 @@
+DROP INDEX IF EXISTS uq_transactions_user_plaid;
+
+CREATE UNIQUE INDEX uq_transactions_plaid
+    ON transactions (plaid_transaction_id)
+    WHERE deleted_at IS NULL AND plaid_transaction_id IS NOT NULL;

--- a/backend/migrations/000004_plaid_dedup_user_scoped.up.sql
+++ b/backend/migrations/000004_plaid_dedup_user_scoped.up.sql
@@ -1,0 +1,18 @@
+-- #63: scope the Plaid-dedup partial unique index by user_id.
+--
+-- Migration 000001 created `uq_transactions_plaid` as a globally unique
+-- partial index on `(plaid_transaction_id)`. That is *stricter* than
+-- multi-tenant correctness requires and creates a real failure mode:
+-- two distinct users connecting to Plaid sandbox (or any environment
+-- that can replay the same transaction_id under different items) would
+-- collide. The semantic we actually want is "no duplicate Plaid row
+-- *for the same user*".
+--
+-- Replace with a partial unique index on (user_id, plaid_transaction_id).
+-- Same partial predicate so soft-deleted rows and rows from non-Plaid
+-- sources (NULL plaid_transaction_id) remain non-conflicting.
+DROP INDEX IF EXISTS uq_transactions_plaid;
+
+CREATE UNIQUE INDEX uq_transactions_user_plaid
+    ON transactions (user_id, plaid_transaction_id)
+    WHERE deleted_at IS NULL AND plaid_transaction_id IS NOT NULL;


### PR DESCRIPTION
## Summary
- Migration 000004 replaces the globally-unique `uq_transactions_plaid` index with a user-scoped `uq_transactions_user_plaid` on `(user_id, plaid_transaction_id)`. The global version was stricter than multi-tenant correctness needs and would collide when two users share Plaid sandbox IDs.
- `CreateBatch` `ON CONFLICT` target updated to match the new partial index.
- Plaid `SyncTransactions` now resurrects soft-deleted rows in place when their `plaid_transaction_id` appears in a fresh `added` payload, rather than inserting a duplicate. User-edited `notes` / `category_id` survive via `MergePlaidUpdate`.
- New repo methods: `FindSoftDeletedByPlaidTransactionIDs`, `ResurrectByPlaidTransactionID`.
- `SyncTransactionsResult` adds `Resurrected` for visibility.

## Test plan
- [x] `TestPlaidSync_NoDuplicatesOnReSync` — cursor reset replay yields 0 inserts; row count unchanged at 2.
- [x] `TestPlaidSync_SoftDeletedReSurfaces` — soft-deleted Plaid row re-appears in payload; same ID restored, unscoped count stays at 2 (not 3), user notes + category survive.
- [x] Full suite green (`go test -p 1 ./...`).
- [x] `go vet` + `gofmt -l` clean.

Closes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)