### PR TITLE
docs: document Colima 4 GiB lint requirement (#67)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@
 - Backend stop: `cd backend && make stop`
 - Backend smoke (start + wait for /health): `cd backend && make smoke`
 - Tests: `cd backend && make test`
-- Lint: `cd backend && make lint`
+- Lint: `cd backend && make lint` (needs ≥4 GiB in the Docker VM — see `docs/dev/colima.md` if lint dies with `signal: killed during compile`)
 - Format Go: `cd backend && docker run --rm -v "$PWD":/app -w /app golangci/golangci-lint:latest-alpine golangci-lint fmt ./...` (rewrites files in place; `golangci-lint run` then verifies)
 - Frontend: `cd frontend && pnpm dev`
 - Full stack: `docker compose up`

--- a/docs/dev/colima.md
+++ b/docs/dev/colima.md
@@ -1,0 +1,35 @@
+# Colima sizing for local development
+
+The backend lints via a `golangci-lint` container (`make lint`). Since M3 the build graph includes the `github.com/plaid/plaid-go/v40/plaid` package — a large, OpenAPI-generated SDK whose typecheck has a hefty peak resident-set size. On Colima's default 2 GiB profile, the kernel OOM-killer terminates the lint compile step:
+
+```
+typecheck: could not import github.com/plaid/plaid-go/v40/plaid
+  (signal: killed during compile)
+```
+
+`go build`, `go vet`, and `go test ./...` all stay well under the limit — only `golangci-lint run` blows past it.
+
+## Fix
+
+Restart Colima with at least 4 GiB:
+
+```sh
+colima stop
+colima start --memory 4
+```
+
+Persist it so future starts pick the bigger profile:
+
+```sh
+colima start --memory 4 --save-config
+```
+
+Docker Desktop / Podman Desktop users: bump the VM's memory in the GUI to ≥4 GiB. CI is unaffected — GitHub-hosted runners ship with ~7 GiB.
+
+## Verifying
+
+```sh
+cd backend && command make lint
+```
+
+Should complete without `signal: killed`.


### PR DESCRIPTION
## Summary
- Add `docs/dev/colima.md` explaining why `make lint` OOMs on the default Colima 2 GiB profile (plaid-go/v40 SDK typecheck) and how to fix it (`colima start --memory 4 --save-config`).
- Add a one-line pointer next to the lint command in `CLAUDE.md`.

Skipped the optional per-package lint split — the doc fix removes the root cause; splitting would mask future memory regressions.

Closes #67

## Test plan
- [x] Manual: read the new doc end-to-end.
- [ ] (Out of scope here) verify locally once Colima is bumped to 4 GiB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)