### PR TITLE
M3 #64: Plaid PFC → internal category mapping at sync time

### DIFF
--- a/backend/internal/repository/plaid_category_map_repo.go
+++ b/backend/internal/repository/plaid_category_map_repo.go
@@ -1,0 +1,42 @@
+package repository
+
+import (
+	"context"
+
+	"gorm.io/gorm"
+)
+
+// PlaidCategoryMapping is one row of the plaid_category_map table. We
+// don't define a GORM model because the data is read-only at app
+// startup — a flat struct keeps the lookup map building trivial.
+type PlaidCategoryMapping struct {
+	PlaidPrimary  string `gorm:"column:plaid_primary"`
+	PlaidDetailed string `gorm:"column:plaid_detailed"`
+	CategoryID    int64  `gorm:"column:category_id"`
+}
+
+// PlaidCategoryMapRepository loads the Plaid PFC → category mapping.
+// The mapping is global (not user-scoped) and is intended to be loaded
+// once at service construction and cached in memory.
+type PlaidCategoryMapRepository interface {
+	LoadAll(ctx context.Context) ([]PlaidCategoryMapping, error)
+}
+
+type plaidCategoryMapRepo struct {
+	db *gorm.DB
+}
+
+func NewPlaidCategoryMapRepository(db *gorm.DB) PlaidCategoryMapRepository {
+	return &plaidCategoryMapRepo{db: db}
+}
+
+func (r *plaidCategoryMapRepo) LoadAll(ctx context.Context) ([]PlaidCategoryMapping, error) {
+	var out []PlaidCategoryMapping
+	if err := r.db.WithContext(ctx).
+		Table("plaid_category_map").
+		Select("plaid_primary, plaid_detailed, category_id").
+		Find(&out).Error; err != nil {
+		return nil, err
+	}
+	return out, nil
+}

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -1,6 +1,8 @@
 package router
 
 import (
+	"context"
+
 	"github.com/gin-gonic/gin"
 	"gorm.io/gorm"
 
@@ -118,7 +120,7 @@ func newPlaidService(
 	piiSvc *service.PIIService,
 ) *plaidsvc.Service {
 	if !cfg.PlaidConfigured() {
-		return plaidsvc.NewService(nil, nil, nil, nil, nil, nil, nil)
+		return plaidsvc.NewService(nil, nil, nil, nil, nil, nil, nil, nil)
 	}
 	client, err := plaidsvc.NewSDKClient(plaidsvc.Config{
 		ClientID: cfg.PlaidClientID,
@@ -132,6 +134,13 @@ func newPlaidService(
 	if err != nil {
 		panic("plaid: secretbox: " + err.Error())
 	}
+	// Load PFC → category map once at startup. A DB failure here is fatal
+	// because the rest of the app expects plaid_category_map to exist; if
+	// the migration hasn't run, the operator needs to know immediately.
+	mapper, err := plaidsvc.NewCategoryMapper(context.Background(), repository.NewPlaidCategoryMapRepository(gormDB))
+	if err != nil {
+		panic("plaid: load category map: " + err.Error())
+	}
 	return plaidsvc.NewService(
 		client,
 		box,
@@ -139,6 +148,7 @@ func newPlaidService(
 		acctRepo,
 		txRepo,
 		piiSvc,
+		mapper,
 		gormDB,
 	)
 }

--- a/backend/internal/service/plaid/category_mapping.go
+++ b/backend/internal/service/plaid/category_mapping.go
@@ -1,0 +1,65 @@
+package plaid
+
+import (
+	"context"
+
+	"github.com/gregwym/offbook/backend/internal/repository"
+)
+
+// CategoryMapper resolves a Plaid PFC (primary, detailed) pair to a local
+// categories.id. Loaded from plaid_category_map once at service construction;
+// callers MUST treat the resolved id as a default that user choice overrides.
+//
+// Lookup is O(1) on a composite string key. A nil receiver is treated as
+// "no mapping configured" so the service can be wired in degraded mode
+// without panicking (e.g., when DB is unreachable at startup).
+type CategoryMapper struct {
+	// table is keyed by primary + "|" + detailed. The "|" separator is
+	// safe because Plaid PFC tokens are ALL_CAPS_WITH_UNDERSCORES and
+	// never contain pipe characters.
+	table map[string]int64
+}
+
+// NewCategoryMapper loads all rows from the repo and builds the in-memory
+// lookup. Returns an empty (but non-nil) mapper if the table is empty so
+// callers don't need a separate nil check.
+func NewCategoryMapper(ctx context.Context, repo repository.PlaidCategoryMapRepository) (*CategoryMapper, error) {
+	rows, err := repo.LoadAll(ctx)
+	if err != nil {
+		return nil, err
+	}
+	m := &CategoryMapper{table: make(map[string]int64, len(rows))}
+	for _, r := range rows {
+		m.table[pfcKey(r.PlaidPrimary, r.PlaidDetailed)] = r.CategoryID
+	}
+	return m, nil
+}
+
+// MapPlaidCategory returns the local category_id for a Plaid PFC pair.
+// ok=false when the pair isn't mapped — caller should leave category_id NULL.
+func (m *CategoryMapper) MapPlaidCategory(primary, detailed string) (int64, bool) {
+	if m == nil || primary == "" || detailed == "" {
+		return 0, false
+	}
+	id, ok := m.table[pfcKey(primary, detailed)]
+	return id, ok
+}
+
+// Size reports how many mappings are loaded. Useful for /health-style
+// surfaces and for tests that want to assert the seed actually loaded.
+func (m *CategoryMapper) Size() int {
+	if m == nil {
+		return 0
+	}
+	return len(m.table)
+}
+
+func pfcKey(primary, detailed string) string {
+	return primary + "|" + detailed
+}
+
+// CategorizationMethodPlaidDefault is the value written into
+// transactions.categorization_method when the Plaid PFC mapper assigned
+// a default category. The other documented value is "manual" (user
+// picked the category). Both are documented in docs/ARCHITECTURE.md.
+const CategorizationMethodPlaidDefault = "plaid_default"

--- a/backend/internal/service/plaid/category_mapping_integration_test.go
+++ b/backend/internal/service/plaid/category_mapping_integration_test.go
@@ -1,0 +1,252 @@
+package plaid_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gregwym/offbook/backend/internal/crypto"
+	"github.com/gregwym/offbook/backend/internal/model"
+	"github.com/gregwym/offbook/backend/internal/repository"
+	"github.com/gregwym/offbook/backend/internal/service"
+	plaidsvc "github.com/gregwym/offbook/backend/internal/service/plaid"
+)
+
+// fakeServerPFC returns a single-page response where the same Plaid txn
+// appears in `added` on the first call and in `modified` on the second.
+// The modified payload keeps the same PFC. Lets us drive the
+// initial-default-categorize then re-sync flow in one test.
+func fakeServerPFC(t *testing.T, plaidAcctID, plaidTxnID string) (*httptest.Server, *int) {
+	t.Helper()
+	var calls int
+	mux := http.NewServeMux()
+	mux.HandleFunc("/transactions/sync", func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		w.Header().Set("Content-Type", "application/json")
+		base := map[string]any{
+			"transaction_id":    plaidTxnID,
+			"account_id":        plaidAcctID,
+			"amount":            12.34,
+			"iso_currency_code": "USD",
+			"name":              "WHOLE FOODS",
+			"merchant_name":     "Whole Foods",
+			"date":              "2026-05-10",
+			"pending":           false,
+			"personal_finance_category": map[string]any{
+				"primary":  "FOOD_AND_DRINK",
+				"detailed": "GROCERIES",
+			},
+		}
+		var added, modified []map[string]any
+		if calls == 1 {
+			added = []map[string]any{base}
+		} else {
+			// Second call: same Plaid txn comes through as a `modified`
+			// (e.g., merchant_name cleaned up by Plaid). PFC unchanged.
+			modified = []map[string]any{base}
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"added":       added,
+			"modified":    modified,
+			"removed":     []any{},
+			"next_cursor": "next",
+			"has_more":    false,
+			"request_id":  "req",
+		})
+	})
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		t.Errorf("unexpected Plaid call: %s %s", r.Method, r.URL.Path)
+		http.Error(w, "unexpected", 500)
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv, &calls
+}
+
+// TestPlaidSync_CategoryMappingFirstPass_AndPreservesUserChoiceOnReSync:
+//
+// Acceptance criteria from #64:
+//   - First sync applies the Plaid PFC → category default
+//   - User then re-categorizes the row (writes a different category_id)
+//   - Second sync (same txn comes through as `modified`) MUST NOT overwrite
+//     the user's choice
+func TestPlaidSync_CategoryMappingFirstPass_AndPreservesUserChoiceOnReSync(t *testing.T) {
+	g := openPlaidTestDB(t)
+	userID := seedPlaidTestUser(t, g)
+
+	// Seed two distinct categories: the Plaid default (groceries) and the
+	// one the user will re-classify into (entertainment, picked because
+	// it's nothing FOOD_AND_DRINK/GROCERIES would ever map to so the
+	// assertion is unambiguous).
+	var groceries, entertainment model.Category
+	if err := g.Where("slug = ?", "groceries").First(&groceries).Error; err != nil {
+		t.Fatalf("groceries category: %v", err)
+	}
+	if err := g.Where("slug = ?", "entertainment").First(&entertainment).Error; err != nil {
+		t.Fatalf("entertainment category: %v", err)
+	}
+
+	const plaidAcctID = "pacct-pfc-1"
+	const plaidTxnID = "ptx-pfc-1"
+	acct := &model.Account{
+		UserID: userID, Name: "PFC Acct", InstitutionSlug: "ins_test",
+		AccountType: "checking", Currency: "USD",
+		PlaidAccountID: ptr(plaidAcctID), IsActive: true,
+	}
+	if err := g.Create(acct).Error; err != nil {
+		t.Fatalf("seed account: %v", err)
+	}
+	t.Cleanup(func() {
+		g.Unscoped().Where("user_id = ?", userID).Delete(&model.Transaction{})
+		g.Unscoped().Delete(&model.Account{}, acct.ID)
+	})
+
+	srv, _ := fakeServerPFC(t, plaidAcctID, plaidTxnID)
+	client, _ := plaidsvc.NewSDKClient(plaidsvc.Config{ClientID: "cid", Secret: "csec", Env: srv.URL})
+	box, _ := crypto.NewSecretBox(newTestKey())
+	itemRepo := repository.NewPlaidItemRepository(g)
+	acctRepo := repository.NewAccountRepository(g)
+	txRepo := repository.NewTransactionRepository(g)
+	piiSvc := service.NewPIIService(repository.NewPIIRepository(g), service.NewAccountService(acctRepo))
+
+	// Real mapper loaded from the seeded plaid_category_map table.
+	mapper, err := plaidsvc.NewCategoryMapper(context.Background(),
+		repository.NewPlaidCategoryMapRepository(g))
+	if err != nil {
+		t.Fatalf("NewCategoryMapper: %v", err)
+	}
+	if mapper.Size() == 0 {
+		t.Fatal("plaid_category_map appears empty — migration 000005 didn't seed?")
+	}
+
+	enc, _ := box.Encrypt([]byte("access-sandbox-fake"))
+	item := &model.PlaidItem{UserID: userID, PlaidItemID: "item-pfc", AccessTokenEnc: enc, Status: "active"}
+	if err := itemRepo.Create(context.Background(), item); err != nil {
+		t.Fatalf("seed item: %v", err)
+	}
+
+	svc := plaidsvc.NewService(client, box, itemRepo, acctRepo, txRepo, piiSvc, mapper, g)
+
+	// First sync: row is created with the Plaid default category.
+	if _, err := svc.SyncTransactions(context.Background(), userID, "item-pfc"); err != nil {
+		t.Fatalf("sync #1: %v", err)
+	}
+	var afterFirst model.Transaction
+	if err := g.Where("plaid_transaction_id = ?", plaidTxnID).First(&afterFirst).Error; err != nil {
+		t.Fatalf("fetch after sync #1: %v", err)
+	}
+	if afterFirst.CategoryID == nil || *afterFirst.CategoryID != groceries.ID {
+		t.Errorf("first sync category = %v, want groceries (%d)", afterFirst.CategoryID, groceries.ID)
+	}
+	if afterFirst.CategorizationMethod == nil || *afterFirst.CategorizationMethod != "plaid_default" {
+		t.Errorf("categorization_method = %v, want plaid_default", afterFirst.CategorizationMethod)
+	}
+
+	// User reclassifies — same write the UI would issue.
+	if err := g.Model(&model.Transaction{}).
+		Where("id = ?", afterFirst.ID).
+		Updates(map[string]any{
+			"category_id":           entertainment.ID,
+			"categorization_method": "manual",
+		}).Error; err != nil {
+		t.Fatalf("user reclassify: %v", err)
+	}
+
+	// Second sync: same Plaid PFC, but the same txn now arrives as `modified`.
+	// MergePlaidUpdate must NOT overwrite the user's category.
+	if _, err := svc.SyncTransactions(context.Background(), userID, "item-pfc"); err != nil {
+		t.Fatalf("sync #2: %v", err)
+	}
+	var afterSecond model.Transaction
+	if err := g.Where("plaid_transaction_id = ?", plaidTxnID).First(&afterSecond).Error; err != nil {
+		t.Fatalf("fetch after sync #2: %v", err)
+	}
+	if afterSecond.CategoryID == nil || *afterSecond.CategoryID != entertainment.ID {
+		t.Errorf("after re-sync category = %v, want entertainment (%d) — user choice clobbered",
+			afterSecond.CategoryID, entertainment.ID)
+	}
+	if afterSecond.CategorizationMethod == nil || *afterSecond.CategorizationMethod != "manual" {
+		t.Errorf("after re-sync categorization_method = %v, want manual — should not revert to plaid_default",
+			afterSecond.CategorizationMethod)
+	}
+}
+
+// TestPlaidSync_NoMappingLeavesCategoryNull: when the PFC doesn't resolve
+// (and the row arrives with no PFC at all, e.g., legacy/unclassified),
+// CategoryID + CategorizationMethod are both nil. Captures the "manual
+// re-categorization always wins; this is just a sane default" contract.
+func TestPlaidSync_NoMappingLeavesCategoryNull(t *testing.T) {
+	g := openPlaidTestDB(t)
+	userID := seedPlaidTestUser(t, g)
+
+	const plaidAcctID = "pacct-no-pfc"
+	const plaidTxnID = "ptx-no-pfc"
+	acct := &model.Account{
+		UserID: userID, Name: "NoPFC Acct", InstitutionSlug: "ins_test",
+		AccountType: "checking", Currency: "USD",
+		PlaidAccountID: ptr(plaidAcctID), IsActive: true,
+	}
+	if err := g.Create(acct).Error; err != nil {
+		t.Fatalf("seed account: %v", err)
+	}
+	t.Cleanup(func() {
+		g.Unscoped().Where("user_id = ?", userID).Delete(&model.Transaction{})
+		g.Unscoped().Delete(&model.Account{}, acct.ID)
+	})
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"added": []map[string]any{
+				{
+					"transaction_id":    plaidTxnID,
+					"account_id":        plaidAcctID,
+					"amount":            1.00,
+					"iso_currency_code": "USD",
+					"name":              "Mystery",
+					"date":              "2026-05-10",
+					"pending":           false,
+					// No personal_finance_category at all.
+				},
+			},
+			"modified":    []any{},
+			"removed":     []any{},
+			"next_cursor": "n",
+			"has_more":    false,
+			"request_id":  "r",
+		})
+	}))
+	t.Cleanup(srv.Close)
+
+	client, _ := plaidsvc.NewSDKClient(plaidsvc.Config{ClientID: "cid", Secret: "csec", Env: srv.URL})
+	box, _ := crypto.NewSecretBox(newTestKey())
+	itemRepo := repository.NewPlaidItemRepository(g)
+	acctRepo := repository.NewAccountRepository(g)
+	txRepo := repository.NewTransactionRepository(g)
+	piiSvc := service.NewPIIService(repository.NewPIIRepository(g), service.NewAccountService(acctRepo))
+	mapper, _ := plaidsvc.NewCategoryMapper(context.Background(), repository.NewPlaidCategoryMapRepository(g))
+
+	enc, _ := box.Encrypt([]byte("access-sandbox-fake"))
+	item := &model.PlaidItem{UserID: userID, PlaidItemID: "item-no-pfc", AccessTokenEnc: enc, Status: "active"}
+	if err := itemRepo.Create(context.Background(), item); err != nil {
+		t.Fatalf("seed item: %v", err)
+	}
+
+	svc := plaidsvc.NewService(client, box, itemRepo, acctRepo, txRepo, piiSvc, mapper, g)
+	if _, err := svc.SyncTransactions(context.Background(), userID, "item-no-pfc"); err != nil {
+		t.Fatalf("sync: %v", err)
+	}
+
+	var got model.Transaction
+	if err := g.Where("plaid_transaction_id = ?", plaidTxnID).First(&got).Error; err != nil {
+		t.Fatalf("fetch: %v", err)
+	}
+	if got.CategoryID != nil {
+		t.Errorf("category_id = %v, want nil (no mapping resolved)", got.CategoryID)
+	}
+	if got.CategorizationMethod != nil {
+		t.Errorf("categorization_method = %v, want nil", got.CategorizationMethod)
+	}
+}

