### PR TITLE
feat(plaid): per-row DLQ + partial-success sync (#80)

### DIFF
--- a/backend/internal/handler/plaid_handler.go
+++ b/backend/internal/handler/plaid_handler.go
@@ -3,10 +3,10 @@ package handler
 import (
 	"errors"
 	"net/http"
+	"strconv"
 
 	"github.com/gin-gonic/gin"
 
-	"github.com/gregwym/offbook/backend/internal/model"
 	"github.com/gregwym/offbook/backend/internal/service/auth"
 	plaidsvc "github.com/gregwym/offbook/backend/internal/service/plaid"
 )
@@ -30,6 +30,9 @@ func (h *PlaidHandler) Register(g *gin.RouterGroup) {
 	g.DELETE("/plaid/items/:item_id", h.DisconnectItem)
 	g.POST("/plaid/items/:item_id/sync-accounts", h.SyncAccounts)
 	g.POST("/plaid/items/:item_id/sync-transactions", h.SyncTransactions)
+	g.GET("/plaid/items/:item_id/errors", h.ListSyncErrors)
+	g.POST("/plaid/errors/:error_id/retry", h.RetrySyncError)
+	g.POST("/plaid/errors/:error_id/dismiss", h.DismissSyncError)
 }
 
 func (h *PlaidHandler) CreateLinkToken(c *gin.Context) {
@@ -101,7 +104,9 @@ func (h *PlaidHandler) SyncAccounts(c *gin.Context) {
 
 // SyncTransactions runs /transactions/sync for the given item, persisting
 // added transactions and the resulting cursor. Response is a narrow
-// {inserted, modified, removed} count — never the transactions themselves.
+// {inserted, modified, removed, failed} count — never the transactions
+// themselves. failed > 0 means rows landed in plaid_sync_errors; see
+// GET /plaid/items/:id/errors.
 func (h *PlaidHandler) SyncTransactions(c *gin.Context) {
 	plaidItemID := c.Param("item_id")
 	if plaidItemID == "" {
@@ -119,24 +124,99 @@ func (h *PlaidHandler) SyncTransactions(c *gin.Context) {
 			"inserted": result.Inserted,
 			"modified": result.Modified,
 			"removed":  result.Removed,
+			"failed":   result.Failed,
 		},
 	})
 }
 
-// ListItems returns the user's linked Plaid items for the Settings page.
-// Response shape: standard list envelope with total. AccessToken is never
+// ListItems returns the user's linked Plaid items for the Settings page,
+// each annotated with its unresolved DLQ count so the UI can render the
+// ⚠️ badge in one round trip (no per-item N+1). AccessToken is never
 // included — model.PlaidItem has `json:"-"` on AccessTokenEnc.
 func (h *PlaidHandler) ListItems(c *gin.Context) {
 	userID := auth.MustUserID(c.Request.Context())
-	items, err := h.svc.ListItems(c.Request.Context(), userID)
+	items, err := h.svc.ListItemsWithSyncErrors(c.Request.Context(), userID)
 	if err != nil {
 		h.writeError(c, err)
 		return
 	}
-	if items == nil {
-		items = []model.PlaidItem{}
-	}
 	c.JSON(http.StatusOK, gin.H{"data": items, "total": len(items)})
+}
+
+// ListSyncErrors returns the DLQ rows for one Plaid item. Query parameter
+// ?status=unresolved (default) hides retried/dismissed rows; ?status=all
+// returns the full history. The raw_payload is the full Plaid transaction
+// JSON, echoed back so the modal can show it as-is.
+func (h *PlaidHandler) ListSyncErrors(c *gin.Context) {
+	plaidItemID := c.Param("item_id")
+	if plaidItemID == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "item_id is required", "code": "INVALID_REQUEST"})
+		return
+	}
+	// Default to unresolved-only — the badge-driven flow wants actionable
+	// rows. ?status=all opens the door for an audit view later.
+	unresolvedOnly := true
+	switch c.Query("status") {
+	case "", "unresolved":
+		unresolvedOnly = true
+	case "all":
+		unresolvedOnly = false
+	default:
+		c.JSON(http.StatusBadRequest, gin.H{"error": "status must be 'unresolved' or 'all'", "code": "INVALID_REQUEST"})
+		return
+	}
+	userID := auth.MustUserID(c.Request.Context())
+	rows, err := h.svc.ListSyncErrors(c.Request.Context(), userID, plaidItemID, unresolvedOnly)
+	if err != nil {
+		h.writeError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"data": rows, "total": len(rows)})
+}
+
+// RetrySyncError replays the row's raw_payload through the same mapping
+// path as a live sync. On success the row is marked resolved=retried_ok
+// (204). On a known replay failure (payload still bad) the row stays
+// unresolved and the handler returns 422 so the UI can keep the row in
+// the list.
+func (h *PlaidHandler) RetrySyncError(c *gin.Context) {
+	id, ok := parseErrorID(c)
+	if !ok {
+		return
+	}
+	userID := auth.MustUserID(c.Request.Context())
+	if err := h.svc.RetrySyncError(c.Request.Context(), userID, id); err != nil {
+		h.writeError(c, err)
+		return
+	}
+	c.Status(http.StatusNoContent)
+}
+
+// DismissSyncError marks the row resolved=dismissed without replaying it.
+// 204 on success; 404 if the row is missing or already resolved.
+func (h *PlaidHandler) DismissSyncError(c *gin.Context) {
+	id, ok := parseErrorID(c)
+	if !ok {
+		return
+	}
+	userID := auth.MustUserID(c.Request.Context())
+	if err := h.svc.DismissSyncError(c.Request.Context(), userID, id); err != nil {
+		h.writeError(c, err)
+		return
+	}
+	c.Status(http.StatusNoContent)
+}
+
+// parseErrorID extracts and validates the :error_id path param.
+// Writes the 400 response itself; returns ok=false when invalid.
+func parseErrorID(c *gin.Context) (int64, bool) {
+	raw := c.Param("error_id")
+	id, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil || id <= 0 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "error_id must be a positive integer", "code": "INVALID_REQUEST"})
+		return 0, false
+	}
+	return id, true
 }
 
 // DisconnectItem soft-deletes the link. Accounts previously synced remain
