### PR TITLE
feat(categorization): user-scoped rule CRUD foundation (#89)

### DIFF
--- a/backend/internal/handler/categorization_rule_handler.go
+++ b/backend/internal/handler/categorization_rule_handler.go
@@ -1,0 +1,132 @@
+package handler
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/gregwym/offbook/backend/internal/service"
+	"github.com/gregwym/offbook/backend/internal/service/auth"
+)
+
+type CategorizationRuleHandler struct {
+	svc *service.CategorizationRuleService
+}
+
+func NewCategorizationRuleHandler(s *service.CategorizationRuleService) *CategorizationRuleHandler {
+	return &CategorizationRuleHandler{svc: s}
+}
+
+func (h *CategorizationRuleHandler) Register(g *gin.RouterGroup) {
+	g.POST("/categorization-rules", h.Create)
+	g.GET("/categorization-rules", h.List)
+	g.GET("/categorization-rules/:id", h.Get)
+	g.PATCH("/categorization-rules/:id", h.Update)
+	g.DELETE("/categorization-rules/:id", h.Delete)
+}
+
+type createRuleRequest struct {
+	Pattern    string `json:"pattern"`
+	MatchType  string `json:"match_type"`
+	CategoryID int64  `json:"category_id"`
+	Priority   int    `json:"priority"`
+	IsActive   *bool  `json:"is_active"`
+}
+
+func (h *CategorizationRuleHandler) Create(c *gin.Context) {
+	var req createRuleRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error(), "code": "INVALID_REQUEST"})
+		return
+	}
+	r, err := h.svc.Create(c.Request.Context(), auth.MustUserID(c.Request.Context()), service.CreateRuleInput{
+		Pattern:    req.Pattern,
+		MatchType:  req.MatchType,
+		CategoryID: req.CategoryID,
+		Priority:   req.Priority,
+		IsActive:   req.IsActive,
+	})
+	if err != nil {
+		h.writeServiceError(c, err)
+		return
+	}
+	c.JSON(http.StatusCreated, gin.H{"data": r})
+}
+
+func (h *CategorizationRuleHandler) Get(c *gin.Context) {
+	id, ok := parseID(c)
+	if !ok {
+		return
+	}
+	r, err := h.svc.Get(c.Request.Context(), auth.MustUserID(c.Request.Context()), id)
+	if err != nil {
+		h.writeServiceError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"data": r})
+}
+
+func (h *CategorizationRuleHandler) List(c *gin.Context) {
+	rules, err := h.svc.List(c.Request.Context(), auth.MustUserID(c.Request.Context()))
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error(), "code": "INTERNAL"})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"data": rules, "total": int64(len(rules))})
+}
+
+type updateRuleRequest struct {
+	Pattern    *string `json:"pattern"`
+	MatchType  *string `json:"match_type"`
+	CategoryID *int64  `json:"category_id"`
+	Priority   *int    `json:"priority"`
+	IsActive   *bool   `json:"is_active"`
+}
+
+func (h *CategorizationRuleHandler) Update(c *gin.Context) {
+	id, ok := parseID(c)
+	if !ok {
+		return
+	}
+	var req updateRuleRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error(), "code": "INVALID_REQUEST"})
+		return
+	}
+	r, err := h.svc.Update(c.Request.Context(), auth.MustUserID(c.Request.Context()), id, service.UpdateRuleInput(req))
+	if err != nil {
+		h.writeServiceError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"data": r})
+}
+
+func (h *CategorizationRuleHandler) Delete(c *gin.Context) {
+	id, ok := parseID(c)
+	if !ok {
+		return
+	}
+	if err := h.svc.SoftDelete(c.Request.Context(), auth.MustUserID(c.Request.Context()), id); err != nil {
+		h.writeServiceError(c, err)
+		return
+	}
+	c.Status(http.StatusNoContent)
+}
+
+func (h *CategorizationRuleHandler) writeServiceError(c *gin.Context, err error) {
+	switch {
+	case errors.Is(err, service.ErrRuleNotFound):
+		c.JSON(http.StatusNotFound, gin.H{"error": err.Error(), "code": "RULE_NOT_FOUND"})
+	case errors.Is(err, service.ErrInvalidRegex):
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error(), "code": "INVALID_REGEX"})
+	case errors.Is(err, service.ErrUnknownCategory):
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error(), "code": "UNKNOWN_CATEGORY"})
+	case errors.Is(err, service.ErrEmptyPattern),
+		errors.Is(err, service.ErrInvalidMatchType),
+		errors.Is(err, service.ErrInvalidPriority):
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error(), "code": "INVALID_RULE"})
+	default:
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error(), "code": "INTERNAL"})
+	}
+}