--- a/backend/internal/service/plaid/category_mapping_test.go
+++ b/backend/internal/service/plaid/category_mapping_test.go
@@ -1,0 +1,93 @@
+package plaid_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gregwym/offbook/backend/internal/repository"
+	plaidsvc "github.com/gregwym/offbook/backend/internal/service/plaid"
+)
+
+// fakeMapRepo is an in-memory PlaidCategoryMapRepository for unit tests.
+// Real DB is exercised separately in the integration test.
+type fakeMapRepo struct {
+	rows []repository.PlaidCategoryMapping
+}
+
+func (r *fakeMapRepo) LoadAll(context.Context) ([]repository.PlaidCategoryMapping, error) {
+	return r.rows, nil
+}
+
+func TestCategoryMapper_LookupTable(t *testing.T) {
+	repo := &fakeMapRepo{rows: []repository.PlaidCategoryMapping{
+		{PlaidPrimary: "FOOD_AND_DRINK", PlaidDetailed: "GROCERIES", CategoryID: 100},
+		{PlaidPrimary: "FOOD_AND_DRINK", PlaidDetailed: "RESTAURANT", CategoryID: 101},
+		{PlaidPrimary: "TRANSPORTATION", PlaidDetailed: "GAS", CategoryID: 200},
+		{PlaidPrimary: "TRANSPORTATION", PlaidDetailed: "TAXIS_AND_RIDE_SHARES", CategoryID: 201},
+		{PlaidPrimary: "INCOME", PlaidDetailed: "WAGES", CategoryID: 300},
+		{PlaidPrimary: "BANK_FEES", PlaidDetailed: "OVERDRAFT_FEES", CategoryID: 400},
+	}}
+	m, err := plaidsvc.NewCategoryMapper(context.Background(), repo)
+	if err != nil {
+		t.Fatalf("NewCategoryMapper: %v", err)
+	}
+	if m.Size() != 6 {
+		t.Errorf("Size = %d, want 6", m.Size())
+	}
+
+	cases := []struct {
+		name     string
+		primary  string
+		detailed string
+		wantID   int64
+		wantOK   bool
+	}{
+		{"groceries", "FOOD_AND_DRINK", "GROCERIES", 100, true},
+		{"restaurant", "FOOD_AND_DRINK", "RESTAURANT", 101, true},
+		{"gas", "TRANSPORTATION", "GAS", 200, true},
+		{"rideshare", "TRANSPORTATION", "TAXIS_AND_RIDE_SHARES", 201, true},
+		{"wages", "INCOME", "WAGES", 300, true},
+		{"overdraft", "BANK_FEES", "OVERDRAFT_FEES", 400, true},
+
+		// Unmapped — Plaid does have these PFCs, we just didn't seed them.
+		{"unmapped detailed", "FOOD_AND_DRINK", "BEER_WINE_AND_LIQUOR", 0, false},
+		{"unknown primary", "MYSTERY", "RESTAURANT", 0, false},
+		// Edge cases: empty inputs never match (defensive — Plaid may omit
+		// PFC on a stray transaction).
+		{"empty primary", "", "GROCERIES", 0, false},
+		{"empty detailed", "FOOD_AND_DRINK", "", 0, false},
+		{"both empty", "", "", 0, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotID, gotOK := m.MapPlaidCategory(tc.primary, tc.detailed)
+			if gotID != tc.wantID || gotOK != tc.wantOK {
+				t.Errorf("(%q,%q) → (%d, %v), want (%d, %v)",
+					tc.primary, tc.detailed, gotID, gotOK, tc.wantID, tc.wantOK)
+			}
+		})
+	}
+}
+
+func TestCategoryMapper_NilSafe(t *testing.T) {
+	var m *plaidsvc.CategoryMapper
+	if id, ok := m.MapPlaidCategory("FOOD_AND_DRINK", "GROCERIES"); ok || id != 0 {
+		t.Errorf("nil receiver should return (0, false), got (%d, %v)", id, ok)
+	}
+	if m.Size() != 0 {
+		t.Errorf("nil receiver Size = %d, want 0", m.Size())
+	}
+}
+
+func TestCategoryMapper_EmptyLoad(t *testing.T) {
+	m, err := plaidsvc.NewCategoryMapper(context.Background(), &fakeMapRepo{})
+	if err != nil {
+		t.Fatalf("NewCategoryMapper: %v", err)
+	}
+	if m.Size() != 0 {
+		t.Errorf("Size = %d, want 0 for empty repo", m.Size())
+	}
+	if _, ok := m.MapPlaidCategory("FOOD_AND_DRINK", "GROCERIES"); ok {
+		t.Error("empty mapper should not return a hit")
+	}
+}