@@ -171,6 +251,16 @@ func (h *PlaidHandler) writeError(c *gin.Context, err error) {
 		c.JSON(http.StatusNotFound, gin.H{
 			"error": err.Error(),
 			"code":  "PLAID_ITEM_NOT_FOUND",
+		})
+	case errors.Is(err, plaidsvc.ErrSyncErrorNotFound):
+		c.JSON(http.StatusNotFound, gin.H{
+			"error": err.Error(),
+			"code":  "PLAID_SYNC_ERROR_NOT_FOUND",
+		})
+	case errors.Is(err, plaidsvc.ErrSyncErrorReplay):
+		c.JSON(http.StatusUnprocessableEntity, gin.H{
+			"error": err.Error(),
+			"code":  "PLAID_SYNC_ERROR_REPLAY",
 		})
 	default:
 		c.JSON(http.StatusBadGateway, gin.H{

--- a/backend/internal/handler/plaid_handler.go
+++ b/backend/internal/handler/plaid_handler.go
@@ -155,7 +155,7 @@ func (h *PlaidHandler) ListSyncErrors(c *gin.Context) {
 	}
 	// Default to unresolved-only — the badge-driven flow wants actionable
 	// rows. ?status=all opens the door for an audit view later.
-	unresolvedOnly := true
+	var unresolvedOnly bool
 	switch c.Query("status") {
 	case "", "unresolved":
 		unresolvedOnly = true

--- a/backend/internal/model/plaid_sync_error.go
+++ b/backend/internal/model/plaid_sync_error.go
@@ -1,0 +1,48 @@
+package model
+
+import (
+	"encoding/json"
+	"time"
+)
+
+// PlaidSyncError is a DLQ row for a single Plaid transaction that failed
+// to import during a /transactions/sync drain. The raw payload is kept so
+// the owner can retry without re-syncing the whole item.
+//
+// Hard-delete only (no soft-delete / no gorm.DeletedAt) — DLQ rows are
+// audit material; "dismissed" is recorded via Resolution, not deletion.
+type PlaidSyncError struct {
+	ID                 int64   `gorm:"primaryKey" json:"id"`
+	UserID             int64   `gorm:"not null" json:"user_id"`
+	PlaidItemID        int64   `gorm:"column:plaid_item_id;not null" json:"plaid_item_id"`
+	PlaidTransactionID *string `gorm:"column:plaid_transaction_id" json:"plaid_transaction_id,omitempty"`
+	// RawPayload is the original Plaid row JSON. JSONB in Postgres; we
+	// keep it as json.RawMessage so handlers can echo it back unmodified.
+	RawPayload   json.RawMessage `gorm:"column:raw_payload;type:jsonb;not null" json:"raw_payload"`
+	ErrorCode    string          `gorm:"column:error_code;not null" json:"error_code"`
+	ErrorMessage string          `gorm:"column:error_message;not null" json:"error_message"`
+	OccurredAt   time.Time       `gorm:"column:occurred_at;not null;default:now()" json:"occurred_at"`
+	// ResolvedAt + Resolution are paired: both NULL = unresolved; both
+	// non-NULL after Retry or Dismiss. The CHECK in 000007 enforces this.
+	ResolvedAt *time.Time `gorm:"column:resolved_at" json:"resolved_at,omitempty"`
+	Resolution *string    `gorm:"column:resolution" json:"resolution,omitempty"`
+}
+
+func (PlaidSyncError) TableName() string { return "plaid_sync_errors" }
+
+// Resolution values for PlaidSyncError.Resolution.
+const (
+	ResolutionRetriedOK = "retried_ok"
+	ResolutionDismissed = "dismissed"
+)
+
+// Error codes recorded in PlaidSyncError.ErrorCode. Free-form text is
+// allowed in the column, but stick to these for known failure modes so
+// the UI can group/filter.
+const (
+	PlaidSyncErrorCodeDecimalOverflow = "DECIMAL_OVERFLOW"
+	PlaidSyncErrorCodeValidation      = "VALIDATION"
+	PlaidSyncErrorCodeMapping         = "MAPPING"
+	PlaidSyncErrorCodeDB              = "DB"
+	PlaidSyncErrorCodeUnknown         = "UNKNOWN"
+)

--- a/backend/internal/repository/plaid_sync_error_repo.go
+++ b/backend/internal/repository/plaid_sync_error_repo.go
@@ -1,0 +1,126 @@
+package repository
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"gorm.io/gorm"
+
+	"github.com/gregwym/offbook/backend/internal/model"
+)
+
+// PlaidSyncErrorRepository owns persistence for plaid_sync_errors rows.
+// Like every multi-tenant repo, every read/write scopes by user_id.
+type PlaidSyncErrorRepository interface {
+	Create(ctx context.Context, row *model.PlaidSyncError) error
+	Get(ctx context.Context, userID, id int64) (*model.PlaidSyncError, error)
+	// ListByItem returns DLQ rows for one Plaid item. If unresolvedOnly is
+	// true, rows with resolved_at IS NOT NULL are excluded.
+	ListByItem(ctx context.Context, userID, plaidItemID int64, unresolvedOnly bool) ([]model.PlaidSyncError, error)
+	// CountUnresolvedByItem returns the badge number — how many DLQ rows
+	// the owner still needs to act on. Indexed via
+	// ix_plaid_sync_errors_item_unresolved.
+	CountUnresolvedByItem(ctx context.Context, userID, plaidItemID int64) (int64, error)
+	// UnresolvedCountsByItems returns badge counts for several items in one
+	// roundtrip — used by the Linked Institutions list endpoint so it
+	// doesn't fan out N+1.
+	UnresolvedCountsByItems(ctx context.Context, userID int64, plaidItemIDs []int64) (map[int64]int64, error)
+	// MarkResolved sets resolved_at + resolution. ErrNotFound if the row
+	// is missing OR already resolved (idempotent guard against
+	// double-click).
+	MarkResolved(ctx context.Context, userID, id int64, resolution string, at time.Time) error
+}
+
+type plaidSyncErrorRepo struct {
+	db *gorm.DB
+}
+
+func NewPlaidSyncErrorRepository(db *gorm.DB) PlaidSyncErrorRepository {
+	return &plaidSyncErrorRepo{db: db}
+}
+
+func (r *plaidSyncErrorRepo) Create(ctx context.Context, row *model.PlaidSyncError) error {
+	return r.db.WithContext(ctx).Create(row).Error
+}
+
+func (r *plaidSyncErrorRepo) Get(ctx context.Context, userID, id int64) (*model.PlaidSyncError, error) {
+	var row model.PlaidSyncError
+	if err := r.db.WithContext(ctx).
+		Where("user_id = ?", userID).
+		First(&row, id).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, ErrNotFound
+		}
+		return nil, err
+	}
+	return &row, nil
+}
+
+func (r *plaidSyncErrorRepo) ListByItem(ctx context.Context, userID, plaidItemID int64, unresolvedOnly bool) ([]model.PlaidSyncError, error) {
+	q := r.db.WithContext(ctx).
+		Where("user_id = ? AND plaid_item_id = ?", userID, plaidItemID)
+	if unresolvedOnly {
+		q = q.Where("resolved_at IS NULL")
+	}
+	var rows []model.PlaidSyncError
+	if err := q.Order("occurred_at DESC, id DESC").Find(&rows).Error; err != nil {
+		return nil, err
+	}
+	return rows, nil
+}
+
+func (r *plaidSyncErrorRepo) CountUnresolvedByItem(ctx context.Context, userID, plaidItemID int64) (int64, error) {
+	var n int64
+	if err := r.db.WithContext(ctx).
+		Model(&model.PlaidSyncError{}).
+		Where("user_id = ? AND plaid_item_id = ? AND resolved_at IS NULL", userID, plaidItemID).
+		Count(&n).Error; err != nil {
+		return 0, err
+	}
+	return n, nil
+}
+
+func (r *plaidSyncErrorRepo) UnresolvedCountsByItems(ctx context.Context, userID int64, plaidItemIDs []int64) (map[int64]int64, error) {
+	out := map[int64]int64{}
+	if len(plaidItemIDs) == 0 {
+		return out, nil
+	}
+	type row struct {
+		PlaidItemID int64
+		N           int64
+	}
+	var rows []row
+	if err := r.db.WithContext(ctx).
+		Model(&model.PlaidSyncError{}).
+		Select("plaid_item_id, COUNT(*) AS n").
+		Where("user_id = ? AND plaid_item_id IN ? AND resolved_at IS NULL", userID, plaidItemIDs).
+		Group("plaid_item_id").
+		Scan(&rows).Error; err != nil {
+		return nil, err
+	}
+	for _, r := range rows {
+		out[r.PlaidItemID] = r.N
+	}
+	return out, nil
+}
+
+func (r *plaidSyncErrorRepo) MarkResolved(ctx context.Context, userID, id int64, resolution string, at time.Time) error {
+	// Filter on resolved_at IS NULL so a second Retry/Dismiss click is a
+	// no-op (ErrNotFound) rather than overwriting the prior resolution
+	// timestamp.
+	res := r.db.WithContext(ctx).
+		Model(&model.PlaidSyncError{}).
+		Where("user_id = ? AND id = ? AND resolved_at IS NULL", userID, id).
+		Updates(map[string]any{
+			"resolved_at": at,
+			"resolution":  resolution,
+		})
+	if res.Error != nil {
+		return res.Error
+	}
+	if res.RowsAffected == 0 {
+		return ErrNotFound
+	}
+	return nil
+}

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -82,7 +82,8 @@ func New(cfg config.Config, gormDB *gorm.DB) *gin.Engine {
 	// service that returns ErrNotConfigured for every call. Handler still
 	// registers either way so the frontend gets a clear PLAID_NOT_CONFIGURED
 	// error rather than a 404.
-	plaidHandler := handler.NewPlaidHandler(newPlaidService(cfg, gormDB, plaidItemRepo, accountRepo, transactionRepo, piiSvc))
+	plaidSyncErrRepo := repository.NewPlaidSyncErrorRepository(gormDB)
+	plaidHandler := handler.NewPlaidHandler(newPlaidService(cfg, gormDB, plaidItemRepo, accountRepo, transactionRepo, plaidSyncErrRepo, piiSvc))
 
 	v1 := r.Group("/api/v1")
 	{
@@ -119,10 +120,11 @@ func newPlaidService(
 	itemRepo repository.PlaidItemRepository,
 	acctRepo repository.AccountRepository,
 	txRepo repository.TransactionRepository,
+	syncErrRepo repository.PlaidSyncErrorRepository,
 	piiSvc *service.PIIService,
 ) *plaidsvc.Service {
 	if !cfg.PlaidConfigured() {
-		return plaidsvc.NewService(nil, nil, nil, nil, nil, nil, nil, nil)
+		return plaidsvc.NewService(nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	}
 	client, err := plaidsvc.NewSDKClient(plaidsvc.Config{
 		ClientID: cfg.PlaidClientID,
@@ -149,6 +151,7 @@ func newPlaidService(
 		itemRepo,
 		acctRepo,
 		txRepo,
+		syncErrRepo,
 		piiSvc,
 		mapper,
 		gormDB,

--- a/backend/internal/service/plaid/category_mapping_integration_test.go
+++ b/backend/internal/service/plaid/category_mapping_integration_test.go
@@ -127,7 +127,7 @@ func TestPlaidSync_CategoryMappingFirstPass_AndPreservesUserChoiceOnReSync(t *te
 		t.Fatalf("seed item: %v", err)
 	}
 
-	svc := plaidsvc.NewService(client, box, itemRepo, acctRepo, txRepo, piiSvc, mapper, g)
+	svc := plaidsvc.NewService(client, box, itemRepo, acctRepo, txRepo, repository.NewPlaidSyncErrorRepository(g), piiSvc, mapper, g)
 
 	// First sync: row is created with the Plaid default category.
 	if _, err := svc.SyncTransactions(context.Background(), userID, "item-pfc"); err != nil {
@@ -234,7 +234,7 @@ func TestPlaidSync_NoMappingLeavesCategoryNull(t *testing.T) {
 		t.Fatalf("seed item: %v", err)
 	}
 
-	svc := plaidsvc.NewService(client, box, itemRepo, acctRepo, txRepo, piiSvc, mapper, g)
+	svc := plaidsvc.NewService(client, box, itemRepo, acctRepo, txRepo, repository.NewPlaidSyncErrorRepository(g), piiSvc, mapper, g)
 	if _, err := svc.SyncTransactions(context.Background(), userID, "item-no-pfc"); err != nil {
 		t.Fatalf("sync: %v", err)
 	}

--- a/backend/internal/service/plaid/dedup_test.go
+++ b/backend/internal/service/plaid/dedup_test.go
@@ -106,7 +106,7 @@ func TestPlaidSync_NoDuplicatesOnReSync(t *testing.T) {
 		t.Fatalf("seed item: %v", err)
 	}
 
-	svc := plaidsvc.NewService(client, box, itemRepo, acctRepo, txRepo, piiSvc, nil, g)
+	svc := plaidsvc.NewService(client, box, itemRepo, acctRepo, txRepo, repository.NewPlaidSyncErrorRepository(g), piiSvc, nil, g)
 
 	// First sync: 2 inserts.
 	r1, err := svc.SyncTransactions(context.Background(), userID, "item-dedup")
@@ -236,7 +236,7 @@ func TestPlaidSync_SoftDeletedReSurfaces(t *testing.T) {
 		t.Fatalf("seed item: %v", err)
 	}
 
-	svc := plaidsvc.NewService(client, box, itemRepo, acctRepo, txRepo, piiSvc, nil, g)
+	svc := plaidsvc.NewService(client, box, itemRepo, acctRepo, txRepo, repository.NewPlaidSyncErrorRepository(g), piiSvc, nil, g)
 
 	r, err := svc.SyncTransactions(context.Background(), userID, "item-resurface")
 	if err != nil {

--- a/backend/internal/service/plaid/service.go
+++ b/backend/internal/service/plaid/service.go
@@ -2,6 +2,7 @@ package plaid
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"regexp"
@@ -52,12 +53,16 @@ type SyncAccountsResult struct {
 // whose plaid_transaction_id matched a previously-soft-deleted local row —
 // they are undeleted in place rather than inserted as duplicates (see #63).
 // Removed is the count of Plaid IDs we were told to forget — for the
-// initial pull this is always 0.
+// initial pull this is always 0. Failed is the count of individual rows
+// that landed in plaid_sync_errors instead of the transactions table —
+// the cursor still advances and other rows still commit (see #80 +
+// docs/ADR/0011).
 type SyncTransactionsResult struct {
 	Inserted    int64 `json:"inserted"`
 	Resurrected int   `json:"resurrected"`
 	Modified    int   `json:"modified"`
 	Removed     int   `json:"removed"`
+	Failed      int   `json:"failed"`
 }
 
 // Service orchestrates the Plaid Link flow: issue link tokens, exchange
@@ -68,21 +73,21 @@ type SyncTransactionsResult struct {
 // at the handler layer. Holder names from /identity/get are routed through
 // piiSvc into pii_store — never written onto the accounts row directly.
 type Service struct {
-	client   Client
-	box      *crypto.SecretBox
-	itemRepo repository.PlaidItemRepository
-	acctRepo repository.AccountRepository
-	txRepo   repository.TransactionRepository
-	piiSvc   *service.PIIService
+	client      Client
+	box         *crypto.SecretBox
+	itemRepo    repository.PlaidItemRepository
+	acctRepo    repository.AccountRepository
+	txRepo      repository.TransactionRepository
+	syncErrRepo repository.PlaidSyncErrorRepository
+	piiSvc      *service.PIIService
 	// catMapper resolves Plaid PFCs to local categories at sync time.
 	// Nil = no auto-categorization (rows land uncategorized; user picks).
 	catMapper *CategoryMapper
 	// db is a deliberate exception to the "services don't see *gorm.DB"
-	// guideline. SyncTransactions needs a single atomic wrap across
-	// transactions + plaid_items updates per ADR-N/A (per-item sync is
-	// all-or-nothing — see issue #62 spec) and the repo abstraction
-	// doesn't currently expose a unit-of-work surface. Inside the
-	// transaction callback we construct fresh tx-bound repo instances
+	// guideline. SyncTransactions needs to wrap the per-item drain in a
+	// single Postgres transaction so it can use savepoints around each
+	// row insert (see #80 / docs/ADR/0011 — partial-success DLQ). Inside
+	// the transaction callback we construct fresh tx-bound repo instances
 	// so all writes hit the same transaction.
 	db *gorm.DB
 }
@@ -100,19 +105,21 @@ func NewService(
 	itemRepo repository.PlaidItemRepository,
 	acctRepo repository.AccountRepository,
 	txRepo repository.TransactionRepository,
+	syncErrRepo repository.PlaidSyncErrorRepository,
 	piiSvc *service.PIIService,
 	catMapper *CategoryMapper,
 	db *gorm.DB,
 ) *Service {
 	return &Service{
-		client:    client,
-		box:       box,
-		itemRepo:  itemRepo,
-		acctRepo:  acctRepo,
-		txRepo:    txRepo,
-		piiSvc:    piiSvc,
-		catMapper: catMapper,
-		db:        db,
+		client:      client,
+		box:         box,
+		itemRepo:    itemRepo,
+		acctRepo:    acctRepo,
+		txRepo:      txRepo,
+		syncErrRepo: syncErrRepo,
+		piiSvc:      piiSvc,
+		catMapper:   catMapper,
+		db:          db,
 	}
 }
 
@@ -396,18 +403,24 @@ func capErrorMessage(s string) string {
 // incremental refreshes (persisted cursor) — the same Plaid endpoint
 // covers both via the cursor handshake.
 //
-// Per #62, the entire per-item sync is wrapped in one db.Transaction:
-//   - all pages are drained from Plaid first (no DB writes)
-//   - then `added` rows are inserted, `modified` rows merged into existing
-//     rows (preserving user-edited category_id / notes), and `removed`
-//     rows soft-deleted
-//   - cursor + last_synced_at advance ONLY if all of the above succeed
+// Two-phase per-item drain (#62 + #80):
+//   - Phase 1: page through Plaid until exhaustion, accumulating in memory.
+//     No DB writes — a Plaid failure can't leave the DB half-updated.
+//   - Phase 2: one db.Transaction. Each `added`/`modified`/`removed` row is
+//     processed inside its own SAVEPOINT so a single bad row (decimal
+//     overflow, bad date, mapping error) goes to plaid_sync_errors instead
+//     of rolling back the whole batch. The cursor + last_synced_at advance
+//     once at the end regardless of how many rows DLQ'd.
 //
-// If anything in the DB phase fails, the cursor stays put and next run
-// re-fetches the same delta — safe because added uses ON CONFLICT DO
-// NOTHING and modified/removed are idempotent on plaid_transaction_id.
+// Sync status terminus:
+//   - All rows ok → 'ok'
+//   - At least one DLQ'd row → 'ok_with_errors' (post-commit write)
+//   - Transactional / Plaid failure → 'error' (recorded by the defer)
+//
+// See docs/ADR/0011 for the rationale on advancing the cursor across
+// partial failures.
 func (s *Service) SyncTransactions(ctx context.Context, userID int64, plaidItemID string) (result SyncTransactionsResult, retErr error) {
-	if !s.Configured() || s.acctRepo == nil || s.txRepo == nil || s.db == nil {
+	if !s.Configured() || s.acctRepo == nil || s.txRepo == nil || s.syncErrRepo == nil || s.db == nil {
 		return SyncTransactionsResult{}, ErrNotConfigured
 	}
 
@@ -471,23 +484,92 @@ func (s *Service) SyncTransactions(ctx context.Context, userID int64, plaidItemI
 	}
 
 	// Phase 2: one transaction for all writes. Tx-bound repos so every
-	// statement hits the same Postgres transaction; rollback on any error
-	// reverts the entire sync including the cursor advance.
+	// statement hits the same Postgres transaction. Per-row savepoints
+	// isolate individual failures — see SAVEPOINT helper below.
 	err = s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		txRepo := repository.NewTransactionRepository(tx)
 		itemRepo := repository.NewPlaidItemRepository(tx)
 		acctRepo := repository.NewAccountRepository(tx)
+		syncErrRepo := repository.NewPlaidSyncErrorRepository(tx)
 		accountIDCache := map[string]int64{}
+		spIdx := 0
+
+		// withSavepoint wraps fn in a Postgres SAVEPOINT so a row-level
+		// failure (constraint violation, type error) rolls back only that
+		// row's work, not the whole batch. After ROLLBACK TO SAVEPOINT
+		// the outer transaction is still alive — subsequent statements
+		// (including the DLQ insert) execute normally.
+		withSavepoint := func(fn func() error) error {
+			spIdx++
+			name := fmt.Sprintf("plaid_row_%d", spIdx)
+			if err := tx.SavePoint(name).Error; err != nil {
+				return fmt.Errorf("plaid: savepoint %s: %w", name, err)
+			}
+			if err := fn(); err != nil {
+				if rErr := tx.RollbackTo(name).Error; rErr != nil {
+					return fmt.Errorf("plaid: rollback to %s: %w (orig: %v)", name, rErr, err)
+				}
+				return err
+			}
+			return nil
+		}
+
+		// recordDLQ writes a plaid_sync_errors row. Runs OUTSIDE the
+		// just-rolled-back savepoint so it can't itself be reverted by a
+		// later RollbackTo. Stays inside the outer transaction so the
+		// cursor advance and DLQ rows commit atomically.
+		recordDLQ := func(pt PlaidTransaction, code string, cause error) error {
+			raw, mErr := json.Marshal(pt)
+			if mErr != nil {
+				raw = json.RawMessage(`{}`)
+			}
+			var ptxIDPtr *string
+			if pt.PlaidTransactionID != "" {
+				v := pt.PlaidTransactionID
+				ptxIDPtr = &v
+			}
+			row := &model.PlaidSyncError{
+				UserID:             userID,
+				PlaidItemID:        item.ID,
+				PlaidTransactionID: ptxIDPtr,
+				RawPayload:         raw,
+				ErrorCode:          code,
+				ErrorMessage:       capErrorMessage(cause.Error()),
+				OccurredAt:         time.Now().UTC(),
+			}
+			if err := syncErrRepo.Create(ctx, row); err != nil {
+				return fmt.Errorf("plaid: write DLQ row: %w", err)
+			}
+			result.Failed++
+			return nil
+		}
+
+		// classifyRowError categorizes a per-row failure so the UI can
+		// group by error_code. account-resolution and mapping errors are
+		// surfaced separately from raw DB errors because they tend to
+		// point at different fixes (run sync-accounts vs. file a bug).
+		classifyRowError := func(err error) string {
+			msg := err.Error()
+			switch {
+			case strings.Contains(msg, "no local account for plaid_account_id"):
+				return model.PlaidSyncErrorCodeMapping
+			case strings.Contains(msg, "parse date"), strings.Contains(msg, "parse authorized_date"):
+				return model.PlaidSyncErrorCodeValidation
+			case strings.Contains(msg, "numeric field overflow"), strings.Contains(msg, "value out of range"):
+				return model.PlaidSyncErrorCodeDecimalOverflow
+			case strings.Contains(msg, "transaction_id empty"), strings.Contains(msg, "account_id empty"):
+				return model.PlaidSyncErrorCodeValidation
+			default:
+				return model.PlaidSyncErrorCodeDB
+			}
+		}
 
 		// Inserts. Two cases per `added`:
 		//   1. plaid_transaction_id matches a soft-deleted local row →
 		//      resurrect (clear deleted_at + overlay via MergePlaidUpdate
 		//      so user-edited notes/category survive the round-trip).
-		//   2. otherwise → batch insert with ON CONFLICT DO NOTHING.
-		// The resurrect pass is what gives #63 its "re-sync of a previously
-		// deleted Plaid row restores in place" guarantee — without it, the
-		// partial unique index (which excludes deleted rows) would silently
-		// let a duplicate land.
+		//   2. otherwise → single-row insert with ON CONFLICT DO NOTHING.
+		// Both paths run inside a savepoint so one bad row just DLQs.
 		if len(added) > 0 {
 			plaidIDs := make([]string, 0, len(added))
 			addedByPlaidID := make(map[string]PlaidTransaction, len(added))
@@ -510,84 +592,110 @@ func (s *Service) SyncTransactions(ctx context.Context, userID int64, plaidItemI
 				if !ok {
 					continue
 				}
-				localID, err := resolveAccountID(ctx, acctRepo, userID, incoming.PlaidAccountID, accountIDCache)
-				if err != nil {
-					return err
-				}
-				merged, err := MergePlaidUpdate(existing, incoming, localID, s.catMapper)
-				if err != nil {
-					return err
-				}
-				if err := txRepo.ResurrectByPlaidTransactionID(ctx, userID, ptxID, merged); err != nil {
-					return fmt.Errorf("plaid: resurrect %s: %w", ptxID, err)
+				perRowErr := withSavepoint(func() error {
+					localID, err := resolveAccountID(ctx, acctRepo, userID, incoming.PlaidAccountID, accountIDCache)
+					if err != nil {
+						return err
+					}
+					merged, err := MergePlaidUpdate(existing, incoming, localID, s.catMapper)
+					if err != nil {
+						return err
+					}
+					return txRepo.ResurrectByPlaidTransactionID(ctx, userID, ptxID, merged)
+				})
+				if perRowErr != nil {
+					if err := recordDLQ(incoming, classifyRowError(perRowErr), perRowErr); err != nil {
+						return err
+					}
+					// Mark as "handled" so the insert pass below doesn't
+					// try again on the same row.
+					resurrectedIDs[ptxID] = struct{}{}
+					continue
 				}
 				resurrectedIDs[ptxID] = struct{}{}
 				result.Resurrected++
 			}
 
-			batch := make([]model.Transaction, 0, len(added)-len(resurrectedIDs))
 			for _, pt := range added {
 				if _, done := resurrectedIDs[pt.PlaidTransactionID]; done {
 					continue
 				}
-				localID, err := resolveAccountID(ctx, acctRepo, userID, pt.PlaidAccountID, accountIDCache)
-				if err != nil {
-					return err
+				perRowErr := withSavepoint(func() error {
+					localID, err := resolveAccountID(ctx, acctRepo, userID, pt.PlaidAccountID, accountIDCache)
+					if err != nil {
+						return err
+					}
+					row, err := MapPlaidTransaction(pt, userID, localID, s.catMapper)
+					if err != nil {
+						return err
+					}
+					n, err := txRepo.CreateBatch(ctx, []model.Transaction{row})
+					if err != nil {
+						return err
+					}
+					result.Inserted += n
+					return nil
+				})
+				if perRowErr != nil {
+					if err := recordDLQ(pt, classifyRowError(perRowErr), perRowErr); err != nil {
+						return err
+					}
 				}
-				row, err := MapPlaidTransaction(pt, userID, localID, s.catMapper)
-				if err != nil {
-					return err
-				}
-				batch = append(batch, row)
-			}
-			if len(batch) > 0 {
-				n, err := txRepo.CreateBatch(ctx, batch)
-				if err != nil {
-					return fmt.Errorf("plaid: insert batch: %w", err)
-				}
-				result.Inserted = n
 			}
 		}
 
 		// Modifications: merge with the existing row so user-edited
-		// fields survive.
+		// fields survive. Wrap each in a savepoint so a single bad
+		// `modified` doesn't poison the rest of the batch.
 		for _, pt := range modified {
-			localID, err := resolveAccountID(ctx, acctRepo, userID, pt.PlaidAccountID, accountIDCache)
-			if err != nil {
-				return err
-			}
-			var existing model.Transaction
-			err = tx.WithContext(ctx).
-				Where("user_id = ? AND plaid_transaction_id = ?", userID, pt.PlaidTransactionID).
-				First(&existing).Error
-			if errors.Is(err, gorm.ErrRecordNotFound) {
-				// Plaid sent a `modified` for something we never
-				// recorded. Treat as a fresh insert so we don't lose it.
-				row, mapErr := MapPlaidTransaction(pt, userID, localID, s.catMapper)
-				if mapErr != nil {
-					return mapErr
+			var insertedAsNew bool
+			perRowErr := withSavepoint(func() error {
+				localID, err := resolveAccountID(ctx, acctRepo, userID, pt.PlaidAccountID, accountIDCache)
+				if err != nil {
+					return err
 				}
-				if _, batchErr := txRepo.CreateBatch(ctx, []model.Transaction{row}); batchErr != nil {
-					return fmt.Errorf("plaid: insert modified-as-new: %w", batchErr)
+				var existing model.Transaction
+				err = tx.WithContext(ctx).
+					Where("user_id = ? AND plaid_transaction_id = ?", userID, pt.PlaidTransactionID).
+					First(&existing).Error
+				if errors.Is(err, gorm.ErrRecordNotFound) {
+					// Plaid sent a `modified` for something we never
+					// recorded. Treat as a fresh insert so we don't lose it.
+					row, mapErr := MapPlaidTransaction(pt, userID, localID, s.catMapper)
+					if mapErr != nil {
+						return mapErr
+					}
+					if _, batchErr := txRepo.CreateBatch(ctx, []model.Transaction{row}); batchErr != nil {
+						return batchErr
+					}
+					insertedAsNew = true
+					return nil
 				}
-				result.Inserted++
+				if err != nil {
+					return err
+				}
+				merged, err := MergePlaidUpdate(existing, pt, localID, s.catMapper)
+				if err != nil {
+					return err
+				}
+				return txRepo.UpdateByPlaidTransactionID(ctx, userID, pt.PlaidTransactionID, merged)
+			})
+			if perRowErr != nil {
+				if err := recordDLQ(pt, classifyRowError(perRowErr), perRowErr); err != nil {
+					return err
+				}
 				continue
 			}
-			if err != nil {
-				return fmt.Errorf("plaid: read existing for modify: %w", err)
+			if insertedAsNew {
+				result.Inserted++
+			} else {
+				result.Modified++
 			}
-			merged, err := MergePlaidUpdate(existing, pt, localID, s.catMapper)
-			if err != nil {
-				return err
-			}
-			if err := txRepo.UpdateByPlaidTransactionID(ctx, userID, pt.PlaidTransactionID, merged); err != nil {
-				return fmt.Errorf("plaid: update modified: %w", err)
-			}
-			result.Modified++
 		}
 
 		// Removals: soft-delete. ErrNotFound is benign (already deleted
-		// or never seen) and shouldn't roll back the transaction.
+		// or never seen). A real DB error here is rare and almost always
+		// systemic — abort rather than DLQ a string ID with no payload.
 		for _, ptxID := range removed {
 			err := txRepo.SoftDeleteByPlaidTransactionID(ctx, userID, ptxID)
 			switch {
@@ -602,7 +710,12 @@ func (s *Service) SyncTransactions(ctx context.Context, userID int64, plaidItemI
 			}
 		}
 
-		// Cursor advance — final write inside the same transaction.
+		// Cursor advance — final write inside the same transaction. Always
+		// happens, even when result.Failed > 0: the whole point of the DLQ
+		// is to let good rows commit and let the cursor move past the
+		// poison row instead of replaying the failure forever (#80).
+		// UpdateCursor sets status='ok' + clears last_sync_error; if any
+		// rows DLQ'd we flip to 'ok_with_errors' AFTER commit (below).
 		if err := itemRepo.UpdateCursor(ctx, userID, item.ID, cursor, time.Now().UTC()); err != nil {
 			return fmt.Errorf("plaid: persist cursor: %w", err)
 		}
@@ -610,6 +723,17 @@ func (s *Service) SyncTransactions(ctx context.Context, userID int64, plaidItemI
 	})
 	if err != nil {
 		return SyncTransactionsResult{}, err
+	}
+
+	// Post-commit status fix-up: if any rows DLQ'd, mark the item
+	// 'ok_with_errors' with a summary message. Done outside the tx so a
+	// failure here is non-fatal — the cursor and DLQ rows already
+	// committed; the worst case is a stale 'ok' status that the next sync
+	// will overwrite. statusCtx is detached so a request cancel doesn't
+	// leave it inconsistent.
+	if result.Failed > 0 {
+		msg := fmt.Sprintf("%d row(s) failed to import; see Linked Institutions", result.Failed)
+		_ = s.itemRepo.UpdateSyncStatus(statusCtx, userID, item.ID, "ok_with_errors", &msg)
 	}
 	return result, nil
 }

--- a/backend/internal/service/plaid/service_test.go
+++ b/backend/internal/service/plaid/service_test.go
@@ -119,7 +119,7 @@ func TestService_CreateLinkToken_HappyPath(t *testing.T) {
 	if err != nil {
 		t.Fatalf("secretbox: %v", err)
 	}
-	svc := plaidsvc.NewService(client, box, &fakeRepo{}, nil, nil, nil, nil, nil)
+	svc := plaidsvc.NewService(client, box, &fakeRepo{}, nil, nil, nil, nil, nil, nil)
 
 	tok, err := svc.CreateLinkToken(context.Background(), 42)
 	if err != nil {
@@ -144,7 +144,7 @@ func TestService_ExchangePublicToken_HappyPath(t *testing.T) {
 	client, _ := plaidsvc.NewSDKClient(plaidsvc.Config{ClientID: "cid", Secret: "csec", Env: srv.URL})
 	box, _ := crypto.NewSecretBox(newTestKey())
 	repo := &fakeRepo{}
-	svc := plaidsvc.NewService(client, box, repo, nil, nil, nil, nil, nil)
+	svc := plaidsvc.NewService(client, box, repo, nil, nil, nil, nil, nil, nil)
 
 	item, err := svc.ExchangePublicToken(context.Background(), 7, "public-sandbox-xyz")
 	if err != nil {
@@ -183,7 +183,7 @@ func TestService_ExchangePublicToken_RejectsEmpty(t *testing.T) {
 	srv, _ := fakePlaid(t)
 	client, _ := plaidsvc.NewSDKClient(plaidsvc.Config{ClientID: "cid", Secret: "csec", Env: srv.URL})
 	box, _ := crypto.NewSecretBox(newTestKey())
-	svc := plaidsvc.NewService(client, box, &fakeRepo{}, nil, nil, nil, nil, nil)
+	svc := plaidsvc.NewService(client, box, &fakeRepo{}, nil, nil, nil, nil, nil, nil)
 
 	if _, err := svc.ExchangePublicToken(context.Background(), 1, "   "); err != plaidsvc.ErrInvalidPublicToken {
 		t.Fatalf("expected ErrInvalidPublicToken, got %v", err)
@@ -191,7 +191,7 @@ func TestService_ExchangePublicToken_RejectsEmpty(t *testing.T) {
 }
 
 func TestService_NotConfigured(t *testing.T) {
-	svc := plaidsvc.NewService(nil, nil, nil, nil, nil, nil, nil, nil)
+	svc := plaidsvc.NewService(nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	if svc.Configured() {
 		t.Fatal("expected !Configured")
 	}

--- a/backend/internal/service/plaid/sync_accounts_integration_test.go
+++ b/backend/internal/service/plaid/sync_accounts_integration_test.go
@@ -209,7 +209,7 @@ func TestService_SyncAccounts_PIIIsolationAndIdempotency(t *testing.T) {
 		t.Fatalf("seed item: %v", err)
 	}
 
-	svc := plaidsvc.NewService(client, box, itemRepo, acctRepo, repository.NewTransactionRepository(g), piiSvc, nil, g)
+	svc := plaidsvc.NewService(client, box, itemRepo, acctRepo, repository.NewTransactionRepository(g), repository.NewPlaidSyncErrorRepository(g), piiSvc, nil, g)
 
 	// First sync: 2 accounts created.
 	r1, err := svc.SyncAccounts(context.Background(), userID, "item-fake-sync-1")
@@ -305,7 +305,7 @@ func TestService_SyncAccounts_ItemNotFound(t *testing.T) {
 	acctRepo := repository.NewAccountRepository(g)
 	acctSvc := service.NewAccountService(acctRepo)
 	piiSvc := service.NewPIIService(repository.NewPIIRepository(g), acctSvc)
-	svc := plaidsvc.NewService(client, box, itemRepo, acctRepo, repository.NewTransactionRepository(g), piiSvc, nil, g)
+	svc := plaidsvc.NewService(client, box, itemRepo, acctRepo, repository.NewTransactionRepository(g), repository.NewPlaidSyncErrorRepository(g), piiSvc, nil, g)
 
 	_, err := svc.SyncAccounts(context.Background(), userID, "nonexistent-item")
 	if err != plaidsvc.ErrItemNotFound {

--- a/backend/internal/service/plaid/sync_errors.go
+++ b/backend/internal/service/plaid/sync_errors.go
@@ -1,0 +1,198 @@
+package plaid
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"gorm.io/gorm"
+
+	"github.com/gregwym/offbook/backend/internal/model"
+	"github.com/gregwym/offbook/backend/internal/repository"
+)
+
+// Sync-error management domain errors.
+var (
+	// ErrSyncErrorNotFound is returned for missing or already-resolved DLQ
+	// rows. Handlers map to 404.
+	ErrSyncErrorNotFound = errors.New("plaid sync error not found")
+
+	// ErrSyncErrorReplay is returned when the raw_payload can't be replayed
+	// (e.g., its account_id no longer maps to a local account). Handlers
+	// surface this as 422 — the row stays unresolved so the owner can
+	// dismiss or try again after fixing the underlying cause.
+	ErrSyncErrorReplay = errors.New("plaid sync error cannot be retried")
+)
+
+// PlaidItemSummary embeds a PlaidItem and adds the unresolved DLQ count.
+// Used by /plaid/items so the Settings page can render the badge without
+// fanning out N+1 follow-up calls.
+type PlaidItemSummary struct {
+	model.PlaidItem
+	UnresolvedSyncErrors int64 `json:"unresolved_sync_errors"`
+}
+
+// ListItemsWithSyncErrors returns every linked item for the user along
+// with its unresolved DLQ count. Replaces the bare ListItems call when
+// the frontend wants the badge.
+func (s *Service) ListItemsWithSyncErrors(ctx context.Context, userID int64) ([]PlaidItemSummary, error) {
+	if s == nil || s.itemRepo == nil {
+		return nil, ErrNotConfigured
+	}
+	items, err := s.itemRepo.ListByUser(ctx, userID)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]PlaidItemSummary, 0, len(items))
+	if len(items) == 0 {
+		return out, nil
+	}
+	ids := make([]int64, 0, len(items))
+	for _, it := range items {
+		ids = append(ids, it.ID)
+	}
+	counts := map[int64]int64{}
+	if s.syncErrRepo != nil {
+		counts, err = s.syncErrRepo.UnresolvedCountsByItems(ctx, userID, ids)
+		if err != nil {
+			return nil, fmt.Errorf("plaid: count sync errors: %w", err)
+		}
+	}
+	for _, it := range items {
+		out = append(out, PlaidItemSummary{
+			PlaidItem:            it,
+			UnresolvedSyncErrors: counts[it.ID],
+		})
+	}
+	return out, nil
+}
+
+// ListSyncErrors returns DLQ rows for the given item. unresolvedOnly = true
+// hides retried/dismissed rows. Item ownership is verified before the
+// listing — a 404 here means "not your item" or "no such item".
+func (s *Service) ListSyncErrors(ctx context.Context, userID int64, plaidItemID string, unresolvedOnly bool) ([]model.PlaidSyncError, error) {
+	if s == nil || s.itemRepo == nil || s.syncErrRepo == nil {
+		return nil, ErrNotConfigured
+	}
+	item, err := s.itemRepo.GetByPlaidItemID(ctx, userID, plaidItemID)
+	if err != nil {
+		if errors.Is(err, repository.ErrNotFound) {
+			return nil, ErrItemNotFound
+		}
+		return nil, err
+	}
+	rows, err := s.syncErrRepo.ListByItem(ctx, userID, item.ID, unresolvedOnly)
+	if err != nil {
+		return nil, fmt.Errorf("plaid: list sync errors: %w", err)
+	}
+	if rows == nil {
+		rows = []model.PlaidSyncError{}
+	}
+	return rows, nil
+}
+
+// DismissSyncError marks a DLQ row resolved without retrying it. Idempotent
+// at the repo layer — a second click returns ErrSyncErrorNotFound rather
+// than reaping the prior resolution timestamp.
+func (s *Service) DismissSyncError(ctx context.Context, userID, errorID int64) error {
+	if s == nil || s.syncErrRepo == nil {
+		return ErrNotConfigured
+	}
+	err := s.syncErrRepo.MarkResolved(ctx, userID, errorID, model.ResolutionDismissed, time.Now().UTC())
+	if errors.Is(err, repository.ErrNotFound) {
+		return ErrSyncErrorNotFound
+	}
+	return err
+}
+
+// RetrySyncError replays raw_payload through the same mapping path as a
+// live sync. On success the row is marked resolved=retried_ok. On failure
+// the row stays unresolved (no second DLQ row — that would multiply forever
+// across retries).
+//
+// Wrapped in one transaction so the txn-insert and resolution flip commit
+// together; a mid-flight failure leaves the row exactly as it was.
+func (s *Service) RetrySyncError(ctx context.Context, userID, errorID int64) error {
+	if s == nil || s.syncErrRepo == nil || s.txRepo == nil || s.acctRepo == nil || s.db == nil {
+		return ErrNotConfigured
+	}
+	row, err := s.syncErrRepo.Get(ctx, userID, errorID)
+	if err != nil {
+		if errors.Is(err, repository.ErrNotFound) {
+			return ErrSyncErrorNotFound
+		}
+		return err
+	}
+	if row.ResolvedAt != nil {
+		return ErrSyncErrorNotFound
+	}
+
+	var pt PlaidTransaction
+	if err := json.Unmarshal(row.RawPayload, &pt); err != nil {
+		return fmt.Errorf("%w: bad raw_payload: %v", ErrSyncErrorReplay, err)
+	}
+
+	return s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		txRepo := repository.NewTransactionRepository(tx)
+		acctRepo := repository.NewAccountRepository(tx)
+		syncErrRepo := repository.NewPlaidSyncErrorRepository(tx)
+		cache := map[string]int64{}
+
+		// Resurrect-aware insert path, mirroring SyncTransactions.
+		soft, err := txRepo.FindSoftDeletedByPlaidTransactionIDs(ctx, userID, []string{pt.PlaidTransactionID})
+		if err != nil {
+			return fmt.Errorf("plaid: retry lookup soft-deleted: %w", err)
+		}
+		if len(soft) > 0 {
+			localID, err := resolveAccountID(ctx, acctRepo, userID, pt.PlaidAccountID, cache)
+			if err != nil {
+				return fmt.Errorf("%w: %v", ErrSyncErrorReplay, err)
+			}
+			merged, err := MergePlaidUpdate(soft[0], pt, localID, s.catMapper)
+			if err != nil {
+				return fmt.Errorf("%w: %v", ErrSyncErrorReplay, err)
+			}
+			if err := txRepo.ResurrectByPlaidTransactionID(ctx, userID, pt.PlaidTransactionID, merged); err != nil {
+				return fmt.Errorf("%w: %v", ErrSyncErrorReplay, err)
+			}
+		} else {
+			localID, err := resolveAccountID(ctx, acctRepo, userID, pt.PlaidAccountID, cache)
+			if err != nil {
+				return fmt.Errorf("%w: %v", ErrSyncErrorReplay, err)
+			}
+			mapped, err := MapPlaidTransaction(pt, userID, localID, s.catMapper)
+			if err != nil {
+				return fmt.Errorf("%w: %v", ErrSyncErrorReplay, err)
+			}
+			if _, err := txRepo.CreateBatch(ctx, []model.Transaction{mapped}); err != nil {
+				return fmt.Errorf("%w: %v", ErrSyncErrorReplay, err)
+			}
+		}
+
+		if err := syncErrRepo.MarkResolved(ctx, userID, errorID, model.ResolutionRetriedOK, time.Now().UTC()); err != nil {
+			if errors.Is(err, repository.ErrNotFound) {
+				// Lost a race with another dismiss — the txn still got
+				// inserted; bubble up so the user can refresh and see it.
+				return ErrSyncErrorNotFound
+			}
+			return err
+		}
+		return nil
+	})
+}
+
+// looksLikeNumericOverflow lets the retry handler distinguish "data still
+// bad" from "replay infra broken" so the UI can render a useful message.
+// Kept here (not in service.go) because it's only used by retry.
+//
+//nolint:unused // reserved for richer retry-error classification (see #80 follow-up)
+func looksLikeNumericOverflow(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "numeric field overflow") || strings.Contains(msg, "value out of range")
+}

--- a/backend/internal/service/plaid/sync_status_integration_test.go
+++ b/backend/internal/service/plaid/sync_status_integration_test.go
@@ -114,7 +114,7 @@ func TestPlaidSync_StatusFlipsOnErrorThenClearsOnSuccess(t *testing.T) {
 		t.Fatalf("seed item: %v", err)
 	}
 
-	svc := plaidsvc.NewService(client, box, itemRepo, acctRepo, txRepo, piiSvc, nil, g)
+	svc := plaidsvc.NewService(client, box, itemRepo, acctRepo, txRepo, repository.NewPlaidSyncErrorRepository(g), piiSvc, nil, g)
 
 	// Phase 1: forced error.
 	if _, err := svc.SyncTransactions(context.Background(), userID, "item-status"); err == nil {

--- a/backend/internal/service/plaid/sync_transactions_incremental_test.go
+++ b/backend/internal/service/plaid/sync_transactions_incremental_test.go
@@ -167,7 +167,7 @@ func TestService_SyncTransactions_IncrementalAddedModifiedRemoved(t *testing.T) 
 	acctRepo := repository.NewAccountRepository(g)
 	txRepo := repository.NewTransactionRepository(g)
 	piiSvc := service.NewPIIService(repository.NewPIIRepository(g), service.NewAccountService(acctRepo))
-	svc := plaidsvc.NewService(client, box, itemRepo, acctRepo, txRepo, piiSvc, nil, g)
+	svc := plaidsvc.NewService(client, box, itemRepo, acctRepo, txRepo, repository.NewPlaidSyncErrorRepository(g), piiSvc, nil, g)
 
 	r, err := svc.SyncTransactions(context.Background(), userID, "item-incr-1")
 	if err != nil {
@@ -325,7 +325,7 @@ func TestService_SyncTransactions_TenantIsolation(t *testing.T) {
 	acctRepo := repository.NewAccountRepository(g)
 	txRepo := repository.NewTransactionRepository(g)
 	piiSvc := service.NewPIIService(repository.NewPIIRepository(g), service.NewAccountService(acctRepo))
-	svc := plaidsvc.NewService(client, box, itemRepo, acctRepo, txRepo, piiSvc, nil, g)
+	svc := plaidsvc.NewService(client, box, itemRepo, acctRepo, txRepo, repository.NewPlaidSyncErrorRepository(g), piiSvc, nil, g)
 
 	if _, err := svc.SyncTransactions(context.Background(), userA, "item-A"); err != nil {
 		t.Fatalf("Sync user A: %v", err)

--- a/backend/internal/service/plaid/sync_transactions_integration_test.go
+++ b/backend/internal/service/plaid/sync_transactions_integration_test.go
@@ -5,8 +5,10 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/shopspring/decimal"
 
@@ -146,7 +148,7 @@ func TestService_SyncTransactions_PaginatesAndPersistsCursor(t *testing.T) {
 		t.Fatalf("seed item: %v", err)
 	}
 
-	svc := plaidsvc.NewService(client, box, itemRepo, acctRepo, txRepo, piiSvc, nil, g)
+	svc := plaidsvc.NewService(client, box, itemRepo, acctRepo, txRepo, repository.NewPlaidSyncErrorRepository(g), piiSvc, nil, g)
 
 	// First full pull
 	r, err := svc.SyncTransactions(context.Background(), userID, "item-sync-1")
@@ -215,7 +217,10 @@ func TestService_SyncTransactions_PaginatesAndPersistsCursor(t *testing.T) {
 	}
 }
 
-func TestService_SyncTransactions_UnknownAccountErrors(t *testing.T) {
+// #80: When Plaid sends transactions for an account_id we haven't synced
+// yet, the rows must DLQ rather than abort the whole sync — otherwise a
+// single stale Plaid mapping permanently blocks the cursor.
+func TestService_SyncTransactions_UnknownAccountGoesToDLQ(t *testing.T) {
 	g := openPlaidTestDB(t)
 	userID := seedPlaidTestUser(t, g)
 	srv, _ := fakeTxnsSyncServer(t, "pacct-never-discovered")
@@ -225,6 +230,7 @@ func TestService_SyncTransactions_UnknownAccountErrors(t *testing.T) {
 	itemRepo := repository.NewPlaidItemRepository(g)
 	acctRepo := repository.NewAccountRepository(g)
 	txRepo := repository.NewTransactionRepository(g)
+	syncErrRepo := repository.NewPlaidSyncErrorRepository(g)
 	piiSvc := service.NewPIIService(repository.NewPIIRepository(g), service.NewAccountService(acctRepo))
 
 	enc, _ := box.Encrypt([]byte("access-sandbox-fake"))
@@ -237,10 +243,266 @@ func TestService_SyncTransactions_UnknownAccountErrors(t *testing.T) {
 	if err := itemRepo.Create(context.Background(), item); err != nil {
 		t.Fatalf("seed item: %v", err)
 	}
+	t.Cleanup(func() {
+		g.Unscoped().Where("user_id = ?", userID).Delete(&model.PlaidSyncError{})
+	})
 
-	svc := plaidsvc.NewService(client, box, itemRepo, acctRepo, txRepo, piiSvc, nil, g)
-	_, err := svc.SyncTransactions(context.Background(), userID, "item-orphan")
-	if err == nil {
-		t.Fatal("expected error when plaid_account_id can't resolve to a local account")
+	svc := plaidsvc.NewService(client, box, itemRepo, acctRepo, txRepo, syncErrRepo, piiSvc, nil, g)
+	r, err := svc.SyncTransactions(context.Background(), userID, "item-orphan")
+	if err != nil {
+		t.Fatalf("SyncTransactions should not return error on per-row mapping failures: %v", err)
+	}
+	// All 3 fake rows reference an unknown account → all 3 DLQ.
+	if r.Failed != 3 {
+		t.Errorf("Failed=%d, want 3 (all rows go to DLQ on unknown account)", r.Failed)
+	}
+	if r.Inserted != 0 {
+		t.Errorf("Inserted=%d, want 0", r.Inserted)
+	}
+
+	// Cursor must still advance — that's the whole point.
+	persisted, _ := itemRepo.GetByPlaidItemID(context.Background(), userID, "item-orphan")
+	if persisted.Cursor == nil || *persisted.Cursor != "final-cursor" {
+		t.Errorf("cursor = %v, want final-cursor (must advance past poison rows)", persisted.Cursor)
+	}
+	if persisted.LastSyncStatus != "ok_with_errors" {
+		t.Errorf("last_sync_status = %q, want ok_with_errors", persisted.LastSyncStatus)
+	}
+
+	// DLQ rows are linked to the item and capture the raw payload + a
+	// mapping-class error code.
+	dlq, err := syncErrRepo.ListByItem(context.Background(), userID, persisted.ID, true)
+	if err != nil {
+		t.Fatalf("list dlq: %v", err)
+	}
+	if len(dlq) != 3 {
+		t.Fatalf("dlq rows = %d, want 3", len(dlq))
+	}
+	for _, row := range dlq {
+		if row.ErrorCode != model.PlaidSyncErrorCodeMapping {
+			t.Errorf("error_code = %q, want %q", row.ErrorCode, model.PlaidSyncErrorCodeMapping)
+		}
+		if row.PlaidTransactionID == nil || *row.PlaidTransactionID == "" {
+			t.Errorf("plaid_transaction_id not preserved: %+v", row.PlaidTransactionID)
+		}
+		// raw_payload should be valid JSON containing the plaid_account_id.
+		if !strings.Contains(string(row.RawPayload), "pacct-never-discovered") {
+			t.Errorf("raw_payload missing account_id: %s", string(row.RawPayload))
+		}
+	}
+
+	count, err := syncErrRepo.CountUnresolvedByItem(context.Background(), userID, persisted.ID)
+	if err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if count != 3 {
+		t.Errorf("unresolved count = %d, want 3", count)
 	}
 }
+
+// Mixed batch: 2 rows map cleanly, 1 row references an unknown account.
+// Asserts good rows commit, bad row DLQs, cursor advances, status =
+// ok_with_errors.
+func TestService_SyncTransactions_PartialSuccess(t *testing.T) {
+	g := openPlaidTestDB(t)
+	userID := seedPlaidTestUser(t, g)
+
+	const goodAcctID = "pacct-mixed-good"
+	const badAcctID = "pacct-mixed-bad" // intentionally not seeded
+	acct := &model.Account{
+		UserID:          userID,
+		Name:            "Mixed Checking",
+		InstitutionSlug: "ins_test",
+		AccountType:     "checking",
+		Currency:        "USD",
+		PlaidAccountID:  &[]string{goodAcctID}[0],
+		IsActive:        true,
+	}
+	if err := g.Create(acct).Error; err != nil {
+		t.Fatalf("seed account: %v", err)
+	}
+	t.Cleanup(func() {
+		g.Unscoped().Where("user_id = ?", userID).Delete(&model.Transaction{})
+		g.Unscoped().Where("user_id = ?", userID).Delete(&model.PlaidSyncError{})
+		g.Unscoped().Delete(&model.Account{}, acct.ID)
+	})
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/transactions/sync", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"added": []map[string]any{
+				{
+					"transaction_id":    "mix-good-1",
+					"account_id":        goodAcctID,
+					"amount":            10.00,
+					"iso_currency_code": "USD",
+					"name":              "Good 1",
+					"date":              "2026-05-10",
+				},
+				{
+					"transaction_id":    "mix-bad-1",
+					"account_id":        badAcctID,
+					"amount":            20.00,
+					"iso_currency_code": "USD",
+					"name":              "Bad 1",
+					"date":              "2026-05-11",
+				},
+				{
+					"transaction_id":    "mix-good-2",
+					"account_id":        goodAcctID,
+					"amount":            30.00,
+					"iso_currency_code": "USD",
+					"name":              "Good 2",
+					"date":              "2026-05-12",
+				},
+			},
+			"modified":    []any{},
+			"removed":     []any{},
+			"next_cursor": "after-mix",
+			"has_more":    false,
+		})
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	client, _ := plaidsvc.NewSDKClient(plaidsvc.Config{ClientID: "cid", Secret: "csec", Env: srv.URL})
+	box, _ := crypto.NewSecretBox(newTestKey())
+	itemRepo := repository.NewPlaidItemRepository(g)
+	acctRepo := repository.NewAccountRepository(g)
+	txRepo := repository.NewTransactionRepository(g)
+	syncErrRepo := repository.NewPlaidSyncErrorRepository(g)
+	piiSvc := service.NewPIIService(repository.NewPIIRepository(g), service.NewAccountService(acctRepo))
+
+	enc, _ := box.Encrypt([]byte("access-sandbox-fake"))
+	item := &model.PlaidItem{
+		UserID:         userID,
+		PlaidItemID:    "item-mix",
+		AccessTokenEnc: enc,
+		Status:         "active",
+	}
+	if err := itemRepo.Create(context.Background(), item); err != nil {
+		t.Fatalf("seed item: %v", err)
+	}
+
+	svc := plaidsvc.NewService(client, box, itemRepo, acctRepo, txRepo, syncErrRepo, piiSvc, nil, g)
+	r, err := svc.SyncTransactions(context.Background(), userID, "item-mix")
+	if err != nil {
+		t.Fatalf("SyncTransactions: %v", err)
+	}
+	if r.Inserted != 2 || r.Failed != 1 {
+		t.Errorf("inserted=%d failed=%d, want 2/1", r.Inserted, r.Failed)
+	}
+
+	// Cursor advanced, status reflects partial.
+	persisted, _ := itemRepo.GetByPlaidItemID(context.Background(), userID, "item-mix")
+	if *persisted.Cursor != "after-mix" {
+		t.Errorf("cursor = %v, want after-mix", persisted.Cursor)
+	}
+	if persisted.LastSyncStatus != "ok_with_errors" {
+		t.Errorf("status = %q, want ok_with_errors", persisted.LastSyncStatus)
+	}
+
+	// Retry the DLQ row AFTER seeding the missing account. The row should
+	// flip to retried_ok and the txn should appear in transactions.
+	badAcct := &model.Account{
+		UserID:          userID,
+		Name:            "Backfilled",
+		InstitutionSlug: "ins_test",
+		AccountType:     "checking",
+		Currency:        "USD",
+		PlaidAccountID:  &[]string{badAcctID}[0],
+		IsActive:        true,
+	}
+	if err := g.Create(badAcct).Error; err != nil {
+		t.Fatalf("seed bad acct: %v", err)
+	}
+	// Delete txns referencing this account first so the FK constraint is
+	// happy when Cleanup runs (LIFO — this fires before the txn cleanup
+	// registered above, hence the explicit txn delete here).
+	t.Cleanup(func() {
+		g.Unscoped().Where("account_id = ?", badAcct.ID).Delete(&model.Transaction{})
+		g.Unscoped().Delete(&model.Account{}, badAcct.ID)
+	})
+
+	dlq, _ := syncErrRepo.ListByItem(context.Background(), userID, persisted.ID, true)
+	if len(dlq) != 1 {
+		t.Fatalf("dlq rows = %d, want 1", len(dlq))
+	}
+	if err := svc.RetrySyncError(context.Background(), userID, dlq[0].ID); err != nil {
+		t.Fatalf("RetrySyncError: %v", err)
+	}
+
+	// Row is now resolved.
+	got, err := syncErrRepo.Get(context.Background(), userID, dlq[0].ID)
+	if err != nil {
+		t.Fatalf("re-fetch dlq row: %v", err)
+	}
+	if got.Resolution == nil || *got.Resolution != model.ResolutionRetriedOK {
+		t.Errorf("resolution = %v, want retried_ok", got.Resolution)
+	}
+
+	// And the txn landed.
+	var retried model.Transaction
+	if err := g.Where("plaid_transaction_id = ?", "mix-bad-1").First(&retried).Error; err != nil {
+		t.Fatalf("retried txn missing: %v", err)
+	}
+	if retried.AccountID != badAcct.ID {
+		t.Errorf("retried account_id = %d, want %d", retried.AccountID, badAcct.ID)
+	}
+
+	// Unresolved count returns to 0.
+	count, _ := syncErrRepo.CountUnresolvedByItem(context.Background(), userID, persisted.ID)
+	if count != 0 {
+		t.Errorf("unresolved count = %d after retry, want 0", count)
+	}
+}
+
+// Multi-tenant safety: user A's DLQ rows must not be visible to user B,
+// even if they happen to share a numeric error_id.
+func TestService_SyncErrors_TenantIsolation(t *testing.T) {
+	g := openPlaidTestDB(t)
+	userA := seedPlaidTestUser(t, g)
+	userB := seedPlaidTestUser(t, g)
+
+	// Seed an item + DLQ row for user A.
+	box, _ := crypto.NewSecretBox(newTestKey())
+	enc, _ := box.Encrypt([]byte("access-sandbox-fake"))
+	itemA := &model.PlaidItem{UserID: userA, PlaidItemID: "iso-item-A", AccessTokenEnc: enc, Status: "active"}
+	if err := g.Create(itemA).Error; err != nil {
+		t.Fatalf("seed item: %v", err)
+	}
+	t.Cleanup(func() {
+		g.Unscoped().Where("user_id IN ?", []int64{userA, userB}).Delete(&model.PlaidSyncError{})
+		g.Unscoped().Delete(&model.PlaidItem{}, itemA.ID)
+	})
+
+	rowA := &model.PlaidSyncError{
+		UserID:       userA,
+		PlaidItemID:  itemA.ID,
+		RawPayload:   json.RawMessage(`{}`),
+		ErrorCode:    model.PlaidSyncErrorCodeMapping,
+		ErrorMessage: "test",
+	}
+	if err := g.Create(rowA).Error; err != nil {
+		t.Fatalf("seed dlq: %v", err)
+	}
+
+	syncErrRepo := repository.NewPlaidSyncErrorRepository(g)
+
+	// User B cannot Get user A's row.
+	if _, err := syncErrRepo.Get(context.Background(), userB, rowA.ID); err == nil {
+		t.Error("user B got user A's DLQ row — tenant leak")
+	}
+	// User B cannot Resolve user A's row.
+	if err := syncErrRepo.MarkResolved(context.Background(), userB, rowA.ID, model.ResolutionDismissed, persistedNow()); err == nil {
+		t.Error("user B resolved user A's DLQ row — tenant leak")
+	}
+	// And user A's row stays unresolved.
+	gotA, _ := syncErrRepo.Get(context.Background(), userA, rowA.ID)
+	if gotA.ResolvedAt != nil {
+		t.Error("user A's row was unexpectedly resolved")
+	}
+}
+
+func persistedNow() time.Time { return time.Now().UTC() }

--- a/backend/migrations/000007_plaid_sync_errors.down.sql
+++ b/backend/migrations/000007_plaid_sync_errors.down.sql
@@ -1,0 +1,16 @@
+BEGIN;
+
+-- Restore the narrower status enum first; any rows currently sitting at
+-- 'ok_with_errors' get coerced to 'ok' so the new CHECK can apply.
+UPDATE plaid_items SET last_sync_status = 'ok' WHERE last_sync_status = 'ok_with_errors';
+
+ALTER TABLE plaid_items DROP CONSTRAINT IF EXISTS plaid_items_last_sync_status_check;
+ALTER TABLE plaid_items
+    ADD CONSTRAINT plaid_items_last_sync_status_check
+    CHECK (last_sync_status IN ('never','syncing','ok','error'));
+
+DROP INDEX IF EXISTS ix_plaid_sync_errors_user;
+DROP INDEX IF EXISTS ix_plaid_sync_errors_item_unresolved;
+DROP TABLE IF EXISTS plaid_sync_errors;
+
+COMMIT;

--- a/backend/migrations/000007_plaid_sync_errors.up.sql
+++ b/backend/migrations/000007_plaid_sync_errors.up.sql
@@ -1,0 +1,45 @@
+BEGIN;
+
+-- #80: per-row DLQ for Plaid /transactions/sync.
+--
+-- Before this migration, any single bad row in a sync batch rolled back the
+-- whole transaction and left the cursor stuck — a 10k-row sync with one bad
+-- row lost 9,999 good rows and would replay the failure forever.
+--
+-- The DLQ row preserves the raw Plaid payload so the owner can retry after
+-- a fix (or a schema/precision change) without re-syncing the whole item.
+-- Hard-delete only — audit/DLQ table, no soft delete. See docs/ADR/0011.
+CREATE TABLE plaid_sync_errors (
+    id                   BIGSERIAL PRIMARY KEY,
+    user_id              BIGINT NOT NULL REFERENCES users(id),
+    plaid_item_id        BIGINT NOT NULL REFERENCES plaid_items(id),
+    plaid_transaction_id TEXT,
+    raw_payload          JSONB NOT NULL,
+    error_code           TEXT NOT NULL,
+    error_message        TEXT NOT NULL,
+    occurred_at          TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    resolved_at          TIMESTAMPTZ,
+    resolution           TEXT
+        CHECK (resolution IS NULL OR resolution IN ('retried_ok','dismissed')),
+    CHECK ((resolved_at IS NULL) = (resolution IS NULL))
+);
+
+-- Owners want a fast "unresolved errors for this item" query (badge count,
+-- modal list). Partial index keeps it tight even as the DLQ grows.
+CREATE INDEX ix_plaid_sync_errors_item_unresolved
+    ON plaid_sync_errors (plaid_item_id)
+    WHERE resolved_at IS NULL;
+
+-- For per-user surfaces (e.g. global DLQ view) and for the multi-tenant
+-- read filter — every read MUST scope on user_id.
+CREATE INDEX ix_plaid_sync_errors_user
+    ON plaid_sync_errors (user_id);
+
+-- Extend the sync status enum so the UI can render partial-success
+-- distinct from a clean run.
+ALTER TABLE plaid_items DROP CONSTRAINT IF EXISTS plaid_items_last_sync_status_check;
+ALTER TABLE plaid_items
+    ADD CONSTRAINT plaid_items_last_sync_status_check
+    CHECK (last_sync_status IN ('never','syncing','ok','ok_with_errors','error'));
+
+COMMIT;

--- a/docs/ADR/0011-plaid-sync-partial-success.md
+++ b/docs/ADR/0011-plaid-sync-partial-success.md
@@ -1,0 +1,45 @@
+# ADR 0011: Plaid `/transactions/sync` — Per-Row DLQ, Cursor Advances on Partial Failure
+
+## Status
+Accepted
+
+## Context
+Until this ADR, `service/plaid.SyncTransactions` was all-or-nothing per item: a single bad row (decimal overflow, malformed date, validation error, transient DB error on one INSERT) rolled back the entire transaction and left the Plaid sync cursor stuck on the prior page. The next sync re-fetched the same delta, hit the same bad row, and rolled back again. For a 10k-row initial pull with one poison row, 9,999 good rows were lost on every attempt and the user had no path forward short of manual SQL.
+
+ADR-0008-style "fail closed" is appropriate for cross-user reads (privacy is the higher-order property). For ingestion, it's the wrong tradeoff: data freshness matters and the cost of dropping one well-formed row to preserve "perfect atomicity" is high.
+
+Plaid's own model treats `/transactions/sync` as a delta stream — the cursor is the only thing that links one sync to the next. Once a row appears in an `added` page and we acknowledge the cursor past that page, Plaid will not re-send it. That makes "advance the cursor but lose the row" especially costly: the row is gone forever unless we keep it ourselves.
+
+## Decision
+1. **Per-row savepoints.** Each `added` / `modified` row is processed inside its own Postgres `SAVEPOINT`. On row-level error we `ROLLBACK TO SAVEPOINT` and continue; on success the savepoint is released implicitly when the outer transaction commits.
+2. **`plaid_sync_errors` DLQ table.** Failed rows are persisted in the same outer transaction with the full Plaid payload (`raw_payload JSONB`), an error code, and an error message. Hard-delete only; "dismissed" is recorded via `resolution`, not deletion.
+3. **Cursor always advances.** Once Phase 1 has drained all pages and Phase 2 has processed every row (success or DLQ), `plaid_items.cursor` is updated to Plaid's `next_cursor`. The DLQ row preserves enough information to replay the original payload, so the cost of moving the cursor past a failed row is bounded.
+4. **`last_sync_status='ok_with_errors'`** when any rows DLQ'd. Distinguishes partial success from a clean run in the UI without burying the signal in `last_sync_error` text.
+5. **Owner-driven retry/dismiss.** `POST /plaid/errors/:id/retry` re-runs the row through the same mapping path inside a new transaction. `POST /plaid/errors/:id/dismiss` marks resolved without replay. No automatic retry — the failure modes (mapping bugs, decimal overflow, missing accounts) are all fixed-by-human, not fixed-by-waiting.
+6. **`removed` rows do NOT go to DLQ.** They carry no payload and soft-delete is idempotent — a real DB error on a `removed` row indicates something systemic and should abort the sync.
+
+## Rationale
+- **Savepoints over per-row transactions.** A single outer transaction lets the cursor advance atomically with the row writes and the DLQ rows. Per-row transactions would commit good rows but require careful ordering to avoid a window where the cursor advances without the DLQ row landing.
+- **Raw payload in JSONB, not parsed columns.** The whole point of the DLQ is to preserve enough state to replay later. Parsing into typed columns would lose any field we didn't think to model, and the failure modes most worth replaying (decimal overflow, new Plaid fields we haven't mapped yet) are exactly the ones where a parsed schema would lose information.
+- **Cursor advances, even with N failures.** The alternative — block the cursor until the DLQ is empty — sounds safer but creates an operationally awful state. The owner can't take action without manually inspecting the DLQ. Worse, it means a single permanently-broken row blocks every future sync forever. Plaid's own model expects the consumer to advance the cursor; the DLQ is our local accommodation for partial success.
+- **Status enum extended, not overloaded.** Existing `ok`/`error` callers continue to work; `ok_with_errors` is additive. The UI keys badge visibility off the `unresolved_sync_errors` count, not the status string, so the status is purely informational.
+- **No automatic retry.** Real failure modes (decimal overflow on crypto amounts, malformed date parsing) need code or data fixes, not retry. Auto-retry would mask the signal.
+
+## Consequences
+- `service/plaid.SyncTransactions` now succeeds even when individual rows fail. Callers see a non-zero `result.Failed` and can prompt the user to inspect the DLQ.
+- `last_sync_status` now has five values: `never`, `syncing`, `ok`, `ok_with_errors`, `error`. The check constraint enforces the enum.
+- Operators must inspect the DLQ to act on broken rows. Settings → Linked Institutions surfaces a `⚠️ N` badge and a modal listing each unresolved row with the raw payload, error code, and Retry / Dismiss controls.
+- `plaid_sync_errors` is a hard-delete table — no `deleted_at`. Right-to-forget on user account deletion must include this table.
+- Multi-tenant: every read and resolve goes through `user_id`; the indexed predicate `WHERE resolved_at IS NULL` keeps the badge-count query cheap as the DLQ grows.
+
+## Alternatives Considered
+- **Roll back the whole sync on any row failure (status quo).** Rejected — see Context. The operational cost is too high.
+- **Per-row transactions instead of savepoints.** Workable, but loses atomicity with the cursor advance. Either the cursor commits separately (window where good rows are written but cursor stale on crash) or each row + cursor is its own tx (10k round-trips for a historical pull).
+- **Skip DLQ — log row failures to stderr only.** Rejected. Logs are not actionable in self-hosted deployments. The owner needs a UI surface with the raw payload to file a bug or apply a workaround.
+- **Auto-retry with exponential backoff.** Rejected for v1. None of the actual failure modes self-resolve; the DLQ row would just churn. Reconsidered if a class of transient failure emerges.
+- **DLQ entries deduped on `plaid_transaction_id`.** Rejected for v1 — if the same row fails twice across syncs (e.g. the user retries after a partial fix), having two rows is acceptable signal. Revisit if DLQ volume turns out to be noisy.
+
+## Follow-up
+- Optional global "all DLQ rows across all items" view if any operator hits the noisy case.
+- Per-error-code metric in any future operator dashboard.
+- If a class of automatically-retryable error emerges (e.g. a transient PG connection blip), add a `next_retry_at` column and a small worker.

--- a/frontend/src/api/plaid.ts
+++ b/frontend/src/api/plaid.ts
@@ -3,6 +3,7 @@ import type {
   ExchangeResponse,
   LinkTokenResponse,
   PlaidItem,
+  PlaidSyncError,
   SyncAccountsResponse,
   SyncTransactionsResponse,
 } from '../types/plaid'
@@ -45,4 +46,26 @@ export async function listItems(): Promise<{ items: PlaidItem[]; total: number }
 
 export async function disconnectItem(itemID: string): Promise<void> {
   await apiClient.delete(`/plaid/items/${encodeURIComponent(itemID)}`)
+}
+
+// listSyncErrors returns DLQ rows for one Plaid item. Default
+// `status=unresolved` matches the badge-driven flow; pass 'all' for an
+// audit view.
+export async function listSyncErrors(
+  itemID: string,
+  status: 'unresolved' | 'all' = 'unresolved',
+): Promise<{ errors: PlaidSyncError[]; total: number }> {
+  const res = await apiClient.get<ApiList<PlaidSyncError>>(
+    `/plaid/items/${encodeURIComponent(itemID)}/errors`,
+    { params: { status } },
+  )
+  return { errors: res.data.data, total: res.data.total }
+}
+
+export async function retrySyncError(errorID: number): Promise<void> {
+  await apiClient.post(`/plaid/errors/${errorID}/retry`)
+}
+
+export async function dismissSyncError(errorID: number): Promise<void> {
+  await apiClient.post(`/plaid/errors/${errorID}/dismiss`)
 }

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -1,8 +1,14 @@
 import { useCallback, useEffect, useState } from 'react'
 import { Link } from 'react-router-dom'
-import { Landmark, Plug, Trash2 } from 'lucide-react'
-import { disconnectItem, listItems } from '../api/plaid'
-import type { PlaidItem } from '../types/plaid'
+import { AlertTriangle, Landmark, Plug, Trash2, X } from 'lucide-react'
+import {
+  disconnectItem,
+  dismissSyncError,
+  listItems,
+  listSyncErrors,
+  retrySyncError,
+} from '../api/plaid'
+import type { PlaidItem, PlaidSyncError } from '../types/plaid'
 
 export function SettingsPage() {
   return (
@@ -21,6 +27,7 @@ function LinkedInstitutionsSection() {
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [disconnecting, setDisconnecting] = useState<string | null>(null)
+  const [errorModalItem, setErrorModalItem] = useState<PlaidItem | null>(null)
 
   const refresh = useCallback(() => {
     return listItems()
@@ -84,34 +91,201 @@ function LinkedInstitutionsSection() {
             No linked institutions yet. Use Connect Bank to add one.
           </div>
         )}
-        {items.map((it) => (
-          <div key={it.id} className="flex items-center gap-4 px-5 py-3">
-            <div className="rounded-md bg-gray-50 p-2 text-gray-500">
-              <Landmark size={18} />
-            </div>
-            <div className="flex-1 min-w-0">
-              <div className="truncate font-medium text-gray-900">
-                {it.institution_name ?? it.plaid_item_id}
+        {items.map((it) => {
+          const errCount = it.unresolved_sync_errors ?? 0
+          return (
+            <div key={it.id} className="flex items-center gap-4 px-5 py-3">
+              <div className="rounded-md bg-gray-50 p-2 text-gray-500">
+                <Landmark size={18} />
               </div>
-              <div className="mt-0.5 text-xs text-gray-500">
-                {statusSummary(it)}
-                {it.last_sync_error ? ` · ${it.last_sync_error}` : ''}
+              <div className="flex-1 min-w-0">
+                <div className="flex items-center gap-2">
+                  <div className="truncate font-medium text-gray-900">
+                    {it.institution_name ?? it.plaid_item_id}
+                  </div>
+                  {errCount > 0 && (
+                    <button
+                      type="button"
+                      onClick={() => setErrorModalItem(it)}
+                      className="inline-flex items-center gap-1 rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-800 hover:bg-amber-200"
+                      aria-label={`Review ${errCount} sync errors for ${it.institution_name ?? it.plaid_item_id}`}
+                    >
+                      <AlertTriangle size={12} />
+                      {errCount}
+                    </button>
+                  )}
+                </div>
+                <div className="mt-0.5 text-xs text-gray-500">
+                  {statusSummary(it)}
+                  {it.last_sync_error ? ` · ${it.last_sync_error}` : ''}
+                </div>
               </div>
+              <button
+                type="button"
+                onClick={() => onDisconnect(it)}
+                disabled={disconnecting === it.plaid_item_id}
+                className="inline-flex items-center gap-1 rounded-md border border-gray-300 px-2.5 py-1 text-xs font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50"
+                aria-label={`Disconnect ${it.institution_name ?? it.plaid_item_id}`}
+              >
+                <Trash2 size={14} />
+                {disconnecting === it.plaid_item_id ? 'Disconnecting…' : 'Disconnect'}
+              </button>
             </div>
-            <button
-              type="button"
-              onClick={() => onDisconnect(it)}
-              disabled={disconnecting === it.plaid_item_id}
-              className="inline-flex items-center gap-1 rounded-md border border-gray-300 px-2.5 py-1 text-xs font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50"
-              aria-label={`Disconnect ${it.institution_name ?? it.plaid_item_id}`}
-            >
-              <Trash2 size={14} />
-              {disconnecting === it.plaid_item_id ? 'Disconnecting…' : 'Disconnect'}
-            </button>
-          </div>
-        ))}
+          )
+        })}
       </div>
+      {errorModalItem && (
+        <SyncErrorsModal
+          item={errorModalItem}
+          onClose={() => {
+            setErrorModalItem(null)
+            // Refresh the badge count after potential resolutions.
+            void refresh()
+          }}
+        />
+      )}
     </section>
+  )
+}
+
+function SyncErrorsModal({ item, onClose }: { item: PlaidItem; onClose: () => void }) {
+  const [errors, setErrors] = useState<PlaidSyncError[]>([])
+  const [loading, setLoading] = useState(true)
+  const [busyID, setBusyID] = useState<number | null>(null)
+  const [err, setErr] = useState<string | null>(null)
+
+  const load = useCallback(() => {
+    return listSyncErrors(item.plaid_item_id, 'unresolved')
+      .then((r) => {
+        setErrors(r.errors)
+        setErr(null)
+      })
+      .catch((e: unknown) => setErr(errMsg(e)))
+      .finally(() => setLoading(false))
+  }, [item.plaid_item_id])
+
+  useEffect(() => {
+    // setState only fires inside then/catch/finally — effect body is sync-pure.
+    void load()
+  }, [load])
+
+  const reload = useCallback(async () => {
+    setLoading(true)
+    await load()
+  }, [load])
+
+  const onRetry = async (row: PlaidSyncError) => {
+    setBusyID(row.id)
+    try {
+      await retrySyncError(row.id)
+      await reload()
+    } catch (e) {
+      setErr(errMsg(e))
+    } finally {
+      setBusyID(null)
+    }
+  }
+
+  const onDismiss = async (row: PlaidSyncError) => {
+    setBusyID(row.id)
+    try {
+      await dismissSyncError(row.id)
+      await reload()
+    } catch (e) {
+      setErr(errMsg(e))
+    } finally {
+      setBusyID(null)
+    }
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Sync errors"
+      onClick={onClose}
+    >
+      <div
+        className="max-h-[90vh] w-full max-w-3xl overflow-hidden rounded-lg bg-white shadow-xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between border-b border-gray-200 px-5 py-3">
+          <div className="flex items-center gap-2">
+            <AlertTriangle size={16} className="text-amber-600" />
+            <h3 className="text-base font-medium text-gray-900">
+              Sync errors — {item.institution_name ?? item.plaid_item_id}
+            </h3>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close"
+            className="rounded p-1 text-gray-400 hover:bg-gray-100 hover:text-gray-600"
+          >
+            <X size={16} />
+          </button>
+        </div>
+        {err && (
+          <div className="mx-5 mt-3 rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
+            {err}
+          </div>
+        )}
+        <div className="max-h-[70vh] overflow-y-auto">
+          {loading && (
+            <div className="px-5 py-6 text-center text-sm text-gray-400">Loading…</div>
+          )}
+          {!loading && errors.length === 0 && (
+            <div className="px-5 py-6 text-center text-sm text-gray-400">
+              All errors resolved.
+            </div>
+          )}
+          {errors.map((row) => (
+            <div key={row.id} className="border-b border-gray-100 px-5 py-4 last:border-b-0">
+              <div className="flex items-start justify-between gap-3">
+                <div className="min-w-0">
+                  <div className="flex items-center gap-2">
+                    <span className="rounded bg-gray-100 px-1.5 py-0.5 font-mono text-xs text-gray-700">
+                      {row.error_code}
+                    </span>
+                    <span className="text-xs text-gray-500">
+                      {new Date(row.occurred_at).toLocaleString()}
+                    </span>
+                  </div>
+                  <p className="mt-1 text-sm text-gray-900">{row.error_message}</p>
+                  {row.plaid_transaction_id && (
+                    <p className="mt-0.5 font-mono text-xs text-gray-500">
+                      txn_id: {row.plaid_transaction_id}
+                    </p>
+                  )}
+                </div>
+                <div className="flex shrink-0 gap-2">
+                  <button
+                    type="button"
+                    onClick={() => onRetry(row)}
+                    disabled={busyID === row.id}
+                    className="rounded-md border border-gray-300 bg-white px-2.5 py-1 text-xs font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50"
+                  >
+                    {busyID === row.id ? '…' : 'Retry'}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => onDismiss(row)}
+                    disabled={busyID === row.id}
+                    className="rounded-md border border-gray-300 bg-white px-2.5 py-1 text-xs font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50"
+                  >
+                    Dismiss
+                  </button>
+                </div>
+              </div>
+              <pre className="mt-2 max-h-48 overflow-auto rounded bg-gray-50 p-2 font-mono text-xs text-gray-800">
+                {JSON.stringify(row.raw_payload, null, 2)}
+              </pre>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
   )
 }
 
@@ -120,6 +294,10 @@ function statusSummary(it: PlaidItem): string {
   switch (status) {
     case 'ok':
       return it.last_synced_at ? `Synced ${formatRelative(it.last_synced_at)}` : 'Synced'
+    case 'ok_with_errors':
+      return it.last_synced_at
+        ? `Synced ${formatRelative(it.last_synced_at)} (with errors)`
+        : 'Synced (with errors)'
     case 'syncing':
       return 'Syncing…'
     case 'error':

--- a/frontend/src/types/plaid.ts
+++ b/frontend/src/types/plaid.ts
@@ -1,6 +1,8 @@
 // PlaidItem mirrors backend model.PlaidItem (JSON tags). The encrypted
 // access_token is intentionally absent — backend serializes `json:"-"` on it.
 // `null` for optional pointer fields preserves explicit-null semantics.
+// `unresolved_sync_errors` is populated only by GET /plaid/items (the
+// list endpoint joins it in to avoid an N+1) — see ADR-0011.
 export type PlaidItem = {
   id: number
   user_id: number
@@ -10,9 +12,27 @@ export type PlaidItem = {
   status: string
   last_synced_at?: string | null
   last_sync_error?: string | null
-  last_sync_status: 'never' | 'syncing' | 'ok' | 'error'
+  last_sync_status: 'never' | 'syncing' | 'ok' | 'ok_with_errors' | 'error'
+  unresolved_sync_errors?: number
   created_at: string
   updated_at: string
+}
+
+// PlaidSyncError mirrors backend model.PlaidSyncError. raw_payload is the
+// original Plaid transaction object — `unknown` rather than a typed shape
+// because the whole point of the DLQ is to preserve whatever Plaid sent,
+// including fields we don't know yet.
+export type PlaidSyncError = {
+  id: number
+  user_id: number
+  plaid_item_id: number
+  plaid_transaction_id?: string | null
+  raw_payload: unknown
+  error_code: string
+  error_message: string
+  occurred_at: string
+  resolved_at?: string | null
+  resolution?: 'retried_ok' | 'dismissed' | null
 }
 
 // LinkTokenResponse — POST /plaid/link/token.
@@ -41,4 +61,5 @@ export type SyncTransactionsResponse = {
   inserted: number
   modified: number
   removed: number
+  failed: number
 }


### PR DESCRIPTION
## Summary
- A single bad transaction in Plaid `/transactions/sync` used to roll back the whole batch and leave the cursor stuck — a 10k-row sync with one poison row lost 9,999 good rows on every retry. This change introduces per-row Postgres `SAVEPOINT`s, a `plaid_sync_errors` DLQ table preserving the raw Plaid payload, and a UI for the owner to Retry or Dismiss each failure.
- Cursor now advances atomically with the DLQ writes — see ADR-0011 for the rationale.
- `last_sync_status` extended with `ok_with_errors` so the Settings UI can render partial success distinct from a clean run.

## What's in the change
- **Migration 000007** — `plaid_sync_errors` (BIGSERIAL, user_id, plaid_item_id, raw_payload JSONB, error_code, error_message, occurred_at, resolved_at, resolution) + extended `last_sync_status` enum.
- **Backend** — `service/plaid` refactored to two-phase (drain → savepoint-wrapped writes), new `RetrySyncError` / `DismissSyncError` / `ListItemsWithSyncErrors` methods. `GET /plaid/items` now returns `unresolved_sync_errors` per item; new `GET /plaid/items/:id/errors`, `POST /plaid/errors/:id/retry`, `POST /plaid/errors/:id/dismiss`.
- **Frontend** — ⚠️ badge on Linked Institutions, modal listing each error with raw payload and Retry / Dismiss buttons.
- **ADR-0011** — partial-success sync semantics, why the cursor advances despite individual row failures.
- **Tests** — mixed batch (good + bad rows), all-poison batch, retry-after-fix flow, multi-tenant isolation on the new repo.

## Test plan
- [ ] `cd backend && make verify` (full backend test suite + frontend lint + build)
- [ ] `cd backend && go run ./cmd/migrate down` then `up` to confirm migration round-trips
- [ ] Connect a Plaid sandbox, sync a known account → confirm `last_sync_status='ok'` and no badge
- [ ] Manually corrupt a row (e.g. via a hand-edited \`plaid_sync_errors\` insert simulating a malformed payload) and confirm the badge appears, modal opens, Dismiss flips the row to resolved, Retry replays cleanly

Closes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)