--- a/backend/internal/model/categorization_rule.go
+++ b/backend/internal/model/categorization_rule.go
@@ -8,6 +8,7 @@ import (
 
 type CategorizationRule struct {
 	ID         int64          `gorm:"primaryKey" json:"id"`
+	UserID     int64          `gorm:"not null;index" json:"user_id"`
 	Pattern    string         `gorm:"not null" json:"pattern"`
 	CategoryID int64          `gorm:"not null" json:"category_id"`
 	MatchType  string         `gorm:"not null" json:"match_type"`

--- a/backend/internal/repository/categorization_rule_repo.go
+++ b/backend/internal/repository/categorization_rule_repo.go
@@ -1,0 +1,83 @@
+package repository
+
+import (
+	"context"
+	"errors"
+
+	"gorm.io/gorm"
+
+	"github.com/gregwym/offbook/backend/internal/model"
+)
+
+// CategorizationRuleRepository is the data-access contract for
+// categorization_rules. Every read/write path is scoped by user_id —
+// rules are user-private and never shared across tenants.
+type CategorizationRuleRepository interface {
+	Create(ctx context.Context, r *model.CategorizationRule) error
+	GetByID(ctx context.Context, userID, id int64) (*model.CategorizationRule, error)
+	List(ctx context.Context, userID int64) ([]model.CategorizationRule, error)
+	Update(ctx context.Context, r *model.CategorizationRule) error
+	SoftDelete(ctx context.Context, userID, id int64) error
+}
+
+type categorizationRuleRepo struct {
+	db *gorm.DB
+}
+
+func NewCategorizationRuleRepository(db *gorm.DB) CategorizationRuleRepository {
+	return &categorizationRuleRepo{db: db}
+}
+
+func (r *categorizationRuleRepo) Create(ctx context.Context, rule *model.CategorizationRule) error {
+	return r.db.WithContext(ctx).Create(rule).Error
+}
+
+func (r *categorizationRuleRepo) GetByID(ctx context.Context, userID, id int64) (*model.CategorizationRule, error) {
+	var rule model.CategorizationRule
+	if err := r.db.WithContext(ctx).
+		Where("user_id = ?", userID).
+		First(&rule, id).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, ErrNotFound
+		}
+		return nil, err
+	}
+	return &rule, nil
+}
+
+func (r *categorizationRuleRepo) List(ctx context.Context, userID int64) ([]model.CategorizationRule, error) {
+	var out []model.CategorizationRule
+	if err := r.db.WithContext(ctx).
+		Where("user_id = ?", userID).
+		Order("priority DESC, id ASC").
+		Find(&out).Error; err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (r *categorizationRuleRepo) Update(ctx context.Context, rule *model.CategorizationRule) error {
+	res := r.db.WithContext(ctx).
+		Where("user_id = ?", rule.UserID).
+		Save(rule)
+	if res.Error != nil {
+		return res.Error
+	}
+	if res.RowsAffected == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+func (r *categorizationRuleRepo) SoftDelete(ctx context.Context, userID, id int64) error {
+	res := r.db.WithContext(ctx).
+		Where("user_id = ?", userID).
+		Delete(&model.CategorizationRule{}, id)
+	if res.Error != nil {
+		return res.Error
+	}
+	if res.RowsAffected == 0 {
+		return ErrNotFound
+	}
+	return nil
+}

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -50,6 +50,10 @@ func New(cfg config.Config, gormDB *gorm.DB) *gin.Engine {
 	categorySvc := service.NewCategoryService(categoryRepo)
 	categoryHandler := handler.NewCategoryHandler(categorySvc)
 
+	ruleRepo := repository.NewCategorizationRuleRepository(gormDB)
+	ruleSvc := service.NewCategorizationRuleService(ruleRepo, categoryRepo)
+	ruleHandler := handler.NewCategorizationRuleHandler(ruleSvc)
+
 	dashboardRepo := repository.NewDashboardRepository(gormDB)
 	dashboardSvc := service.NewDashboardService(dashboardRepo)
 	dashboardHandler := handler.NewDashboardHandler(dashboardSvc)
@@ -99,6 +103,7 @@ func New(cfg config.Config, gormDB *gorm.DB) *gin.Engine {
 		piiHandler.RegisterAccountRoutes(secured)
 		transactionHandler.Register(secured)
 		categoryHandler.Register(secured)
+		ruleHandler.Register(secured)
 		dashboardHandler.Register(secured)
 		householdHandler.Register(secured)
 		aggregatorHandler.Register(secured)

--- a/backend/internal/service/categorization_rule_service.go
+++ b/backend/internal/service/categorization_rule_service.go
@@ -1,0 +1,164 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/gregwym/offbook/backend/internal/model"
+	"github.com/gregwym/offbook/backend/internal/repository"
+)
+
+var (
+	ErrRuleNotFound     = errors.New("categorization rule not found")
+	ErrEmptyPattern     = errors.New("pattern must not be empty")
+	ErrInvalidMatchType = errors.New("match_type must be one of: contains, regex, exact")
+	ErrInvalidRegex     = errors.New("pattern is not a valid regular expression")
+	ErrInvalidPriority  = errors.New("priority must be >= 0")
+	ErrUnknownCategory  = errors.New("category does not exist")
+)
+
+var validMatchTypes = map[string]struct{}{
+	"contains": {},
+	"regex":    {},
+	"exact":    {},
+}
+
+type CreateRuleInput struct {
+	Pattern    string
+	MatchType  string
+	CategoryID int64
+	Priority   int
+	IsActive   *bool
+}
+
+// UpdateRuleInput is a sparse patch. Nil pointer = leave alone.
+type UpdateRuleInput struct {
+	Pattern    *string
+	MatchType  *string
+	CategoryID *int64
+	Priority   *int
+	IsActive   *bool
+}
+
+// CategorizationRuleService owns rule validation and CRUD. It depends on
+// CategoryRepository only to verify CategoryID points at a real row — rules
+// have no cross-user visibility, so no further dependencies are needed.
+type CategorizationRuleService struct {
+	repo    repository.CategorizationRuleRepository
+	catRepo repository.CategoryRepository
+}
+
+func NewCategorizationRuleService(
+	repo repository.CategorizationRuleRepository,
+	catRepo repository.CategoryRepository,
+) *CategorizationRuleService {
+	return &CategorizationRuleService{repo: repo, catRepo: catRepo}
+}
+
+func (s *CategorizationRuleService) Create(ctx context.Context, userID int64, in CreateRuleInput) (*model.CategorizationRule, error) {
+	r := &model.CategorizationRule{
+		UserID:     userID,
+		Pattern:    strings.TrimSpace(in.Pattern),
+		MatchType:  strings.TrimSpace(in.MatchType),
+		CategoryID: in.CategoryID,
+		Priority:   in.Priority,
+		IsActive:   true,
+	}
+	if in.IsActive != nil {
+		r.IsActive = *in.IsActive
+	}
+	if err := s.validate(ctx, r); err != nil {
+		return nil, err
+	}
+	if err := s.repo.Create(ctx, r); err != nil {
+		return nil, fmt.Errorf("create rule: %w", err)
+	}
+	return r, nil
+}
+
+func (s *CategorizationRuleService) Get(ctx context.Context, userID, id int64) (*model.CategorizationRule, error) {
+	r, err := s.repo.GetByID(ctx, userID, id)
+	if err != nil {
+		if errors.Is(err, repository.ErrNotFound) {
+			return nil, ErrRuleNotFound
+		}
+		return nil, err
+	}
+	return r, nil
+}
+
+func (s *CategorizationRuleService) List(ctx context.Context, userID int64) ([]model.CategorizationRule, error) {
+	return s.repo.List(ctx, userID)
+}
+
+func (s *CategorizationRuleService) Update(ctx context.Context, userID, id int64, in UpdateRuleInput) (*model.CategorizationRule, error) {
+	r, err := s.repo.GetByID(ctx, userID, id)
+	if err != nil {
+		if errors.Is(err, repository.ErrNotFound) {
+			return nil, ErrRuleNotFound
+		}
+		return nil, err
+	}
+	if in.Pattern != nil {
+		r.Pattern = strings.TrimSpace(*in.Pattern)
+	}
+	if in.MatchType != nil {
+		r.MatchType = strings.TrimSpace(*in.MatchType)
+	}
+	if in.CategoryID != nil {
+		r.CategoryID = *in.CategoryID
+	}
+	if in.Priority != nil {
+		r.Priority = *in.Priority
+	}
+	if in.IsActive != nil {
+		r.IsActive = *in.IsActive
+	}
+	if err := s.validate(ctx, r); err != nil {
+		return nil, err
+	}
+	if err := s.repo.Update(ctx, r); err != nil {
+		if errors.Is(err, repository.ErrNotFound) {
+			return nil, ErrRuleNotFound
+		}
+		return nil, fmt.Errorf("update rule: %w", err)
+	}
+	return r, nil
+}
+
+func (s *CategorizationRuleService) SoftDelete(ctx context.Context, userID, id int64) error {
+	if err := s.repo.SoftDelete(ctx, userID, id); err != nil {
+		if errors.Is(err, repository.ErrNotFound) {
+			return ErrRuleNotFound
+		}
+		return fmt.Errorf("soft delete rule: %w", err)
+	}
+	return nil
+}
+
+func (s *CategorizationRuleService) validate(ctx context.Context, r *model.CategorizationRule) error {
+	if r.Pattern == "" {
+		return ErrEmptyPattern
+	}
+	if _, ok := validMatchTypes[r.MatchType]; !ok {
+		return ErrInvalidMatchType
+	}
+	if r.MatchType == "regex" {
+		if _, err := regexp.Compile(r.Pattern); err != nil {
+			return ErrInvalidRegex
+		}
+	}
+	if r.Priority < 0 {
+		return ErrInvalidPriority
+	}
+	if _, err := s.catRepo.GetByID(ctx, r.CategoryID); err != nil {
+		if errors.Is(err, repository.ErrNotFound) {
+			return ErrUnknownCategory
+		}
+		return fmt.Errorf("validate category: %w", err)
+	}
+	return nil
+}

--- a/backend/internal/service/categorization_rule_service_test.go
+++ b/backend/internal/service/categorization_rule_service_test.go
@@ -1,0 +1,207 @@
+package service_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"gorm.io/gorm"
+
+	"github.com/gregwym/offbook/backend/internal/model"
+	"github.com/gregwym/offbook/backend/internal/repository"
+	"github.com/gregwym/offbook/backend/internal/service"
+)
+
+func newRuleSvc(t *testing.T) (*service.CategorizationRuleService, int64, *gorm.DB) {
+	t.Helper()
+	g := openTestDB(t)
+	userID := seedTestUser(t, g)
+	return service.NewCategorizationRuleService(
+		repository.NewCategorizationRuleRepository(g),
+		repository.NewCategoryRepository(g),
+	), userID, g
+}
+
+// firstSystemCategory returns the lowest-id system category id, which the
+// seed migration guarantees exists. Tests need a real category to pass
+// validation but don't care which one.
+func firstSystemCategory(t *testing.T, g *gorm.DB) int64 {
+	t.Helper()
+	var c model.Category
+	if err := g.Where("is_system = ?", true).Order("id ASC").First(&c).Error; err != nil {
+		t.Fatalf("load seed category: %v", err)
+	}
+	return c.ID
+}
+
+func TestCategorizationRuleService_Create_Validation(t *testing.T) {
+	svc, userID, g := newRuleSvc(t)
+	ctx := context.Background()
+	catID := firstSystemCategory(t, g)
+
+	base := service.CreateRuleInput{
+		Pattern:    "WHOLEFDS",
+		MatchType:  "contains",
+		CategoryID: catID,
+		Priority:   10,
+	}
+
+	cases := []struct {
+		name    string
+		mutate  func(*service.CreateRuleInput)
+		wantErr error
+	}{
+		{"valid", func(*service.CreateRuleInput) {}, nil},
+		{"empty pattern", func(in *service.CreateRuleInput) { in.Pattern = "  " }, service.ErrEmptyPattern},
+		{"bad match_type", func(in *service.CreateRuleInput) { in.MatchType = "bogus" }, service.ErrInvalidMatchType},
+		{"invalid regex", func(in *service.CreateRuleInput) {
+			in.MatchType = "regex"
+			in.Pattern = "([unclosed"
+		}, service.ErrInvalidRegex},
+		{"valid regex", func(in *service.CreateRuleInput) {
+			in.MatchType = "regex"
+			in.Pattern = `^AMZN\s`
+		}, nil},
+		{"negative priority", func(in *service.CreateRuleInput) { in.Priority = -1 }, service.ErrInvalidPriority},
+		{"unknown category", func(in *service.CreateRuleInput) { in.CategoryID = 9_999_999 }, service.ErrUnknownCategory},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			in := base
+			tc.mutate(&in)
+			r, err := svc.Create(ctx, userID, in)
+			if tc.wantErr != nil {
+				if !errors.Is(err, tc.wantErr) {
+					t.Errorf("Create err = %v, want %v", err, tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected err: %v", err)
+			}
+			if r == nil || r.ID == 0 || r.UserID != userID {
+				t.Fatalf("expected created rule, got %+v", r)
+			}
+			t.Cleanup(func() { _ = svc.SoftDelete(ctx, userID, r.ID) })
+		})
+	}
+}
+
+// TestCategorizationRuleService_List_OrderAndScope verifies ordering and
+// soft-delete exclusion in one pass.
+func TestCategorizationRuleService_List_OrderAndScope(t *testing.T) {
+	svc, userID, g := newRuleSvc(t)
+	ctx := context.Background()
+	catID := firstSystemCategory(t, g)
+
+	mk := func(pattern string, priority int) *model.CategorizationRule {
+		r, err := svc.Create(ctx, userID, service.CreateRuleInput{
+			Pattern: pattern, MatchType: "contains", CategoryID: catID, Priority: priority,
+		})
+		if err != nil {
+			t.Fatalf("create %s: %v", pattern, err)
+		}
+		t.Cleanup(func() { _ = svc.SoftDelete(ctx, userID, r.ID) })
+		return r
+	}
+
+	low := mk("low", 1)
+	high := mk("high", 100)
+	mid := mk("mid", 50)
+
+	rules, err := svc.List(ctx, userID)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(rules) != 3 {
+		t.Fatalf("got %d rules, want 3", len(rules))
+	}
+	if rules[0].ID != high.ID || rules[1].ID != mid.ID || rules[2].ID != low.ID {
+		t.Errorf("unexpected order: %d, %d, %d (want %d, %d, %d)",
+			rules[0].ID, rules[1].ID, rules[2].ID, high.ID, mid.ID, low.ID)
+	}
+
+	// Soft-delete the middle one and verify it disappears.
+	if err := svc.SoftDelete(ctx, userID, mid.ID); err != nil {
+		t.Fatalf("soft delete: %v", err)
+	}
+	rules, err = svc.List(ctx, userID)
+	if err != nil {
+		t.Fatalf("list after delete: %v", err)
+	}
+	if len(rules) != 2 {
+		t.Errorf("after soft-delete: got %d, want 2", len(rules))
+	}
+	for _, r := range rules {
+		if r.ID == mid.ID {
+			t.Errorf("soft-deleted rule still listed: %d", r.ID)
+		}
+	}
+}
+
+// TestCategorizationRuleService_TenantIsolation: user B cannot read or delete
+// user A's rule.
+func TestCategorizationRuleService_TenantIsolation(t *testing.T) {
+	svc, userA, g := newRuleSvc(t)
+	ctx := context.Background()
+	catID := firstSystemCategory(t, g)
+
+	r, err := svc.Create(ctx, userA, service.CreateRuleInput{
+		Pattern: "TENANT-ISO", MatchType: "exact", CategoryID: catID, Priority: 5,
+	})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	t.Cleanup(func() { _ = svc.SoftDelete(ctx, userA, r.ID) })
+
+	userB := seedTestUser(t, g)
+
+	if _, err := svc.Get(ctx, userB, r.ID); !errors.Is(err, service.ErrRuleNotFound) {
+		t.Errorf("cross-tenant Get err = %v, want ErrRuleNotFound", err)
+	}
+	if err := svc.SoftDelete(ctx, userB, r.ID); !errors.Is(err, service.ErrRuleNotFound) {
+		t.Errorf("cross-tenant SoftDelete err = %v, want ErrRuleNotFound", err)
+	}
+	newPattern := "HACKED"
+	if _, err := svc.Update(ctx, userB, r.ID, service.UpdateRuleInput{Pattern: &newPattern}); !errors.Is(err, service.ErrRuleNotFound) {
+		t.Errorf("cross-tenant Update err = %v, want ErrRuleNotFound", err)
+	}
+
+	// List for user B must not include user A's rule.
+	rules, err := svc.List(ctx, userB)
+	if err != nil {
+		t.Fatalf("list B: %v", err)
+	}
+	for _, item := range rules {
+		if item.ID == r.ID {
+			t.Errorf("cross-tenant List leaked rule %d to user %d", item.ID, userB)
+		}
+	}
+}
+
+// TestCategorizationRuleService_Update_RevalidatesRegex makes sure an Update
+// that flips match_type to regex with a bad pattern is rejected, the same
+// way Create rejects it.
+func TestCategorizationRuleService_Update_RevalidatesRegex(t *testing.T) {
+	svc, userID, g := newRuleSvc(t)
+	ctx := context.Background()
+	catID := firstSystemCategory(t, g)
+
+	r, err := svc.Create(ctx, userID, service.CreateRuleInput{
+		Pattern: "WHOLEFDS", MatchType: "contains", CategoryID: catID, Priority: 10,
+	})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	t.Cleanup(func() { _ = svc.SoftDelete(ctx, userID, r.ID) })
+
+	regex := "regex"
+	bad := "([unclosed"
+	if _, err := svc.Update(ctx, userID, r.ID, service.UpdateRuleInput{
+		MatchType: &regex,
+		Pattern:   &bad,
+	}); !errors.Is(err, service.ErrInvalidRegex) {
+		t.Errorf("Update err = %v, want ErrInvalidRegex", err)
+	}
+}

--- a/backend/migrations/000008_categorization_rules_user_id.down.sql
+++ b/backend/migrations/000008_categorization_rules_user_id.down.sql
@@ -1,0 +1,10 @@
+-- Reverse 000008: restore the global priority index, drop the user-scoped
+-- one, then drop user_id. Order matters — drop the index that depends on
+-- the column before the column itself.
+DROP INDEX IF EXISTS ix_categorization_rules_user_priority;
+
+CREATE INDEX ix_categorization_rules_priority
+    ON categorization_rules (priority DESC, id)
+    WHERE deleted_at IS NULL AND is_active = TRUE;
+
+ALTER TABLE categorization_rules DROP COLUMN IF EXISTS user_id;

--- a/backend/migrations/000008_categorization_rules_user_id.up.sql
+++ b/backend/migrations/000008_categorization_rules_user_id.up.sql
@@ -1,0 +1,18 @@
+-- #89: scope categorization_rules by user_id.
+--
+-- `categorization_rules` was created in migration 000001 before the
+-- multi-tenant model landed (M2.5). Per .claude/rules/database.md, every
+-- user-owned domain table requires `user_id BIGINT NOT NULL REFERENCES users(id)`.
+-- The table is unused so far (M4 ships the first writers), so we add the
+-- column NOT NULL outright — no backfill needed.
+ALTER TABLE categorization_rules
+    ADD COLUMN user_id BIGINT NOT NULL REFERENCES users(id);
+
+-- Lookups in the engine always filter by (user_id, is_active=true) ordered
+-- by priority DESC, id. Replace the existing priority index with a
+-- user-scoped equivalent.
+DROP INDEX IF EXISTS ix_categorization_rules_priority;
+
+CREATE INDEX ix_categorization_rules_user_priority
+    ON categorization_rules (user_id, priority DESC, id)
+    WHERE deleted_at IS NULL AND is_active = TRUE;


### PR DESCRIPTION
## Summary
- Migration 000008 adds `user_id NOT NULL REFERENCES users(id)` to `categorization_rules` (table was unused so no backfill); swaps the priority index for a user-scoped variant
- Full repo → service → handler stack for `/api/v1/categorization-rules` (POST / GET list / GET :id / PATCH :id / DELETE :id) with session-derived `user_id` filtering
- Service validates pattern non-empty, `match_type ∈ {contains, regex, exact}` (regex pre-compiled), `priority ≥ 0`, and category existence; emits `ErrInvalidRegex`, `ErrUnknownCategory`, etc.
- Tests cover validation, ordering + soft-delete, cross-tenant isolation across Get/Update/SoftDelete/List, and that PATCH-to-regex revalidates the pattern

Closes #89.

## Test plan
- [x] `go test ./... -race -p 1` (all green)
- [x] `go vet ./...` (clean)
- [x] `go run ./cmd/migrate down && go run ./cmd/migrate up` round-trip
- [x] frontend `pnpm lint` + `pnpm build` (untouched, both green)
- [ ] Manual smoke: POST → GET → PATCH → DELETE via `/api/v1/categorization-rules` (deferred — exercised by service integration tests against real Postgres)

🤖 Generated with [Claude Code](https://claude.com/claude-code)