--- a/backend/internal/service/plaid/client.go
+++ b/backend/internal/service/plaid/client.go
@@ -65,6 +65,11 @@ type PlaidTransaction struct {
 	Date               string  // "YYYY-MM-DD"
 	AuthorizedDate     *string // optional "YYYY-MM-DD"
 	Pending            bool
+	// Personal finance category — Plaid's hierarchical taxonomy.
+	// Strings (not enums) so we never need a Go release to add a new PFC.
+	// May be "" when Plaid hasn't classified a transaction (rare).
+	PFCPrimary  string
+	PFCDetailed string
 }
 
 // AccountsResult bundles the institution descriptor and the account list
@@ -314,6 +319,10 @@ func convertPlaidTransaction(t plaid.Transaction) PlaidTransaction {
 	if ad, ok := t.GetAuthorizedDateOk(); ok && ad != nil && *ad != "" {
 		v := *ad
 		out.AuthorizedDate = &v
+	}
+	if pfc, ok := t.GetPersonalFinanceCategoryOk(); ok && pfc != nil {
+		out.PFCPrimary = pfc.GetPrimary()
+		out.PFCDetailed = pfc.GetDetailed()
 	}
 	return out
 }

--- a/backend/internal/service/plaid/dedup_test.go
+++ b/backend/internal/service/plaid/dedup_test.go
@@ -106,7 +106,7 @@ func TestPlaidSync_NoDuplicatesOnReSync(t *testing.T) {
 		t.Fatalf("seed item: %v", err)
 	}
 
