### PR TITLE
M3 #65: Plaid sync status indicator per account

### DIFF
--- a/backend/internal/handler/account_handler.go
+++ b/backend/internal/handler/account_handler.go
@@ -71,7 +71,7 @@ func (h *AccountHandler) Get(c *gin.Context) {
 	if !ok {
 		return
 	}
-	a, err := h.svc.Get(c.Request.Context(), auth.MustUserID(c.Request.Context()), id)
+	a, err := h.svc.GetResponse(c.Request.Context(), auth.MustUserID(c.Request.Context()), id)
 	if err != nil {
 		h.writeServiceError(c, err)
 		return
@@ -114,7 +114,7 @@ func (h *AccountHandler) List(c *gin.Context) {
 		f.Offset = n
 	}
 
-	accounts, total, err := h.svc.List(c.Request.Context(), auth.MustUserID(c.Request.Context()), f)
+	accounts, total, err := h.svc.ListResponse(c.Request.Context(), auth.MustUserID(c.Request.Context()), f)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error(), "code": "INTERNAL"})
 		return

--- a/backend/internal/model/plaid_item.go
+++ b/backend/internal/model/plaid_item.go
@@ -23,7 +23,10 @@ type PlaidItem struct {
 	Status          string         `gorm:"not null;default:active" json:"status"`
 	Cursor          *string        `json:"-"`
 	LastSyncedAt    *time.Time     `gorm:"column:last_synced_at" json:"last_synced_at,omitempty"`
-	LastError       *string        `gorm:"column:last_error" json:"last_error,omitempty"`
+	LastSyncError   *string        `gorm:"column:last_sync_error" json:"last_sync_error,omitempty"`
+	// LastSyncStatus: 'never' | 'syncing' | 'ok' | 'error'. The lifecycle
+	// is owned by service/plaid — handlers should not write this directly.
+	LastSyncStatus string `gorm:"column:last_sync_status;not null;default:never" json:"last_sync_status"`
 	CreatedAt       time.Time      `json:"created_at"`
 	UpdatedAt       time.Time      `json:"updated_at"`
 	DeletedAt       gorm.DeletedAt `gorm:"index" json:"-"`

--- a/backend/internal/model/plaid_item.go
+++ b/backend/internal/model/plaid_item.go
@@ -14,22 +14,22 @@ import (
 // invisible to API queries but stays around for historical reconciliation
 // until a hard purge.
 type PlaidItem struct {
-	ID              int64          `gorm:"primaryKey" json:"id"`
-	UserID          int64          `gorm:"not null" json:"user_id"`
-	PlaidItemID     string         `gorm:"column:plaid_item_id;not null" json:"plaid_item_id"`
-	AccessTokenEnc  []byte         `gorm:"column:access_token_enc;type:bytea;not null" json:"-"`
-	InstitutionID   *string        `gorm:"column:institution_id" json:"institution_id,omitempty"`
-	InstitutionName *string        `gorm:"column:institution_name" json:"institution_name,omitempty"`
-	Status          string         `gorm:"not null;default:active" json:"status"`
-	Cursor          *string        `json:"-"`
-	LastSyncedAt    *time.Time     `gorm:"column:last_synced_at" json:"last_synced_at,omitempty"`
-	LastSyncError   *string        `gorm:"column:last_sync_error" json:"last_sync_error,omitempty"`
+	ID              int64      `gorm:"primaryKey" json:"id"`
+	UserID          int64      `gorm:"not null" json:"user_id"`
+	PlaidItemID     string     `gorm:"column:plaid_item_id;not null" json:"plaid_item_id"`
+	AccessTokenEnc  []byte     `gorm:"column:access_token_enc;type:bytea;not null" json:"-"`
+	InstitutionID   *string    `gorm:"column:institution_id" json:"institution_id,omitempty"`
+	InstitutionName *string    `gorm:"column:institution_name" json:"institution_name,omitempty"`
+	Status          string     `gorm:"not null;default:active" json:"status"`
+	Cursor          *string    `json:"-"`
+	LastSyncedAt    *time.Time `gorm:"column:last_synced_at" json:"last_synced_at,omitempty"`
+	LastSyncError   *string    `gorm:"column:last_sync_error" json:"last_sync_error,omitempty"`
 	// LastSyncStatus: 'never' | 'syncing' | 'ok' | 'error'. The lifecycle
 	// is owned by service/plaid — handlers should not write this directly.
-	LastSyncStatus string `gorm:"column:last_sync_status;not null;default:never" json:"last_sync_status"`
-	CreatedAt       time.Time      `json:"created_at"`
-	UpdatedAt       time.Time      `json:"updated_at"`
-	DeletedAt       gorm.DeletedAt `gorm:"index" json:"-"`
+	LastSyncStatus string         `gorm:"column:last_sync_status;not null;default:never" json:"last_sync_status"`
+	CreatedAt      time.Time      `json:"created_at"`
+	UpdatedAt      time.Time      `json:"updated_at"`
+	DeletedAt      gorm.DeletedAt `gorm:"index" json:"-"`
 }
 
 func (PlaidItem) TableName() string { return "plaid_items" }

--- a/backend/internal/repository/plaid_item_repo.go
+++ b/backend/internal/repository/plaid_item_repo.go
@@ -18,11 +18,18 @@ type PlaidItemRepository interface {
 	GetByID(ctx context.Context, userID, id int64) (*model.PlaidItem, error)
 	GetByPlaidItemID(ctx context.Context, userID int64, plaidItemID string) (*model.PlaidItem, error)
 	ListByUser(ctx context.Context, userID int64) ([]model.PlaidItem, error)
-	UpdateStatus(ctx context.Context, userID, id int64, status string, lastError *string) error
+	UpdateStatus(ctx context.Context, userID, id int64, status string, lastSyncError *string) error
 	// UpdateCursor persists the /transactions/sync cursor + last sync time.
 	// Called after each successful pagination flush so a crash mid-pull
-	// resumes from the last committed page.
+	// resumes from the last committed page. Also flips last_sync_status to
+	// 'ok' and clears last_sync_error — the cursor only advances on a
+	// successful drain.
 	UpdateCursor(ctx context.Context, userID, id int64, cursor string, lastSyncedAt time.Time) error
+	// UpdateSyncStatus writes the per-sync lifecycle fields. Called at the
+	// start of a sync ('syncing') and on failure ('error' with the message).
+	// Success is recorded by UpdateCursor inside the same DB transaction as
+	// the rest of the sync, so there's no separate UpdateSyncStatus('ok').
+	UpdateSyncStatus(ctx context.Context, userID, id int64, status string, syncError *string) error
 	SoftDelete(ctx context.Context, userID, id int64) error
 }
 
@@ -75,13 +82,13 @@ func (r *plaidItemRepo) ListByUser(ctx context.Context, userID int64) ([]model.P
 	return items, nil
 }
 
-func (r *plaidItemRepo) UpdateStatus(ctx context.Context, userID, id int64, status string, lastError *string) error {
+func (r *plaidItemRepo) UpdateStatus(ctx context.Context, userID, id int64, status string, lastSyncError *string) error {
 	res := r.db.WithContext(ctx).
 		Model(&model.PlaidItem{}).
 		Where("user_id = ? AND id = ?", userID, id).
 		Updates(map[string]any{
-			"status":     status,
-			"last_error": lastError,
+			"status":          status,
+			"last_sync_error": lastSyncError,
 		})
 	if res.Error != nil {
 		return res.Error
@@ -93,12 +100,35 @@ func (r *plaidItemRepo) UpdateStatus(ctx context.Context, userID, id int64, stat
 }
 
 func (r *plaidItemRepo) UpdateCursor(ctx context.Context, userID, id int64, cursor string, lastSyncedAt time.Time) error {
+	// The cursor only advances on a successful drain — so this is also the
+	// success terminus for the per-sync lifecycle. Clear any prior error and
+	// flip status to 'ok' in the same write so the UI doesn't have to stitch
+	// these together across rows.
 	res := r.db.WithContext(ctx).
 		Model(&model.PlaidItem{}).
 		Where("user_id = ? AND id = ?", userID, id).
 		Updates(map[string]any{
-			"cursor":         cursor,
-			"last_synced_at": lastSyncedAt,
+			"cursor":           cursor,
+			"last_synced_at":   lastSyncedAt,
+			"last_sync_status": "ok",
+			"last_sync_error":  nil,
+		})
+	if res.Error != nil {
+		return res.Error
+	}
+	if res.RowsAffected == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+func (r *plaidItemRepo) UpdateSyncStatus(ctx context.Context, userID, id int64, status string, syncError *string) error {
+	res := r.db.WithContext(ctx).
+		Model(&model.PlaidItem{}).
+		Where("user_id = ? AND id = ?", userID, id).
+		Updates(map[string]any{
+			"last_sync_status": status,
+			"last_sync_error":  syncError,
 		})
 	if res.Error != nil {
 		return res.Error

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -32,7 +32,8 @@ func New(cfg config.Config, gormDB *gorm.DB) *gin.Engine {
 	authHandler := handler.NewAuthHandler(authSvc)
 
 	accountRepo := repository.NewAccountRepository(gormDB)
-	accountSvc := service.NewAccountService(accountRepo)
+	plaidItemRepo := repository.NewPlaidItemRepository(gormDB)
+	accountSvc := service.NewAccountService(accountRepo).WithPlaidItemRepo(plaidItemRepo)
 	accountHandler := handler.NewAccountHandler(accountSvc)
 
 	// PII flow: pii_repo is wired ONLY into pii_service, which is wired ONLY
@@ -81,7 +82,7 @@ func New(cfg config.Config, gormDB *gorm.DB) *gin.Engine {
 	// service that returns ErrNotConfigured for every call. Handler still
 	// registers either way so the frontend gets a clear PLAID_NOT_CONFIGURED
 	// error rather than a 404.
-	plaidHandler := handler.NewPlaidHandler(newPlaidService(cfg, gormDB, accountRepo, transactionRepo, piiSvc))
+	plaidHandler := handler.NewPlaidHandler(newPlaidService(cfg, gormDB, plaidItemRepo, accountRepo, transactionRepo, piiSvc))
 
 	v1 := r.Group("/api/v1")
 	{
@@ -115,6 +116,7 @@ func New(cfg config.Config, gormDB *gorm.DB) *gin.Engine {
 func newPlaidService(
 	cfg config.Config,
 	gormDB *gorm.DB,
+	itemRepo repository.PlaidItemRepository,
 	acctRepo repository.AccountRepository,
 	txRepo repository.TransactionRepository,
 	piiSvc *service.PIIService,
@@ -144,7 +146,7 @@ func newPlaidService(
 	return plaidsvc.NewService(
 		client,
 		box,
-		repository.NewPlaidItemRepository(gormDB),
+		itemRepo,
 		acctRepo,
 		txRepo,
 		piiSvc,

--- a/backend/internal/service/account_response.go
+++ b/backend/internal/service/account_response.go
@@ -1,0 +1,23 @@
+package service
+
+import (
+	"time"
+
+	"github.com/gregwym/offbook/backend/internal/model"
+)
+
+// AccountResponse is the JSON shape returned from account read endpoints.
+//
+// It embeds the raw model.Account so existing client fields stay byte-stable
+// (#65 is purely additive on the wire) and layers on three sync-status
+// fields joined from the underlying plaid_items row.
+//
+// For non-Plaid accounts, all three sync fields are nil and marshal as
+// `null` (not omitted) so the frontend can treat the wire shape uniformly:
+// "if last_sync_status === null, this account isn't Plaid-linked".
+type AccountResponse struct {
+	*model.Account
+	LastSyncStatus *string    `json:"last_sync_status"`
+	LastSyncedAt   *time.Time `json:"last_synced_at"`
+	LastSyncError  *string    `json:"last_sync_error"`
+}

--- a/backend/internal/service/account_service.go
+++ b/backend/internal/service/account_service.go
@@ -61,12 +61,25 @@ type UpdateAccountInput struct {
 // AccountService owns business rules for accounts. It deliberately does NOT
 // receive pii_repo or pii_service — PII is set via the separate pii endpoints.
 // All operations are scoped to a user_id derived from the session.
+//
+// plaidItemRepo is an optional dependency used solely to join sync status
+// into account response payloads (#65). Nil = no Plaid wiring on this
+// instance; the response fields will be nil for every account.
 type AccountService struct {
-	repo repository.AccountRepository
+	repo          repository.AccountRepository
+	plaidItemRepo repository.PlaidItemRepository
 }
 
 func NewAccountService(repo repository.AccountRepository) *AccountService {
 	return &AccountService{repo: repo}
+}
+
+// WithPlaidItemRepo lets the router inject the optional dependency without
+// breaking every caller of NewAccountService. Returns the service so the
+// construction stays a one-liner.
+func (s *AccountService) WithPlaidItemRepo(p repository.PlaidItemRepository) *AccountService {
+	s.plaidItemRepo = p
+	return s
 }
 
 func (s *AccountService) Create(ctx context.Context, userID int64, in CreateAccountInput) (*model.Account, error) {
@@ -157,6 +170,72 @@ func (s *AccountService) Update(ctx context.Context, userID, id int64, in Update
 		return nil, fmt.Errorf("update account: %w", err)
 	}
 	return a, nil
+}
+
+// GetResponse returns the enriched DTO for one account.
+func (s *AccountService) GetResponse(ctx context.Context, userID, id int64) (*AccountResponse, error) {
+	a, err := s.Get(ctx, userID, id)
+	if err != nil {
+		return nil, err
+	}
+	items, err := s.loadPlaidItems(ctx, userID)
+	if err != nil {
+		return nil, err
+	}
+	resp := s.buildResponse(a, items)
+	return &resp, nil
+}
+
+// ListResponse mirrors List but returns enriched DTOs.
+func (s *AccountService) ListResponse(ctx context.Context, userID int64, f repository.AccountFilter) ([]AccountResponse, int64, error) {
+	accounts, total, err := s.List(ctx, userID, f)
+	if err != nil {
+		return nil, 0, err
+	}
+	items, err := s.loadPlaidItems(ctx, userID)
+	if err != nil {
+		return nil, 0, err
+	}
+	out := make([]AccountResponse, 0, len(accounts))
+	for i := range accounts {
+		out = append(out, s.buildResponse(&accounts[i], items))
+	}
+	return out, total, nil
+}
+
+// loadPlaidItems indexes the user's PlaidItem rows by plaid_item_id (the
+// Plaid-issued string ID stored on accounts.plaid_item_id). Returns nil
+// when this instance has no Plaid wiring — caller handles that as "no
+// sync status on any account".
+func (s *AccountService) loadPlaidItems(ctx context.Context, userID int64) (map[string]*model.PlaidItem, error) {
+	if s.plaidItemRepo == nil {
+		return nil, nil
+	}
+	items, err := s.plaidItemRepo.ListByUser(ctx, userID)
+	if err != nil {
+		return nil, fmt.Errorf("load plaid items: %w", err)
+	}
+	out := make(map[string]*model.PlaidItem, len(items))
+	for i := range items {
+		out[items[i].PlaidItemID] = &items[i]
+	}
+	return out, nil
+}
+
+func (s *AccountService) buildResponse(a *model.Account, items map[string]*model.PlaidItem) AccountResponse {
+	resp := AccountResponse{Account: a}
+	if a.PlaidItemID == nil || items == nil {
+		return resp
+	}
+	item, ok := items[*a.PlaidItemID]
+	if !ok {
+		return resp
+	}
+	status := item.LastSyncStatus
+	resp.LastSyncStatus = &status
+	resp.LastSyncedAt = item.LastSyncedAt
+	resp.LastSyncError = item.LastSyncError
+	return resp
 }
 
 func (s *AccountService) SoftDelete(ctx context.Context, userID, id int64) error {

--- a/backend/internal/service/plaid/service.go
+++ b/backend/internal/service/plaid/service.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"regexp"
 	"strings"
 	"time"
 
+	"github.com/plaid/plaid-go/v40/plaid"
 	"gorm.io/gorm"
 
 	"github.com/gregwym/offbook/backend/internal/crypto"
@@ -14,6 +16,11 @@ import (
 	"github.com/gregwym/offbook/backend/internal/repository"
 	"github.com/gregwym/offbook/backend/internal/service"
 )
+
+// requestIDPattern strips Plaid `request_id=...` tokens (and JSON `"request_id":"..."`)
+// from raw error strings before they're surfaced to users — they're internal-
+// trace identifiers, not user-actionable.
+var requestIDPattern = regexp.MustCompile(`(?i)(?:[, ]?\brequest_id\b\s*[:=]\s*"?[A-Za-z0-9_-]+"?)`)
 
 // Domain errors. Handlers map these to HTTP status codes.
 var (
@@ -310,6 +317,47 @@ func zeroBytes(b []byte) {
 	}
 }
 
+// safeSyncErrorMessage extracts a user-presentable string from a sync error.
+//
+// Preference order:
+//  1. If the chain contains a Plaid GenericOpenAPIError, surface the
+//     structured `error_code` + `display_message` (already polished by Plaid).
+//  2. Otherwise fall back to the error string with two redactions: any
+//     `request_id=...` token gets dropped, and the result is capped so a
+//     pathological wrapped error doesn't blow out the TEXT column or UI pill.
+//
+// Internal stack frames are already absent — `fmt.Errorf("plaid: ... %w")`
+// only contains our own prefixes, which are safe to expose.
+func safeSyncErrorMessage(err error) string {
+	if err == nil {
+		return ""
+	}
+	for cur := err; cur != nil; cur = errors.Unwrap(cur) {
+		if pe, convErr := plaid.ToPlaidError(cur); convErr == nil {
+			msg := pe.ErrorCode
+			if pe.DisplayMessage.IsSet() && pe.DisplayMessage.Get() != nil {
+				dm := strings.TrimSpace(*pe.DisplayMessage.Get())
+				if dm != "" {
+					msg = pe.ErrorCode + ": " + dm
+				}
+			}
+			return capErrorMessage(msg)
+		}
+	}
+	// No structured Plaid error → redact request_id from the wrapped text.
+	return capErrorMessage(requestIDPattern.ReplaceAllString(err.Error(), ""))
+}
+
+// capErrorMessage trims and caps to keep the TEXT column + UI pill sane.
+func capErrorMessage(s string) string {
+	s = strings.TrimSpace(s)
+	const max = 500
+	if len(s) > max {
+		s = s[:max] + "…"
+	}
+	return s
+}
+
 // SyncTransactions runs /transactions/sync for the given item. Works
 // identically for the first-time historical pull (empty cursor) and for
 // incremental refreshes (persisted cursor) — the same Plaid endpoint
@@ -325,7 +373,7 @@ func zeroBytes(b []byte) {
 // If anything in the DB phase fails, the cursor stays put and next run
 // re-fetches the same delta — safe because added uses ON CONFLICT DO
 // NOTHING and modified/removed are idempotent on plaid_transaction_id.
-func (s *Service) SyncTransactions(ctx context.Context, userID int64, plaidItemID string) (SyncTransactionsResult, error) {
+func (s *Service) SyncTransactions(ctx context.Context, userID int64, plaidItemID string) (result SyncTransactionsResult, retErr error) {
 	if !s.Configured() || s.acctRepo == nil || s.txRepo == nil || s.db == nil {
 		return SyncTransactionsResult{}, ErrNotConfigured
 	}
@@ -337,6 +385,27 @@ func (s *Service) SyncTransactions(ctx context.Context, userID int64, plaidItemI
 		}
 		return SyncTransactionsResult{}, fmt.Errorf("plaid: lookup item: %w", err)
 	}
+
+	// Per-sync lifecycle: flip to 'syncing' up front. On success, UpdateCursor
+	// (inside the DB transaction below) flips to 'ok' and clears the error.
+	// On error/panic, the defer flips to 'error' with a user-safe message.
+	// Use a background ctx for the status writes so a request cancel doesn't
+	// leave the row stuck in 'syncing'.
+	statusCtx := context.WithoutCancel(ctx)
+	if err := s.itemRepo.UpdateSyncStatus(statusCtx, userID, item.ID, "syncing", nil); err != nil {
+		return SyncTransactionsResult{}, fmt.Errorf("plaid: mark syncing: %w", err)
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			msg := fmt.Sprintf("panic during sync: %v", r)
+			_ = s.itemRepo.UpdateSyncStatus(statusCtx, userID, item.ID, "error", &msg)
+			panic(r)
+		}
+		if retErr != nil {
+			msg := safeSyncErrorMessage(retErr)
+			_ = s.itemRepo.UpdateSyncStatus(statusCtx, userID, item.ID, "error", &msg)
+		}
+	}()
 
 	tokenBytes, err := s.box.Decrypt(item.AccessTokenEnc)
 	if err != nil {
@@ -368,7 +437,6 @@ func (s *Service) SyncTransactions(ctx context.Context, userID int64, plaidItemI
 		}
 	}
 
-	var result SyncTransactionsResult
 	// Phase 2: one transaction for all writes. Tx-bound repos so every
 	// statement hits the same Postgres transaction; rollback on any error
 	// reverts the entire sync including the cursor advance.

--- a/backend/internal/service/plaid/service_test.go
+++ b/backend/internal/service/plaid/service_test.go
@@ -90,6 +90,9 @@ func (r *fakeRepo) SoftDelete(context.Context, int64, int64) error { return nil 
 func (r *fakeRepo) UpdateCursor(context.Context, int64, int64, string, time.Time) error {
 	return nil
 }
+func (r *fakeRepo) UpdateSyncStatus(context.Context, int64, int64, string, *string) error {
+	return nil
+}
 
 // (fakeRepo implements PlaidItemRepository — the transaction-repo methods
 // added in #62 / #63 live on a separate interface and aren't exercised here.)

--- a/backend/internal/service/plaid/sync_status_integration_test.go
+++ b/backend/internal/service/plaid/sync_status_integration_test.go
@@ -1,0 +1,185 @@
+package plaid_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/gregwym/offbook/backend/internal/crypto"
+	"github.com/gregwym/offbook/backend/internal/model"
+	"github.com/gregwym/offbook/backend/internal/repository"
+	"github.com/gregwym/offbook/backend/internal/service"
+	plaidsvc "github.com/gregwym/offbook/backend/internal/service/plaid"
+)
+
+// flippableSyncServer alternates between success and failure on /transactions/sync:
+//
+//	call 1 → 500 (forces sync into the error path)
+//	call 2 → 200 with one txn, has_more=false (success path)
+//
+// All other paths 500 with an error in the body so we can verify the
+// safeSyncErrorMessage redaction path handles raw error strings (no
+// PlaidError extraction available since httptest doesn't echo their
+// canonical shape).
+func flippableSyncServer(t *testing.T, plaidAcctID string) (*httptest.Server, *int32) {
+	t.Helper()
+	var calls int32
+	mux := http.NewServeMux()
+	mux.HandleFunc("/transactions/sync", func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&calls, 1)
+		if n == 1 {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusInternalServerError)
+			// Body shaped like a Plaid error so safeSyncErrorMessage can
+			// pluck error_code + display_message via the PlaidError path.
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"error_type":      "ITEM_ERROR",
+				"error_code":      "ITEM_LOGIN_REQUIRED",
+				"error_message":   "the login details of this item have changed",
+				"display_message": "Please reconnect your account.",
+				"request_id":      "req-secret-123",
+			})
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"added": []map[string]any{
+				{
+					"transaction_id":    "ptx-status-ok-1",
+					"account_id":        plaidAcctID,
+					"amount":            7.50,
+					"iso_currency_code": "USD",
+					"name":              "Stable after error",
+					"date":              "2026-05-12",
+					"pending":           false,
+				},
+			},
+			"modified":    []any{},
+			"removed":     []any{},
+			"next_cursor": "cursor-recovered",
+			"has_more":    false,
+			"request_id":  "req-ok",
+		})
+	})
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		t.Errorf("unexpected Plaid call: %s %s", r.Method, r.URL.Path)
+		http.Error(w, "unexpected", 500)
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv, &calls
+}
+
+// TestPlaidSync_StatusFlipsOnErrorThenClearsOnSuccess proves the #65
+// lifecycle wiring end-to-end:
+//   - a sync that errors leaves last_sync_status='error' with a populated
+//     last_sync_error and DOES NOT advance cursor / last_synced_at
+//   - a subsequent successful sync flips status to 'ok', clears the error,
+//     and advances last_synced_at
+func TestPlaidSync_StatusFlipsOnErrorThenClearsOnSuccess(t *testing.T) {
+	g := openPlaidTestDB(t)
+	userID := seedPlaidTestUser(t, g)
+	const plaidAcctID = "pacct-status-1"
+
+	acct := &model.Account{
+		UserID: userID, Name: "Status Acct", InstitutionSlug: "ins_test",
+		AccountType: "checking", Currency: "USD",
+		PlaidAccountID: ptr(plaidAcctID), IsActive: true,
+	}
+	if err := g.Create(acct).Error; err != nil {
+		t.Fatalf("seed account: %v", err)
+	}
+	t.Cleanup(func() {
+		g.Unscoped().Where("user_id = ?", userID).Delete(&model.Transaction{})
+		g.Unscoped().Delete(&model.Account{}, acct.ID)
+	})
+
+	srv, calls := flippableSyncServer(t, plaidAcctID)
+	client, _ := plaidsvc.NewSDKClient(plaidsvc.Config{ClientID: "cid", Secret: "csec", Env: srv.URL})
+	box, _ := crypto.NewSecretBox(newTestKey())
+	itemRepo := repository.NewPlaidItemRepository(g)
+	acctRepo := repository.NewAccountRepository(g)
+	txRepo := repository.NewTransactionRepository(g)
+	piiSvc := service.NewPIIService(repository.NewPIIRepository(g), service.NewAccountService(acctRepo))
+
+	enc, _ := box.Encrypt([]byte("access-sandbox-fake"))
+	item := &model.PlaidItem{
+		UserID: userID, PlaidItemID: "item-status", AccessTokenEnc: enc,
+		Status: "active", LastSyncStatus: "never",
+	}
+	if err := itemRepo.Create(context.Background(), item); err != nil {
+		t.Fatalf("seed item: %v", err)
+	}
+
+	svc := plaidsvc.NewService(client, box, itemRepo, acctRepo, txRepo, piiSvc, nil, g)
+
+	// Phase 1: forced error.
+	if _, err := svc.SyncTransactions(context.Background(), userID, "item-status"); err == nil {
+		t.Fatal("sync #1: expected error from upstream 500")
+	}
+	if got := atomic.LoadInt32(calls); got != 1 {
+		t.Fatalf("calls after sync #1 = %d, want 1", got)
+	}
+
+	var afterErr model.PlaidItem
+	if err := g.First(&afterErr, item.ID).Error; err != nil {
+		t.Fatalf("reload after error: %v", err)
+	}
+	if afterErr.LastSyncStatus != "error" {
+		t.Errorf("last_sync_status = %q, want error", afterErr.LastSyncStatus)
+	}
+	if afterErr.LastSyncError == nil || *afterErr.LastSyncError == "" {
+		t.Fatalf("last_sync_error empty after failed sync")
+	}
+	// Redaction: request_id must not leak into the user-facing message.
+	if got := *afterErr.LastSyncError; containsSubstring(got, "req-secret-123") {
+		t.Errorf("last_sync_error leaked request_id: %q", got)
+	}
+	if afterErr.LastSyncedAt != nil {
+		t.Errorf("last_synced_at advanced on failure: %v", afterErr.LastSyncedAt)
+	}
+	if afterErr.Cursor != nil {
+		t.Errorf("cursor advanced on failure: %v", afterErr.Cursor)
+	}
+
+	// Phase 2: success on retry.
+	r, err := svc.SyncTransactions(context.Background(), userID, "item-status")
+	if err != nil {
+		t.Fatalf("sync #2: %v", err)
+	}
+	if r.Inserted != 1 {
+		t.Errorf("sync #2: inserted=%d, want 1", r.Inserted)
+	}
+
+	var afterOK model.PlaidItem
+	if err := g.First(&afterOK, item.ID).Error; err != nil {
+		t.Fatalf("reload after success: %v", err)
+	}
+	if afterOK.LastSyncStatus != "ok" {
+		t.Errorf("last_sync_status = %q, want ok", afterOK.LastSyncStatus)
+	}
+	if afterOK.LastSyncError != nil {
+		t.Errorf("last_sync_error not cleared on success: %v", *afterOK.LastSyncError)
+	}
+	if afterOK.LastSyncedAt == nil {
+		t.Errorf("last_synced_at not set on success")
+	}
+	if afterOK.Cursor == nil || *afterOK.Cursor != "cursor-recovered" {
+		t.Errorf("cursor = %v, want cursor-recovered", afterOK.Cursor)
+	}
+}
+
+func containsSubstring(haystack, needle string) bool {
+	if needle == "" {
+		return true
+	}
+	for i := 0; i+len(needle) <= len(haystack); i++ {
+		if haystack[i:i+len(needle)] == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/backend/migrations/000006_plaid_sync_status.down.sql
+++ b/backend/migrations/000006_plaid_sync_status.down.sql
@@ -1,0 +1,6 @@
+BEGIN;
+
+ALTER TABLE plaid_items DROP COLUMN IF EXISTS last_sync_status;
+ALTER TABLE plaid_items RENAME COLUMN last_sync_error TO last_error;
+
+COMMIT;

--- a/backend/migrations/000006_plaid_sync_status.up.sql
+++ b/backend/migrations/000006_plaid_sync_status.up.sql
@@ -1,0 +1,20 @@
+BEGIN;
+
+-- #65: per-item sync status indicator.
+--
+-- Renames the existing `last_error` column to the more descriptive
+-- `last_sync_error` and adds a coarse status enum so the UI can render a
+-- traffic-light pill without having to peek at the text. `last_synced_at`
+-- already exists from 000003.
+--
+-- Additive: existing rows get `last_sync_status='never'` until the next
+-- sync flips them to 'syncing' / 'ok' / 'error'. Renames are a metadata
+-- change in Postgres; no rewrite, no lock escalation worth worrying about
+-- at this table's size.
+ALTER TABLE plaid_items RENAME COLUMN last_error TO last_sync_error;
+
+ALTER TABLE plaid_items
+    ADD COLUMN last_sync_status TEXT NOT NULL DEFAULT 'never'
+        CHECK (last_sync_status IN ('never','syncing','ok','error'));
+
+COMMIT;

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -181,6 +181,7 @@ Otherwise re-importing a previously-deleted transaction fails.
 - **categories** — hierarchical via `parent_id`, seeded with ~20 system categories
 - **categorization_rules** — `pattern, category_id, match_type ('contains'|'regex'|'exact'), priority`
 - **plaid_category_map** — `plaid_primary, plaid_detailed, category_id`. Static lookup table (migration 000005) mapping the Plaid `personal_finance_category` taxonomy to local categories. Editable by SQL migration only — keeps the mapping reviewable in git. Loaded once into a `CategoryMapper` at service construction.
+- **plaid_items** — link to one Plaid Item per user (`access_token_enc`, institution metadata, cursor). Carries per-sync lifecycle fields: `last_sync_status` (enum `never|syncing|ok|error`), `last_synced_at`, `last_sync_error`. Lifecycle is owned by `service/plaid`: `UpdateSyncStatus("syncing")` at start, `UpdateCursor(...)` flips to `ok` and clears the error on success (same transaction as txn writes), deferred `UpdateSyncStatus("error", msg)` on panic/error. See ADR-0010 for token encryption.
 - **budgets** — `category_id, period ('monthly'|'weekly'|'annual'), amount, rollover, is_active`
 - **savings_goals** — `name, target_amount, current_amount, target_date, account_id`
 - **investments** — append-only snapshots: `account_id, ticker, name, asset_class, quantity, cost_basis, market_value, snapshot_date, source`

--- a/frontend/src/components/SyncStatusPill.tsx
+++ b/frontend/src/components/SyncStatusPill.tsx
@@ -1,0 +1,94 @@
+import { useState } from 'react'
+import type { Account } from '../types/account'
+
+// SyncStatusPill renders a compact traffic-light indicator for a Plaid-linked
+// account. Manual accounts (last_sync_status === null) render nothing — the
+// issue spec is explicit that there's no pill for non-Plaid rows.
+//
+// `error` is click-to-expand so the message stays inline without blowing up
+// the table row by default. Other states have no expansion target.
+export function SyncStatusPill({ account }: { account: Account }) {
+  const [open, setOpen] = useState(false)
+  const status = account.last_sync_status
+  if (status === null) return null
+
+  const label = pillLabel(status, account.last_synced_at)
+  const tone = pillTone(status)
+  const expandable = status === 'error' && account.last_sync_error
+
+  return (
+    <div className="inline-flex flex-col items-start gap-1">
+      <button
+        type="button"
+        disabled={!expandable}
+        onClick={() => expandable && setOpen((v) => !v)}
+        className={`inline-flex items-center gap-1.5 rounded-full px-2 py-0.5 text-xs font-medium ${tone} ${expandable ? 'cursor-pointer hover:brightness-95' : 'cursor-default'}`}
+        aria-expanded={expandable ? open : undefined}
+      >
+        <span aria-hidden="true" className={`h-1.5 w-1.5 rounded-full ${dotTone(status)}`} />
+        {label}
+      </button>
+      {expandable && open && (
+        <div className="max-w-xs whitespace-pre-wrap rounded-md border border-red-200 bg-red-50 px-2 py-1 text-xs text-red-700">
+          {account.last_sync_error}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function pillLabel(status: NonNullable<Account['last_sync_status']>, lastSyncedAt: string | null): string {
+  switch (status) {
+    case 'syncing':
+      return 'Syncing…'
+    case 'error':
+      return 'Sync failed'
+    case 'never':
+      return 'Not synced'
+    case 'ok':
+      return lastSyncedAt ? `Synced ${formatRelative(lastSyncedAt)}` : 'Synced'
+  }
+}
+
+function pillTone(status: NonNullable<Account['last_sync_status']>): string {
+  switch (status) {
+    case 'ok':
+      return 'bg-emerald-100 text-emerald-800'
+    case 'syncing':
+      return 'bg-amber-100 text-amber-800'
+    case 'error':
+      return 'bg-red-100 text-red-800'
+    case 'never':
+      return 'bg-gray-100 text-gray-700'
+  }
+}
+
+function dotTone(status: NonNullable<Account['last_sync_status']>): string {
+  switch (status) {
+    case 'ok':
+      return 'bg-emerald-500'
+    case 'syncing':
+      return 'bg-amber-500'
+    case 'error':
+      return 'bg-red-500'
+    case 'never':
+      return 'bg-gray-400'
+  }
+}
+
+// formatRelative renders a coarse "Xm/h/d ago" — enough resolution for a
+// sync indicator. Anything older than 30 days falls back to a calendar date
+// so the pill doesn't claim "1y ago" forever.
+function formatRelative(iso: string): string {
+  const then = new Date(iso).getTime()
+  if (Number.isNaN(then)) return 'recently'
+  const diffSec = Math.max(0, Math.floor((Date.now() - then) / 1000))
+  if (diffSec < 60) return 'just now'
+  const mins = Math.floor(diffSec / 60)
+  if (mins < 60) return `${mins}m ago`
+  const hours = Math.floor(mins / 60)
+  if (hours < 24) return `${hours}h ago`
+  const days = Math.floor(hours / 24)
+  if (days < 30) return `${days}d ago`
+  return new Date(iso).toLocaleDateString()
+}

--- a/frontend/src/pages/AccountsPage.tsx
+++ b/frontend/src/pages/AccountsPage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState, type ReactNode } from 'react'
 import { Pencil, Plus, Trash2 } from 'lucide-react'
 import { AmountDisplay } from '../components/AmountDisplay'
 import { PIIPanel } from '../components/PIIPanel'
+import { SyncStatusPill } from '../components/SyncStatusPill'
 import { useAccountsStore } from '../store/accountsStore'
 import {
   ACCOUNT_TYPES,
@@ -52,15 +53,16 @@ export function AccountsPage() {
               <th className="px-4 py-2 text-left">Last 4</th>
               <th className="px-4 py-2 text-right">Balance</th>
               <th className="px-4 py-2 text-center">Active</th>
+              <th className="px-4 py-2 text-left">Sync</th>
               <th className="px-4 py-2"></th>
             </tr>
           </thead>
           <tbody className="divide-y divide-gray-100">
             {loading && accounts.length === 0 && (
-              <tr><td colSpan={7} className="px-4 py-6 text-center text-gray-400">Loading…</td></tr>
+              <tr><td colSpan={8} className="px-4 py-6 text-center text-gray-400">Loading…</td></tr>
             )}
             {!loading && accounts.length === 0 && (
-              <tr><td colSpan={7} className="px-4 py-6 text-center text-gray-400">No accounts yet.</td></tr>
+              <tr><td colSpan={8} className="px-4 py-6 text-center text-gray-400">No accounts yet.</td></tr>
             )}
             {accounts.map((a) => (
               <tr key={a.id} className="hover:bg-gray-50">
@@ -75,6 +77,9 @@ export function AccountsPage() {
                   <span className={a.is_active ? 'text-emerald-700' : 'text-gray-400'}>
                     {a.is_active ? 'yes' : 'no'}
                   </span>
+                </td>
+                <td className="px-4 py-2">
+                  <SyncStatusPill account={a} />
                 </td>
                 <td className="px-4 py-2 text-right">
                   <button

--- a/frontend/src/types/account.ts
+++ b/frontend/src/types/account.ts
@@ -1,5 +1,9 @@
 // Account mirrors backend model.Account. Money fields arrive as decimal
 // strings (NUMERIC(30,18)) — never parse into Number; format via AmountDisplay.
+//
+// The three last_sync_* fields are joined from the underlying plaid_items
+// row server-side (#65). They are `null` for accounts not linked to Plaid
+// (manual entries) — the frontend uses that as the signal to hide the pill.
 export type Account = {
   id: number
   user_id: number
@@ -14,7 +18,15 @@ export type Account = {
   is_active: boolean
   created_at: string
   updated_at: string
+  last_sync_status: SyncStatus | null
+  last_synced_at: string | null
+  last_sync_error: string | null
 }
+
+// SyncStatus mirrors the CHECK constraint in migration 000006 on
+// plaid_items.last_sync_status.
+export const SYNC_STATUSES = ['never', 'syncing', 'ok', 'error'] as const
+export type SyncStatus = (typeof SYNC_STATUSES)[number]
 
 // Mirrors the CHECK constraint in migration 000001 + service.validAccountTypes.
 export const ACCOUNT_TYPES = [


### PR DESCRIPTION
## Summary
- Adds per-sync lifecycle (`last_sync_status` enum + `last_sync_error`) to `plaid_items` via migration 000006; `SyncTransactions` flips through `syncing → ok/error` with defer-based panic safety
- Joins the three sync fields into Account GET/LIST responses (nulls for non-Plaid accounts) and renders a click-to-expand pill on `AccountsPage`
- Surfaces structured Plaid `error_code: display_message` via `plaid.ToPlaidError` when available, redacts `request_id` from raw error strings, caps message length at 500 chars

## Test plan
- [x] Integration test forces an upstream 500 then a success — verifies status flips `error → ok`, error message is set/cleared, cursor + last_synced_at only advance on success, and `request_id` is redacted from the user-facing message
- [x] `go vet ./...` clean
- [x] Full backend test suite green with `-p 1` (pre-existing parallel-test interference on `make test` reproduces on `main`)
- [x] Frontend `tsc -b && vite build` clean
- [ ] Manual: connect Plaid sandbox, hit an error path, confirm pill renders red and message expands inline

Closes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)