-	svc := plaidsvc.NewService(client, box, itemRepo, acctRepo, txRepo, piiSvc, g)
+	svc := plaidsvc.NewService(client, box, itemRepo, acctRepo, txRepo, piiSvc, nil, g)
 
 	// First sync: 2 inserts.
 	r1, err := svc.SyncTransactions(context.Background(), userID, "item-dedup")
@@ -236,7 +236,7 @@ func TestPlaidSync_SoftDeletedReSurfaces(t *testing.T) {
 		t.Fatalf("seed item: %v", err)
 	}
 
-	svc := plaidsvc.NewService(client, box, itemRepo, acctRepo, txRepo, piiSvc, g)
+	svc := plaidsvc.NewService(client, box, itemRepo, acctRepo, txRepo, piiSvc, nil, g)
 
 	r, err := svc.SyncTransactions(context.Background(), userID, "item-resurface")
 	if err != nil {

--- a/backend/internal/service/plaid/merge_update_test.go
+++ b/backend/internal/service/plaid/merge_update_test.go
@@ -43,7 +43,7 @@ func TestMergePlaidUpdate_PendingToPosted(t *testing.T) {
 		AuthorizedDate:     &auth,
 	}
 
-	merged, err := plaidsvc.MergePlaidUpdate(existing, incoming, 11)
+	merged, err := plaidsvc.MergePlaidUpdate(existing, incoming, 11, nil)
 	if err != nil {
 		t.Fatalf("MergePlaidUpdate: %v", err)
 	}
@@ -103,7 +103,7 @@ func TestMergePlaidUpdate_NilFieldsClearable(t *testing.T) {
 		Date:               "2026-05-10",
 		// MerchantName intentionally nil
 	}
-	merged, err := plaidsvc.MergePlaidUpdate(existing, incoming, 1)
+	merged, err := plaidsvc.MergePlaidUpdate(existing, incoming, 1, nil)
 	if err != nil {
 		t.Fatalf("MergePlaidUpdate: %v", err)
 	}

--- a/backend/internal/service/plaid/service.go
+++ b/backend/internal/service/plaid/service.go
@@ -67,6 +67,9 @@ type Service struct {
 	acctRepo repository.AccountRepository
 	txRepo   repository.TransactionRepository
 	piiSvc   *service.PIIService
+	// catMapper resolves Plaid PFCs to local categories at sync time.
+	// Nil = no auto-categorization (rows land uncategorized; user picks).
+	catMapper *CategoryMapper
 	// db is a deliberate exception to the "services don't see *gorm.DB"
 	// guideline. SyncTransactions needs a single atomic wrap across
 	// transactions + plaid_items updates per ADR-N/A (per-item sync is
@@ -79,9 +82,11 @@ type Service struct {
 
 // NewService constructs a Service. Pass nil for client/box/repos to
 // indicate the instance is not Plaid-enabled — calls then return
-// ErrNotConfigured. txRepo, piiSvc, and db are only needed for the
-// discovery and transaction-sync surfaces; link-only setups can pass nil
-// and the affected methods will error out cleanly.
+// ErrNotConfigured. txRepo, piiSvc, db, and catMapper are only needed
+// for the discovery and transaction-sync surfaces; link-only setups can
+// pass nil and the affected methods will error out cleanly. catMapper
+// may be nil even when Plaid is otherwise configured — transactions
+// then land uncategorized.
 func NewService(
 	client Client,
 	box *crypto.SecretBox,
@@ -89,16 +94,18 @@ func NewService(
 	acctRepo repository.AccountRepository,
 	txRepo repository.TransactionRepository,
 	piiSvc *service.PIIService,
+	catMapper *CategoryMapper,
 	db *gorm.DB,
 ) *Service {
 	return &Service{
-		client:   client,
-		box:      box,
-		itemRepo: itemRepo,
-		acctRepo: acctRepo,
-		txRepo:   txRepo,
-		piiSvc:   piiSvc,
-		db:       db,
+		client:    client,
+		box:       box,
+		itemRepo:  itemRepo,
+		acctRepo:  acctRepo,
+		txRepo:    txRepo,
+		piiSvc:    piiSvc,
+		catMapper: catMapper,
+		db:        db,
 	}
 }
 
@@ -406,7 +413,7 @@ func (s *Service) SyncTransactions(ctx context.Context, userID int64, plaidItemI
 				if err != nil {
 					return err
 				}
-				merged, err := MergePlaidUpdate(existing, incoming, localID)
+				merged, err := MergePlaidUpdate(existing, incoming, localID, s.catMapper)
 				if err != nil {
 					return err
 				}
@@ -426,7 +433,7 @@ func (s *Service) SyncTransactions(ctx context.Context, userID int64, plaidItemI
 				if err != nil {
 					return err
 				}
-				row, err := MapPlaidTransaction(pt, userID, localID)
+				row, err := MapPlaidTransaction(pt, userID, localID, s.catMapper)
 				if err != nil {
 					return err
 				}
@@ -455,7 +462,7 @@ func (s *Service) SyncTransactions(ctx context.Context, userID int64, plaidItemI
 			if errors.Is(err, gorm.ErrRecordNotFound) {
 				// Plaid sent a `modified` for something we never
 				// recorded. Treat as a fresh insert so we don't lose it.
-				row, mapErr := MapPlaidTransaction(pt, userID, localID)
+				row, mapErr := MapPlaidTransaction(pt, userID, localID, s.catMapper)
 				if mapErr != nil {
 					return mapErr
 				}
@@ -468,7 +475,7 @@ func (s *Service) SyncTransactions(ctx context.Context, userID int64, plaidItemI
 			if err != nil {
 				return fmt.Errorf("plaid: read existing for modify: %w", err)
 			}
-			merged, err := MergePlaidUpdate(existing, pt, localID)
+			merged, err := MergePlaidUpdate(existing, pt, localID, s.catMapper)
 			if err != nil {
 				return err
 			}

--- a/backend/internal/service/plaid/service_test.go
+++ b/backend/internal/service/plaid/service_test.go
@@ -116,7 +116,7 @@ func TestService_CreateLinkToken_HappyPath(t *testing.T) {
 	if err != nil {
 		t.Fatalf("secretbox: %v", err)
 	}
-	svc := plaidsvc.NewService(client, box, &fakeRepo{}, nil, nil, nil, nil)
+	svc := plaidsvc.NewService(client, box, &fakeRepo{}, nil, nil, nil, nil, nil)
 
 	tok, err := svc.CreateLinkToken(context.Background(), 42)
 	if err != nil {
@@ -141,7 +141,7 @@ func TestService_ExchangePublicToken_HappyPath(t *testing.T) {
 	client, _ := plaidsvc.NewSDKClient(plaidsvc.Config{ClientID: "cid", Secret: "csec", Env: srv.URL})
 	box, _ := crypto.NewSecretBox(newTestKey())
 	repo := &fakeRepo{}
-	svc := plaidsvc.NewService(client, box, repo, nil, nil, nil, nil)
+	svc := plaidsvc.NewService(client, box, repo, nil, nil, nil, nil, nil)
 
 	item, err := svc.ExchangePublicToken(context.Background(), 7, "public-sandbox-xyz")
 	if err != nil {
@@ -180,7 +180,7 @@ func TestService_ExchangePublicToken_RejectsEmpty(t *testing.T) {
 	srv, _ := fakePlaid(t)
 	client, _ := plaidsvc.NewSDKClient(plaidsvc.Config{ClientID: "cid", Secret: "csec", Env: srv.URL})
 	box, _ := crypto.NewSecretBox(newTestKey())
-	svc := plaidsvc.NewService(client, box, &fakeRepo{}, nil, nil, nil, nil)
+	svc := plaidsvc.NewService(client, box, &fakeRepo{}, nil, nil, nil, nil, nil)
 
 	if _, err := svc.ExchangePublicToken(context.Background(), 1, "   "); err != plaidsvc.ErrInvalidPublicToken {
 		t.Fatalf("expected ErrInvalidPublicToken, got %v", err)
@@ -188,7 +188,7 @@ func TestService_ExchangePublicToken_RejectsEmpty(t *testing.T) {
 }
 
 func TestService_NotConfigured(t *testing.T) {
-	svc := plaidsvc.NewService(nil, nil, nil, nil, nil, nil, nil)
+	svc := plaidsvc.NewService(nil, nil, nil, nil, nil, nil, nil, nil)
 	if svc.Configured() {
 		t.Fatal("expected !Configured")
 	}

--- a/backend/internal/service/plaid/sync_accounts_integration_test.go
+++ b/backend/internal/service/plaid/sync_accounts_integration_test.go
@@ -209,7 +209,7 @@ func TestService_SyncAccounts_PIIIsolationAndIdempotency(t *testing.T) {
 		t.Fatalf("seed item: %v", err)
 	}
 
-	svc := plaidsvc.NewService(client, box, itemRepo, acctRepo, repository.NewTransactionRepository(g), piiSvc, g)
+	svc := plaidsvc.NewService(client, box, itemRepo, acctRepo, repository.NewTransactionRepository(g), piiSvc, nil, g)
 
 	// First sync: 2 accounts created.
 	r1, err := svc.SyncAccounts(context.Background(), userID, "item-fake-sync-1")
@@ -305,7 +305,7 @@ func TestService_SyncAccounts_ItemNotFound(t *testing.T) {
 	acctRepo := repository.NewAccountRepository(g)
 	acctSvc := service.NewAccountService(acctRepo)
 	piiSvc := service.NewPIIService(repository.NewPIIRepository(g), acctSvc)
-	svc := plaidsvc.NewService(client, box, itemRepo, acctRepo, repository.NewTransactionRepository(g), piiSvc, g)
+	svc := plaidsvc.NewService(client, box, itemRepo, acctRepo, repository.NewTransactionRepository(g), piiSvc, nil, g)
 
 	_, err := svc.SyncAccounts(context.Background(), userID, "nonexistent-item")
 	if err != plaidsvc.ErrItemNotFound {

--- a/backend/internal/service/plaid/sync_transactions_incremental_test.go
+++ b/backend/internal/service/plaid/sync_transactions_incremental_test.go
@@ -167,7 +167,7 @@ func TestService_SyncTransactions_IncrementalAddedModifiedRemoved(t *testing.T) 
 	acctRepo := repository.NewAccountRepository(g)
 	txRepo := repository.NewTransactionRepository(g)
 	piiSvc := service.NewPIIService(repository.NewPIIRepository(g), service.NewAccountService(acctRepo))
-	svc := plaidsvc.NewService(client, box, itemRepo, acctRepo, txRepo, piiSvc, g)
+	svc := plaidsvc.NewService(client, box, itemRepo, acctRepo, txRepo, piiSvc, nil, g)
 
 	r, err := svc.SyncTransactions(context.Background(), userID, "item-incr-1")
 	if err != nil {
@@ -325,7 +325,7 @@ func TestService_SyncTransactions_TenantIsolation(t *testing.T) {
 	acctRepo := repository.NewAccountRepository(g)
 	txRepo := repository.NewTransactionRepository(g)
 	piiSvc := service.NewPIIService(repository.NewPIIRepository(g), service.NewAccountService(acctRepo))
-	svc := plaidsvc.NewService(client, box, itemRepo, acctRepo, txRepo, piiSvc, g)
+	svc := plaidsvc.NewService(client, box, itemRepo, acctRepo, txRepo, piiSvc, nil, g)
 
 	if _, err := svc.SyncTransactions(context.Background(), userA, "item-A"); err != nil {
 		t.Fatalf("Sync user A: %v", err)

--- a/backend/internal/service/plaid/sync_transactions_integration_test.go
+++ b/backend/internal/service/plaid/sync_transactions_integration_test.go
@@ -146,7 +146,7 @@ func TestService_SyncTransactions_PaginatesAndPersistsCursor(t *testing.T) {
 		t.Fatalf("seed item: %v", err)
 	}
 
-	svc := plaidsvc.NewService(client, box, itemRepo, acctRepo, txRepo, piiSvc, g)
+	svc := plaidsvc.NewService(client, box, itemRepo, acctRepo, txRepo, piiSvc, nil, g)
 
 	// First full pull
 	r, err := svc.SyncTransactions(context.Background(), userID, "item-sync-1")
@@ -238,7 +238,7 @@ func TestService_SyncTransactions_UnknownAccountErrors(t *testing.T) {
 		t.Fatalf("seed item: %v", err)
 	}
 
-	svc := plaidsvc.NewService(client, box, itemRepo, acctRepo, txRepo, piiSvc, g)
+	svc := plaidsvc.NewService(client, box, itemRepo, acctRepo, txRepo, piiSvc, nil, g)
 	_, err := svc.SyncTransactions(context.Background(), userID, "item-orphan")
 	if err == nil {
 		t.Fatal("expected error when plaid_account_id can't resolve to a local account")

--- a/backend/internal/service/plaid/transaction_mapping.go
+++ b/backend/internal/service/plaid/transaction_mapping.go
@@ -26,7 +26,12 @@ import (
 //
 // userID + accountID are supplied by the service after resolving the
 // session user and matching the Plaid account_id to a local accounts.id.
-func MapPlaidTransaction(p PlaidTransaction, userID, accountID int64) (model.Transaction, error) {
+//
+// The mapper is optional (nil = no auto-categorization). When non-nil and
+// the (PFCPrimary, PFCDetailed) pair resolves, CategoryID is set and
+// CategorizationMethod is "plaid_default". User-edited values always win
+// on subsequent updates — see MergePlaidUpdate.
+func MapPlaidTransaction(p PlaidTransaction, userID, accountID int64, mapper *CategoryMapper) (model.Transaction, error) {
 	if p.PlaidTransactionID == "" {
 		return model.Transaction{}, fmt.Errorf("plaid: transaction_id empty")
 	}
@@ -58,7 +63,7 @@ func MapPlaidTransaction(p PlaidTransaction, userID, accountID int64) (model.Tra
 		description = &v
 	}
 
-	return model.Transaction{
+	out := model.Transaction{
 		UserID:             userID,
 		AccountID:          accountID,
 		Amount:             p.Amount.Neg(), // sign flip, see header
@@ -70,7 +75,14 @@ func MapPlaidTransaction(p PlaidTransaction, userID, accountID int64) (model.Tra
 		Source:             source,
 		ExternalID:         &externalID,
 		PlaidTransactionID: &plaidID,
-	}, nil
+	}
+
+	if catID, ok := mapper.MapPlaidCategory(p.PFCPrimary, p.PFCDetailed); ok {
+		out.CategoryID = &catID
+		method := CategorizationMethodPlaidDefault
+		out.CategorizationMethod = &method
+	}
+	return out, nil
 }
 
 // MergePlaidUpdate overlays an incoming /transactions/sync `modified` entry
@@ -86,8 +98,8 @@ func MapPlaidTransaction(p PlaidTransaction, userID, accountID int64) (model.Tra
 // The function is pure — it returns the merged row without writing. Caller
 // passes the result to the repo's update method. accountID is supplied
 // (rather than re-derived) so the merge stays independent of repo state.
-func MergePlaidUpdate(existing model.Transaction, incoming PlaidTransaction, accountID int64) (model.Transaction, error) {
-	mapped, err := MapPlaidTransaction(incoming, existing.UserID, accountID)
+func MergePlaidUpdate(existing model.Transaction, incoming PlaidTransaction, accountID int64, mapper *CategoryMapper) (model.Transaction, error) {
+	mapped, err := MapPlaidTransaction(incoming, existing.UserID, accountID, mapper)
 	if err != nil {
 		return model.Transaction{}, err
 	}
@@ -100,11 +112,19 @@ func MergePlaidUpdate(existing model.Transaction, incoming PlaidTransaction, acc
 	merged.MerchantName = mapped.MerchantName
 	merged.TransactionDate = mapped.TransactionDate
 	merged.PostedDate = mapped.PostedDate
+	// Category: a non-null existing CategoryID is sacred — that's either
+	// the user's manual pick OR a prior plaid_default that the user has
+	// implicitly accepted. Only fill from the mapper when the row has no
+	// category yet (e.g., previously imported before the mapper existed,
+	// or Plaid only just classified this transaction).
+	if existing.CategoryID == nil && mapped.CategoryID != nil {
+		merged.CategoryID = mapped.CategoryID
+		merged.CategorizationMethod = mapped.CategorizationMethod
+	}
 	// User-edited fields — preserve. Intentionally not enumerated as
 	// "deny-list overlay" because the safer default for unknown future
 	// fields is "leave it alone".
-	//   existing.Notes, existing.CategoryID, existing.IsTransfer,
-	//   existing.TransferPairID, existing.CategorizationMethod
+	//   existing.Notes, existing.IsTransfer, existing.TransferPairID
 	// remain on `merged`.
 	return merged, nil
 }

--- a/backend/internal/service/plaid/transaction_mapping_test.go
+++ b/backend/internal/service/plaid/transaction_mapping_test.go
@@ -22,7 +22,7 @@ func TestMapPlaidTransaction_SignFlipAndDates(t *testing.T) {
 		Date:               "2026-05-16",
 		AuthorizedDate:     &authDate,
 	}
-	got, err := plaidsvc.MapPlaidTransaction(in, 7, 42)
+	got, err := plaidsvc.MapPlaidTransaction(in, 7, 42, nil)
 	if err != nil {
 		t.Fatalf("MapPlaidTransaction: %v", err)
 	}
@@ -66,7 +66,7 @@ func TestMapPlaidTransaction_NilAuthorizedDate(t *testing.T) {
 		Name:               "Payroll deposit",
 		Date:               "2026-05-01",
 	}
-	got, err := plaidsvc.MapPlaidTransaction(in, 1, 2)
+	got, err := plaidsvc.MapPlaidTransaction(in, 1, 2, nil)
 	if err != nil {
 		t.Fatalf("MapPlaidTransaction: %v", err)
 	}
@@ -88,7 +88,7 @@ func TestMapPlaidTransaction_PrecisionPreserved(t *testing.T) {
 		Name:     "Micro txn",
 		Date:     "2026-05-01",
 	}
-	got, err := plaidsvc.MapPlaidTransaction(in, 1, 2)
+	got, err := plaidsvc.MapPlaidTransaction(in, 1, 2, nil)
 	if err != nil {
 		t.Fatalf("MapPlaidTransaction: %v", err)
 	}
@@ -105,7 +105,7 @@ func TestMapPlaidTransaction_RejectsBadDate(t *testing.T) {
 		Amount:             decimal.NewFromInt(1),
 		Date:               "not-a-date",
 	}
-	if _, err := plaidsvc.MapPlaidTransaction(in, 1, 2); err == nil {
+	if _, err := plaidsvc.MapPlaidTransaction(in, 1, 2, nil); err == nil {
 		t.Fatal("expected parse error for malformed date")
 	}
 }
@@ -119,7 +119,7 @@ func TestMapPlaidTransaction_DateIsUTC(t *testing.T) {
 		Amount:             decimal.NewFromInt(1),
 		Date:               "2026-01-31",
 	}
-	got, err := plaidsvc.MapPlaidTransaction(in, 1, 2)
+	got, err := plaidsvc.MapPlaidTransaction(in, 1, 2, nil)
 	if err != nil {
 		t.Fatalf("MapPlaidTransaction: %v", err)
 	}

--- a/backend/migrations/000005_plaid_category_map.down.sql
+++ b/backend/migrations/000005_plaid_category_map.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS plaid_category_map;

--- a/backend/migrations/000005_plaid_category_map.up.sql
+++ b/backend/migrations/000005_plaid_category_map.up.sql
@@ -1,0 +1,138 @@
+-- #64: persistent mapping from Plaid personal_finance_category (PFC) to
+-- our internal categories. Lives in SQL (not Go literals) so an admin can
+-- edit/extend the table without a Go release and so the mapping is
+-- reviewable in git diffs.
+--
+-- PK is (plaid_primary, plaid_detailed). A row with NO mapping = the
+-- transaction lands uncategorized and the user picks. Manual choices
+-- always win on update — see transaction_mapping.go.
+CREATE TABLE plaid_category_map (
+    plaid_primary  TEXT   NOT NULL,
+    plaid_detailed TEXT   NOT NULL,
+    category_id    BIGINT NOT NULL REFERENCES categories(id),
+    PRIMARY KEY (plaid_primary, plaid_detailed)
+);
+CREATE INDEX ix_plaid_category_map_category_id ON plaid_category_map (category_id);
+
+-- Seed common Plaid PFCs. Reference taxonomy:
+--   https://plaid.com/documents/transactions-personal-finance-category-taxonomy.csv
+-- Insert by joining against categories.slug so the mapping survives a
+-- categories.id reshuffle (system categories are seeded in 000002).
+INSERT INTO plaid_category_map (plaid_primary, plaid_detailed, category_id)
+SELECT v.plaid_primary, v.plaid_detailed, c.id
+FROM (VALUES
+    -- INCOME → income
+    ('INCOME', 'WAGES',                              'income'),
+    ('INCOME', 'TAX_REFUND',                         'income'),
+    ('INCOME', 'DIVIDENDS',                          'income'),
+    ('INCOME', 'INTEREST_EARNED',                    'income'),
+    ('INCOME', 'RETIREMENT_PENSION',                 'income'),
+    ('INCOME', 'UNEMPLOYMENT',                       'income'),
+    ('INCOME', 'OTHER_INCOME',                       'income'),
+
+    -- TRANSFER_IN / TRANSFER_OUT → transfer
+    -- (We do map these to the system "Transfer" category. Down-stream
+    --  spending math should filter on is_transfer / category=transfer
+    --  rather than rely on an unmapped null.)
+    ('TRANSFER_IN',  'ACCOUNT_TRANSFER',             'transfer'),
+    ('TRANSFER_IN',  'DEPOSIT',                      'transfer'),
+    ('TRANSFER_IN',  'SAVINGS',                      'transfer'),
+    ('TRANSFER_IN',  'OTHER_TRANSFER_IN',            'transfer'),
+    ('TRANSFER_OUT', 'ACCOUNT_TRANSFER',             'transfer'),
+    ('TRANSFER_OUT', 'WITHDRAWAL',                   'transfer'),
+    ('TRANSFER_OUT', 'SAVINGS',                      'transfer'),
+    ('TRANSFER_OUT', 'OTHER_TRANSFER_OUT',           'transfer'),
+
+    -- LOAN_PAYMENTS — mostly bills, mortgage is its own bucket
+    ('LOAN_PAYMENTS', 'MORTGAGE_PAYMENT',            'rent-mortgage'),
+    ('LOAN_PAYMENTS', 'CAR_PAYMENT',                 'transportation'),
+    ('LOAN_PAYMENTS', 'STUDENT_LOAN_PAYMENT',        'education'),
+    -- credit_card_payment intentionally unmapped: it's an inter-account
+    -- transfer, not spending. User chooses if they want a category.
+
+    -- BANK_FEES → fees-and-charges
+    ('BANK_FEES', 'ATM_FEES',                        'fees-and-charges'),
+    ('BANK_FEES', 'FOREIGN_TRANSACTION_FEES',        'fees-and-charges'),
+    ('BANK_FEES', 'INSUFFICIENT_FUNDS',              'fees-and-charges'),
+    ('BANK_FEES', 'INTEREST_CHARGE',                 'fees-and-charges'),
+    ('BANK_FEES', 'OVERDRAFT_FEES',                  'fees-and-charges'),
+    ('BANK_FEES', 'OTHER_BANK_FEES',                 'fees-and-charges'),
+
+    -- ENTERTAINMENT → entertainment
+    ('ENTERTAINMENT', 'TV_AND_MOVIES',               'entertainment'),
+    ('ENTERTAINMENT', 'MUSIC_AND_AUDIO',             'entertainment'),
+    ('ENTERTAINMENT', 'VIDEO_GAMES',                 'entertainment'),
+    ('ENTERTAINMENT', 'SPORTING_EVENTS_AMUSEMENT_PARKS_AND_MUSEUMS', 'entertainment'),
+    ('ENTERTAINMENT', 'CASINOS_AND_GAMBLING',        'entertainment'),
+    ('ENTERTAINMENT', 'OTHER_ENTERTAINMENT',         'entertainment'),
+
+    -- FOOD_AND_DRINK
+    ('FOOD_AND_DRINK', 'GROCERIES',                  'groceries'),
+    ('FOOD_AND_DRINK', 'RESTAURANT',                 'food-and-dining'),
+    ('FOOD_AND_DRINK', 'FAST_FOOD',                  'food-and-dining'),
+    ('FOOD_AND_DRINK', 'COFFEE',                     'food-and-dining'),
+    ('FOOD_AND_DRINK', 'BEER_WINE_AND_LIQUOR',       'food-and-dining'),
+    ('FOOD_AND_DRINK', 'VENDING_MACHINES',           'food-and-dining'),
+    ('FOOD_AND_DRINK', 'OTHER_FOOD_AND_DRINK',       'food-and-dining'),
+
+    -- GENERAL_MERCHANDISE → shopping (with clothing carve-out)
+    ('GENERAL_MERCHANDISE', 'CLOTHING_AND_ACCESSORIES', 'clothing'),
+    ('GENERAL_MERCHANDISE', 'DEPARTMENT_STORES',     'shopping'),
+    ('GENERAL_MERCHANDISE', 'ONLINE_MARKETPLACES',   'shopping'),
+    ('GENERAL_MERCHANDISE', 'SUPERSTORES',           'shopping'),
+    ('GENERAL_MERCHANDISE', 'OTHER_GENERAL_MERCHANDISE', 'shopping'),
+
+    -- HOME_IMPROVEMENT → housing
+    ('HOME_IMPROVEMENT', 'FURNITURE',                'housing'),
+    ('HOME_IMPROVEMENT', 'HARDWARE',                 'housing'),
+    ('HOME_IMPROVEMENT', 'REPAIR_AND_MAINTENANCE',   'housing'),
+    ('HOME_IMPROVEMENT', 'OTHER_HOME_IMPROVEMENT',   'housing'),
+
+    -- MEDICAL → healthcare
+    ('MEDICAL', 'DENTAL_CARE',                       'healthcare'),
+    ('MEDICAL', 'EYE_CARE',                          'healthcare'),
+    ('MEDICAL', 'PHARMACIES_AND_SUPPLEMENTS',        'healthcare'),
+    ('MEDICAL', 'PRIMARY_CARE',                      'healthcare'),
+    ('MEDICAL', 'VETERINARY_SERVICES',               'healthcare'),
+    ('MEDICAL', 'OTHER_MEDICAL',                     'healthcare'),
+
+    -- PERSONAL_CARE → personal-care
+    ('PERSONAL_CARE', 'HAIR_AND_BEAUTY',             'personal-care'),
+    ('PERSONAL_CARE', 'LAUNDRY_AND_DRY_CLEANING',    'personal-care'),
+    ('PERSONAL_CARE', 'GYMS_AND_FITNESS_CENTERS',    'personal-care'),
+    ('PERSONAL_CARE', 'OTHER_PERSONAL_CARE',         'personal-care'),
+
+    -- GENERAL_SERVICES — split between insurance and shopping; education has its own
+    ('GENERAL_SERVICES', 'INSURANCE',                'insurance'),
+    ('GENERAL_SERVICES', 'EDUCATION',                'education'),
+    ('GENERAL_SERVICES', 'SUBSCRIPTIONS',            'subscriptions'),
+
+    -- GOVERNMENT_AND_NON_PROFIT
+    ('GOVERNMENT_AND_NON_PROFIT', 'DONATIONS',       'gifts-and-donations'),
+
+    -- TRANSPORTATION
+    ('TRANSPORTATION', 'GAS',                        'gas'),
+    ('TRANSPORTATION', 'PUBLIC_TRANSIT',             'transportation'),
+    ('TRANSPORTATION', 'TAXIS_AND_RIDE_SHARES',      'transportation'),
+    ('TRANSPORTATION', 'PARKING',                    'transportation'),
+    ('TRANSPORTATION', 'TOLLS',                      'transportation'),
+    ('TRANSPORTATION', 'BIKES_AND_SCOOTERS',         'transportation'),
+    ('TRANSPORTATION', 'OTHER_TRANSPORTATION',       'transportation'),
+
+    -- TRAVEL
+    ('TRAVEL', 'FLIGHTS',                            'travel'),
+    ('TRAVEL', 'LODGING',                            'travel'),
+    ('TRAVEL', 'RENTAL_CARS',                        'travel'),
+    ('TRAVEL', 'OTHER_TRAVEL',                       'travel'),
+
+    -- RENT_AND_UTILITIES
+    ('RENT_AND_UTILITIES', 'RENT',                       'rent-mortgage'),
+    ('RENT_AND_UTILITIES', 'GAS_AND_ELECTRICITY',        'utilities'),
+    ('RENT_AND_UTILITIES', 'INTERNET_AND_CABLE',         'utilities'),
+    ('RENT_AND_UTILITIES', 'TELEPHONE',                  'utilities'),
+    ('RENT_AND_UTILITIES', 'WATER',                      'utilities'),
+    ('RENT_AND_UTILITIES', 'SEWAGE_AND_WASTE_MANAGEMENT','utilities'),
+    ('RENT_AND_UTILITIES', 'OTHER_UTILITIES',            'utilities')
+) AS v(plaid_primary, plaid_detailed, slug)
+JOIN categories c ON c.slug = v.slug AND c.deleted_at IS NULL
+ON CONFLICT (plaid_primary, plaid_detailed) DO NOTHING;

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -175,9 +175,12 @@ Otherwise re-importing a previously-deleted transaction fails.
 - **accounts** — `id, name, institution_slug, account_type, currency, balance, last_four, plaid_account_id, plaid_item_id, is_active, created_at, updated_at, deleted_at`
 - **transactions** — `id, account_id, category_id, amount, currency, description, description_clean, merchant_name, transaction_date, posted_date, source, external_id, plaid_transaction_id, categorization_method, is_transfer, transfer_pair_id, notes, created_at, updated_at, deleted_at`
   - `source`: `'plaid' | 'csv' | 'pdf' | 'manual'`
+  - `categorization_method`: `'manual'` (user picked) | `'plaid_default'` (auto-assigned from `plaid_category_map` at Plaid sync). Null when the row is uncategorized. Manual always wins on merge — see `service/plaid/transaction_mapping.go::MergePlaidUpdate`.
   - Partial unique index on `(account_id, external_id) WHERE deleted_at IS NULL` for deduplication (see Soft-delete-safe uniqueness above)
+  - Partial unique index on `(user_id, plaid_transaction_id) WHERE deleted_at IS NULL AND plaid_transaction_id IS NOT NULL` (migration 000004) — user-scoped Plaid dedup
 - **categories** — hierarchical via `parent_id`, seeded with ~20 system categories
 - **categorization_rules** — `pattern, category_id, match_type ('contains'|'regex'|'exact'), priority`
+- **plaid_category_map** — `plaid_primary, plaid_detailed, category_id`. Static lookup table (migration 000005) mapping the Plaid `personal_finance_category` taxonomy to local categories. Editable by SQL migration only — keeps the mapping reviewable in git. Loaded once into a `CategoryMapper` at service construction.
 - **budgets** — `category_id, period ('monthly'|'weekly'|'annual'), amount, rollover, is_active`
 - **savings_goals** — `name, target_amount, current_amount, target_date, account_id`
 - **investments** — append-only snapshots: `account_id, ticker, name, asset_class, quantity, cost_basis, market_value, snapshot_date, source`


### PR DESCRIPTION
## Summary
- New migration **000005** introduces `plaid_category_map(plaid_primary, plaid_detailed, category_id)` with **78 seeded rows** covering the common Plaid `personal_finance_category` taxonomy. Mapping joins on `categories.slug` so it survives category-id reshuffles, and lives in SQL so it's reviewable in git diffs and editable without a Go release.
- `PlaidTransaction` now carries `PFCPrimary` + `PFCDetailed`; SDK converter extracts via `GetPersonalFinanceCategoryOk()`.
- `CategoryMapper` (`internal/service/plaid/category_mapping.go`) loads the table into an in-memory map once at boot. Nil-receiver safe.
- `MapPlaidTransaction` assigns `category_id` + `categorization_method = "plaid_default"` on a mapper hit.
- **`MergePlaidUpdate` never overwrites a non-null existing `category_id`** — user choice always wins on re-sync.
- Router loads the mapper at startup; failure is fatal (forces operator to notice the migration didn't run).
- `docs/ARCHITECTURE.md` updated with the `categorization_method` enum and the new table.

## Test plan
- [x] `TestCategoryMapper_LookupTable` — table-driven hits, misses, empty inputs.
- [x] `TestCategoryMapper_NilSafe` / `TestCategoryMapper_EmptyLoad` — graceful degradation.
- [x] `TestPlaidSync_CategoryMappingFirstPass_AndPreservesUserChoiceOnReSync` — real DB: first sync sets plaid_default; user reclassifies; re-sync (same txn as `modified`) preserves user's category + method.
- [x] `TestPlaidSync_NoMappingLeavesCategoryNull` — txn with no PFC stays uncategorized.
- [x] Full suite green (`go test -p 1 ./...`), `go vet` + `gofmt -l` clean.

Closes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)