### PR TITLE
feat(categorization): bulk re-categorize endpoint (#91)

### DIFF
--- a/backend/internal/handler/categorization_rule_handler.go
+++ b/backend/internal/handler/categorization_rule_handler.go
@@ -24,6 +24,29 @@ func (h *CategorizationRuleHandler) Register(g *gin.RouterGroup) {
 	g.GET("/categorization-rules/:id", h.Get)
 	g.PATCH("/categorization-rules/:id", h.Update)
 	g.DELETE("/categorization-rules/:id", h.Delete)
+	g.POST("/categorization-rules/apply", h.Apply)
+}
+
+type applyRulesRequest struct {
+	Scope string `json:"scope"`
+}
+
+// Apply runs the bulk re-categorize endpoint. Empty body defaults to
+// scope="all"; explicit scope ∈ {all, uncategorized, plaid_default}.
+func (h *CategorizationRuleHandler) Apply(c *gin.Context) {
+	var req applyRulesRequest
+	if c.Request.ContentLength > 0 {
+		if err := c.ShouldBindJSON(&req); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error(), "code": "INVALID_REQUEST"})
+			return
+		}
+	}
+	result, err := h.svc.Apply(c.Request.Context(), auth.MustUserID(c.Request.Context()), req.Scope)
+	if err != nil {
+		h.writeServiceError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"data": result})
 }
 
 type createRuleRequest struct {
@@ -122,6 +145,8 @@ func (h *CategorizationRuleHandler) writeServiceError(c *gin.Context, err error)
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error(), "code": "INVALID_REGEX"})
 	case errors.Is(err, service.ErrUnknownCategory):
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error(), "code": "UNKNOWN_CATEGORY"})
+	case errors.Is(err, service.ErrInvalidApplyScope):
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error(), "code": "INVALID_SCOPE"})
 	case errors.Is(err, service.ErrEmptyPattern),
 		errors.Is(err, service.ErrInvalidMatchType),
 		errors.Is(err, service.ErrInvalidPriority):

--- a/backend/internal/repository/transaction_repo.go
+++ b/backend/internal/repository/transaction_repo.go
@@ -64,7 +64,30 @@ type TransactionRepository interface {
 	// (live or soft-deleted) for the key. The caller is expected to pass a
 	// row produced by plaid.MergePlaidUpdate so user-edited fields survive.
 	ResurrectByPlaidTransactionID(ctx context.Context, userID int64, plaidTxnID string, merged model.Transaction) error
+	// ListForCategorizationScope returns a chunk of non-deleted transactions
+	// for the user, ordered by id ASC for cursor-style pagination. Callers
+	// drive a loop by passing the last returned row's id as afterID on the
+	// next call. The empty slice signals end-of-scan.
+	//
+	// scope filters the underlying query:
+	//   - "all"           — every non-deleted transaction
+	//   - "uncategorized" — category_id IS NULL
+	//   - "plaid_default" — categorization_method = 'plaid_default'
+	//
+	// Manual rows (categorization_method = 'manual') are NOT filtered out
+	// here — the bulk-apply service inspects each row so it can count
+	// "skipped_manual" for the response. For scope='plaid_default' the
+	// method filter inherently excludes manual rows.
+	ListForCategorizationScope(ctx context.Context, userID int64, scope string, afterID int64, limit int) ([]model.Transaction, error)
 }
+
+// CategorizationScopes enumerates the valid `scope` values for
+// ListForCategorizationScope and the bulk re-categorize endpoint.
+const (
+	CategorizationScopeAll           = "all"
+	CategorizationScopeUncategorized = "uncategorized"
+	CategorizationScopePlaidDefault  = "plaid_default"
+)
 
 type transactionRepo struct {
 	db *gorm.DB
@@ -263,6 +286,33 @@ func (r *transactionRepo) ResurrectByPlaidTransactionID(ctx context.Context, use
 		return ErrNotFound
 	}
 	return nil
+}
+
+func (r *transactionRepo) ListForCategorizationScope(ctx context.Context, userID int64, scope string, afterID int64, limit int) ([]model.Transaction, error) {
+	if limit <= 0 {
+		limit = 1000
+	}
+	q := r.db.WithContext(ctx).
+		Model(&model.Transaction{}).
+		Where("user_id = ?", userID)
+	if afterID > 0 {
+		q = q.Where("id > ?", afterID)
+	}
+	switch scope {
+	case CategorizationScopeUncategorized:
+		q = q.Where("category_id IS NULL")
+	case CategorizationScopePlaidDefault:
+		q = q.Where("categorization_method = ?", "plaid_default")
+	case CategorizationScopeAll, "":
+		// no extra predicate
+	default:
+		return nil, errors.New("unknown categorization scope: " + scope)
+	}
+	var out []model.Transaction
+	if err := q.Order("id ASC").Limit(limit).Find(&out).Error; err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (r *transactionRepo) SoftDelete(ctx context.Context, userID, id int64) error {

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -51,7 +51,7 @@ func New(cfg config.Config, gormDB *gorm.DB) *gin.Engine {
 	categorySvc := service.NewCategoryService(categoryRepo)
 	categoryHandler := handler.NewCategoryHandler(categorySvc)
 
-	ruleSvc := service.NewCategorizationRuleService(ruleRepo, categoryRepo)
+	ruleSvc := service.NewCategorizationRuleService(ruleRepo, categoryRepo).WithBulkApply(transactionRepo, gormDB)
 	ruleHandler := handler.NewCategorizationRuleHandler(ruleSvc)
 
 	dashboardRepo := repository.NewDashboardRepository(gormDB)

--- a/backend/internal/service/categorization_rule_apply_test.go
+++ b/backend/internal/service/categorization_rule_apply_test.go
@@ -204,9 +204,8 @@ func TestCategorizationRuleService_Apply_ScopeUncategorized(t *testing.T) {
 	t.Cleanup(func() { g.Unscoped().Delete(&model.CategorizationRule{}, rule.ID) })
 
 	// 3 uncategorized matching, 2 plaid_default already-categorized matching.
-	uncat := []*model.Transaction{}
 	for i := 0; i < 3; i++ {
-		uncat = append(uncat, mkTxn(t, g, userID, accountID, withDescription("WHOLEFDS #"+fmt.Sprint(i))))
+		mkTxn(t, g, userID, accountID, withDescription("WHOLEFDS #"+fmt.Sprint(i)))
 	}
 	for i := 0; i < 2; i++ {
 		mkTxn(t, g, userID, accountID,

--- a/backend/internal/service/categorization_rule_apply_test.go
+++ b/backend/internal/service/categorization_rule_apply_test.go
@@ -1,0 +1,304 @@
+package service_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/shopspring/decimal"
+	"gorm.io/gorm"
+
+	"github.com/gregwym/offbook/backend/internal/model"
+	"github.com/gregwym/offbook/backend/internal/repository"
+	"github.com/gregwym/offbook/backend/internal/service"
+)
+
+// newRuleApplySvc builds a CategorizationRuleService with bulk-apply
+// wiring, plus a seeded user + account + spare categories for tests.
+func newRuleApplySvc(t *testing.T) (svc *service.CategorizationRuleService, userID, accountID, fixtureCat int64, g *gorm.DB) {
+	t.Helper()
+	g = openTestDB(t)
+	userID = seedTestUser(t, g)
+
+	ctx := context.Background()
+	suffix := time.Now().Format("150405.000000")
+	acc := &model.Account{
+		UserID:          userID,
+		Name:            "rule-apply-" + suffix,
+		InstitutionSlug: "fixture",
+		AccountType:     "checking",
+		Currency:        "USD",
+	}
+	if err := g.WithContext(ctx).Create(acc).Error; err != nil {
+		t.Fatalf("seed account: %v", err)
+	}
+	t.Cleanup(func() {
+		g.Unscoped().Where("account_id = ?", acc.ID).Delete(&model.Transaction{})
+		g.Unscoped().Delete(&model.Account{}, acc.ID)
+	})
+
+	cat := &model.Category{
+		Name:     "RuleApplyFixture",
+		Slug:     "rule-apply-fixture-" + suffix,
+		IsSystem: false,
+	}
+	if err := g.WithContext(ctx).Create(cat).Error; err != nil {
+		t.Fatalf("seed category: %v", err)
+	}
+	t.Cleanup(func() { g.Unscoped().Delete(&model.Category{}, cat.ID) })
+
+	svc = service.NewCategorizationRuleService(
+		repository.NewCategorizationRuleRepository(g),
+		repository.NewCategoryRepository(g),
+	).WithBulkApply(repository.NewTransactionRepository(g), g)
+
+	return svc, userID, acc.ID, cat.ID, g
+}
+
+// mkTxn inserts a transaction directly via gorm (bypassing transaction_service
+// to keep the fixture deterministic — we own the categorization fields).
+func mkTxn(t *testing.T, g *gorm.DB, userID, accountID int64, opts ...func(*model.Transaction)) *model.Transaction {
+	t.Helper()
+	tx := &model.Transaction{
+		UserID:          userID,
+		AccountID:       accountID,
+		Amount:          decimal.NewFromInt(-10),
+		Currency:        "USD",
+		TransactionDate: time.Date(2026, 5, 15, 0, 0, 0, 0, time.UTC),
+		Source:          "manual",
+	}
+	for _, opt := range opts {
+		opt(tx)
+	}
+	if err := g.Create(tx).Error; err != nil {
+		t.Fatalf("seed txn: %v", err)
+	}
+	return tx
+}
+
+func withDescription(s string) func(*model.Transaction) {
+	return func(tx *model.Transaction) {
+		v := s
+		tx.Description = &v
+	}
+}
+
+func withManualCategory(catID int64) func(*model.Transaction) {
+	return func(tx *model.Transaction) {
+		id := catID
+		method := "manual"
+		tx.CategoryID = &id
+		tx.CategorizationMethod = &method
+	}
+}
+
+func withPlaidDefaultCategory(catID int64) func(*model.Transaction) {
+	return func(tx *model.Transaction) {
+		id := catID
+		method := "plaid_default"
+		tx.CategoryID = &id
+		tx.CategorizationMethod = &method
+	}
+}
+
+// TestCategorizationRuleService_Apply_ScopeAll: 100 fixture txns, 1 rule
+// that matches half of them — those get updated; manual rows are untouched.
+func TestCategorizationRuleService_Apply_ScopeAll(t *testing.T) {
+	svc, userID, accountID, fixtureCat, g := newRuleApplySvc(t)
+	ctx := context.Background()
+
+	// Seed one rule.
+	rule := &model.CategorizationRule{
+		UserID: userID, Pattern: "WHOLEFDS", MatchType: "contains",
+		CategoryID: fixtureCat, Priority: 50, IsActive: true,
+	}
+	if err := g.Create(rule).Error; err != nil {
+		t.Fatalf("seed rule: %v", err)
+	}
+	t.Cleanup(func() { g.Unscoped().Delete(&model.CategorizationRule{}, rule.ID) })
+
+	// 50 matching, 30 non-matching, 20 manual (which should be skipped even
+	// though they contain WHOLEFDS — verifies the manual-wins rule).
+	for i := 0; i < 50; i++ {
+		mkTxn(t, g, userID, accountID, withDescription("WHOLEFDS #"+fmt.Sprint(i)))
+	}
+	for i := 0; i < 30; i++ {
+		mkTxn(t, g, userID, accountID, withDescription("OTHER #"+fmt.Sprint(i)))
+	}
+	for i := 0; i < 20; i++ {
+		mkTxn(t, g, userID, accountID,
+			withDescription("WHOLEFDS manual #"+fmt.Sprint(i)),
+			withManualCategory(fixtureCat))
+	}
+
+	result, err := svc.Apply(ctx, userID, "")
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if result.Scanned != 100 {
+		t.Errorf("Scanned = %d, want 100", result.Scanned)
+	}
+	if result.Updated != 50 {
+		t.Errorf("Updated = %d, want 50", result.Updated)
+	}
+	if result.SkippedManual != 20 {
+		t.Errorf("SkippedManual = %d, want 20", result.SkippedManual)
+	}
+
+	// Verify the manual rows still have categorization_method=manual.
+	var manualCount int64
+	if err := g.Model(&model.Transaction{}).
+		Where("user_id = ? AND categorization_method = ?", userID, "manual").
+		Count(&manualCount).Error; err != nil {
+		t.Fatalf("count manual: %v", err)
+	}
+	if manualCount != 20 {
+		t.Errorf("manual rows post-apply = %d, want 20", manualCount)
+	}
+
+	// Verify the matched rows are now method=rule with rule_id set.
+	var ruleCount int64
+	if err := g.Model(&model.Transaction{}).
+		Where("user_id = ? AND categorization_method = ? AND categorization_rule_id = ?",
+			userID, "rule", rule.ID).
+		Count(&ruleCount).Error; err != nil {
+		t.Fatalf("count rule rows: %v", err)
+	}
+	if ruleCount != 50 {
+		t.Errorf("rule-categorized rows = %d, want 50", ruleCount)
+	}
+
+	// Second run is a no-op for already-rule-set rows.
+	result2, err := svc.Apply(ctx, userID, "")
+	if err != nil {
+		t.Fatalf("Apply (rerun): %v", err)
+	}
+	if result2.Updated != 0 {
+		t.Errorf("rerun Updated = %d, want 0 (idempotent)", result2.Updated)
+	}
+}
+
+// TestCategorizationRuleService_Apply_ScopeUncategorized: only rows with
+// NULL category_id are scanned. Pre-categorized rows (manual or
+// plaid_default) are not in the scan set at all.
+func TestCategorizationRuleService_Apply_ScopeUncategorized(t *testing.T) {
+	svc, userID, accountID, fixtureCat, g := newRuleApplySvc(t)
+	ctx := context.Background()
+
+	// Second category so we can prove pre-categorized rows weren't touched.
+	other := &model.Category{Name: "Other", Slug: "uncat-other-" + time.Now().Format("150405.000000")}
+	if err := g.Create(other).Error; err != nil {
+		t.Fatalf("seed other: %v", err)
+	}
+	t.Cleanup(func() { g.Unscoped().Delete(&model.Category{}, other.ID) })
+
+	rule := &model.CategorizationRule{
+		UserID: userID, Pattern: "WHOLEFDS", MatchType: "contains",
+		CategoryID: fixtureCat, Priority: 50, IsActive: true,
+	}
+	if err := g.Create(rule).Error; err != nil {
+		t.Fatalf("seed rule: %v", err)
+	}
+	t.Cleanup(func() { g.Unscoped().Delete(&model.CategorizationRule{}, rule.ID) })
+
+	// 3 uncategorized matching, 2 plaid_default already-categorized matching.
+	uncat := []*model.Transaction{}
+	for i := 0; i < 3; i++ {
+		uncat = append(uncat, mkTxn(t, g, userID, accountID, withDescription("WHOLEFDS #"+fmt.Sprint(i))))
+	}
+	for i := 0; i < 2; i++ {
+		mkTxn(t, g, userID, accountID,
+			withDescription("WHOLEFDS plaid #"+fmt.Sprint(i)),
+			withPlaidDefaultCategory(other.ID))
+	}
+
+	result, err := svc.Apply(ctx, userID, "uncategorized")
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if result.Scanned != 3 {
+		t.Errorf("Scanned = %d, want 3", result.Scanned)
+	}
+	if result.Updated != 3 {
+		t.Errorf("Updated = %d, want 3", result.Updated)
+	}
+	if result.SkippedManual != 0 {
+		t.Errorf("SkippedManual = %d, want 0", result.SkippedManual)
+	}
+
+	// plaid_default rows remain pointed at `other`.
+	var stillPlaid int64
+	if err := g.Model(&model.Transaction{}).
+		Where("user_id = ? AND categorization_method = ? AND category_id = ?",
+			userID, "plaid_default", other.ID).
+		Count(&stillPlaid).Error; err != nil {
+		t.Fatalf("count plaid_default: %v", err)
+	}
+	if stillPlaid != 2 {
+		t.Errorf("plaid_default rows post-apply = %d, want 2 (uncategorized scope must not touch them)", stillPlaid)
+	}
+}
+
+// TestCategorizationRuleService_Apply_TenantIsolation: a user's Apply
+// must not touch another user's transactions.
+func TestCategorizationRuleService_Apply_TenantIsolation(t *testing.T) {
+	svcA, userA, accountA, fixtureCat, g := newRuleApplySvc(t)
+	ctx := context.Background()
+
+	// User B has a transaction that user A's rule would otherwise match.
+	userB := seedTestUser(t, g)
+	suffix := time.Now().Format("150405.000000")
+	accB := &model.Account{
+		UserID: userB, Name: "B-" + suffix, InstitutionSlug: "fixture",
+		AccountType: "checking", Currency: "USD",
+	}
+	if err := g.Create(accB).Error; err != nil {
+		t.Fatalf("seed account B: %v", err)
+	}
+	t.Cleanup(func() {
+		g.Unscoped().Where("account_id = ?", accB.ID).Delete(&model.Transaction{})
+		g.Unscoped().Delete(&model.Account{}, accB.ID)
+	})
+
+	ruleA := &model.CategorizationRule{
+		UserID: userA, Pattern: "WHOLEFDS", MatchType: "contains",
+		CategoryID: fixtureCat, Priority: 50, IsActive: true,
+	}
+	if err := g.Create(ruleA).Error; err != nil {
+		t.Fatalf("seed rule A: %v", err)
+	}
+	t.Cleanup(func() { g.Unscoped().Delete(&model.CategorizationRule{}, ruleA.ID) })
+
+	mkTxn(t, g, userA, accountA, withDescription("WHOLEFDS A1"))
+	bTxn := mkTxn(t, g, userB, accB.ID, withDescription("WHOLEFDS B1"))
+
+	result, err := svcA.Apply(ctx, userA, "")
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if result.Scanned != 1 || result.Updated != 1 {
+		t.Errorf("user A scope: scanned=%d updated=%d, want 1/1 (user B's row must not be in scope)",
+			result.Scanned, result.Updated)
+	}
+
+	// User B's row is unchanged.
+	var afterB model.Transaction
+	if err := g.First(&afterB, bTxn.ID).Error; err != nil {
+		t.Fatalf("fetch B txn: %v", err)
+	}
+	if afterB.CategoryID != nil {
+		t.Errorf("user B's txn category_id = %v, want nil — cross-tenant write", afterB.CategoryID)
+	}
+}
+
+// TestCategorizationRuleService_Apply_BadScopeRejected catches typo/scope-
+// validation bugs without a Postgres round-trip per case.
+func TestCategorizationRuleService_Apply_BadScopeRejected(t *testing.T) {
+	svc, userID, _, _, _ := newRuleApplySvc(t)
+	ctx := context.Background()
+	if _, err := svc.Apply(ctx, userID, "garbage"); !errors.Is(err, service.ErrInvalidApplyScope) {
+		t.Errorf("bad scope err = %v, want ErrInvalidApplyScope", err)
+	}
+}

--- a/backend/internal/service/categorization_rule_service.go
+++ b/backend/internal/service/categorization_rule_service.go
@@ -7,17 +7,21 @@ import (
 	"regexp"
 	"strings"
 
+	"gorm.io/gorm"
+
 	"github.com/gregwym/offbook/backend/internal/model"
 	"github.com/gregwym/offbook/backend/internal/repository"
+	"github.com/gregwym/offbook/backend/internal/service/categorization"
 )
 
 var (
-	ErrRuleNotFound     = errors.New("categorization rule not found")
-	ErrEmptyPattern     = errors.New("pattern must not be empty")
-	ErrInvalidMatchType = errors.New("match_type must be one of: contains, regex, exact")
-	ErrInvalidRegex     = errors.New("pattern is not a valid regular expression")
-	ErrInvalidPriority  = errors.New("priority must be >= 0")
-	ErrUnknownCategory  = errors.New("category does not exist")
+	ErrRuleNotFound      = errors.New("categorization rule not found")
+	ErrEmptyPattern      = errors.New("pattern must not be empty")
+	ErrInvalidMatchType  = errors.New("match_type must be one of: contains, regex, exact")
+	ErrInvalidRegex      = errors.New("pattern is not a valid regular expression")
+	ErrInvalidPriority   = errors.New("priority must be >= 0")
+	ErrUnknownCategory   = errors.New("category does not exist")
+	ErrInvalidApplyScope = errors.New("scope must be one of: all, uncategorized, plaid_default")
 )
 
 var validMatchTypes = map[string]struct{}{
@@ -46,9 +50,16 @@ type UpdateRuleInput struct {
 // CategorizationRuleService owns rule validation and CRUD. It depends on
 // CategoryRepository only to verify CategoryID points at a real row — rules
 // have no cross-user visibility, so no further dependencies are needed.
+//
+// txRepo + db are optional dependencies used by Apply to bulk re-categorize
+// existing transactions against the user's current rules. CRUD continues to
+// work without them; if Apply is called and they're nil, it returns
+// ErrInvalidApplyScope so the router can fail loudly during wiring.
 type CategorizationRuleService struct {
 	repo    repository.CategorizationRuleRepository
 	catRepo repository.CategoryRepository
+	txRepo  repository.TransactionRepository
+	db      *gorm.DB
 }
 
 func NewCategorizationRuleService(
@@ -56,6 +67,16 @@ func NewCategorizationRuleService(
 	catRepo repository.CategoryRepository,
 ) *CategorizationRuleService {
 	return &CategorizationRuleService{repo: repo, catRepo: catRepo}
+}
+
+// WithBulkApply wires the dependencies needed for the Apply (bulk
+// re-categorize) endpoint — a transaction repository for the scan and a
+// *gorm.DB so each chunk runs in its own DB transaction. Returns the
+// receiver for one-line construction in the router.
+func (s *CategorizationRuleService) WithBulkApply(txRepo repository.TransactionRepository, db *gorm.DB) *CategorizationRuleService {
+	s.txRepo = txRepo
+	s.db = db
+	return s
 }
 
 func (s *CategorizationRuleService) Create(ctx context.Context, userID int64, in CreateRuleInput) (*model.CategorizationRule, error) {
@@ -137,6 +158,106 @@ func (s *CategorizationRuleService) SoftDelete(ctx context.Context, userID, id i
 		return fmt.Errorf("soft delete rule: %w", err)
 	}
 	return nil
+}
+
+// ApplyResult summarizes a bulk-apply run.
+type ApplyResult struct {
+	Scanned       int `json:"scanned"`
+	Updated       int `json:"updated"`
+	SkippedManual int `json:"skipped_manual"`
+}
+
+// Apply walks the user's transactions in chunks and re-runs the categorization
+// engine against the current rule set. The scope filters which rows are
+// scanned (see repository.CategorizationScope* constants); within the scanned
+// set, rows whose categorization_method is 'manual' are always skipped (user
+// picks are sacred). A row is updated only when a rule matches AND the
+// resulting decision differs from the row's current state — re-runs are
+// effectively idempotent.
+func (s *CategorizationRuleService) Apply(ctx context.Context, userID int64, scope string) (ApplyResult, error) {
+	if scope == "" {
+		scope = repository.CategorizationScopeAll
+	}
+	switch scope {
+	case repository.CategorizationScopeAll,
+		repository.CategorizationScopeUncategorized,
+		repository.CategorizationScopePlaidDefault:
+	default:
+		return ApplyResult{}, ErrInvalidApplyScope
+	}
+	if s.txRepo == nil || s.db == nil {
+		// Wiring bug — Apply was called on a service without WithBulkApply.
+		// Return ErrInvalidApplyScope rather than panicking so the handler maps
+		// it to a 400; the router should always call WithBulkApply.
+		return ApplyResult{}, ErrInvalidApplyScope
+	}
+
+	stored, err := s.repo.List(ctx, userID)
+	if err != nil {
+		return ApplyResult{}, fmt.Errorf("load rules: %w", err)
+	}
+	rules := categorization.Compile(stored)
+
+	var result ApplyResult
+	const chunkSize = 1000
+	afterID := int64(0)
+
+	for {
+		batch, err := s.txRepo.ListForCategorizationScope(ctx, userID, scope, afterID, chunkSize)
+		if err != nil {
+			return result, fmt.Errorf("scan transactions: %w", err)
+		}
+		if len(batch) == 0 {
+			break
+		}
+		// Wrap each chunk in its own DB transaction so a mid-chunk failure
+		// commits prior chunks' progress. Per-row Update lives behind a
+		// tx-bound repo so all writes hit the same Postgres transaction.
+		err = s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+			txRepo := repository.NewTransactionRepository(tx)
+			for i := range batch {
+				row := &batch[i]
+				result.Scanned++
+				afterID = row.ID
+
+				if row.CategorizationMethod != nil && *row.CategorizationMethod == "manual" {
+					result.SkippedManual++
+					continue
+				}
+				if len(rules) == 0 {
+					continue
+				}
+				d, ok := categorization.Categorize(rules, row.DescriptionClean, row.Description, row.MerchantName)
+				if !ok {
+					continue
+				}
+				// No-op if the row already reflects this decision.
+				if row.CategoryID != nil && *row.CategoryID == d.CategoryID &&
+					row.CategorizationRuleID != nil && *row.CategorizationRuleID == d.RuleID &&
+					row.CategorizationMethod != nil && *row.CategorizationMethod == categorization.MethodRule {
+					continue
+				}
+				catID := d.CategoryID
+				ruleID := d.RuleID
+				method := categorization.MethodRule
+				row.CategoryID = &catID
+				row.CategorizationRuleID = &ruleID
+				row.CategorizationMethod = &method
+				if err := txRepo.Update(ctx, row); err != nil {
+					return fmt.Errorf("update transaction %d: %w", row.ID, err)
+				}
+				result.Updated++
+			}
+			return nil
+		})
+		if err != nil {
+			return result, err
+		}
+		if len(batch) < chunkSize {
+			break
+		}
+	}
+	return result, nil
 }
 
 func (s *CategorizationRuleService) validate(ctx context.Context, r *model.CategorizationRule) error {


### PR DESCRIPTION
## Summary
- New endpoint `POST /api/v1/categorization-rules/apply` accepting `{scope?: "all" | "uncategorized" | "plaid_default"}` (default `all`). Returns `{data: {scanned, updated, skipped_manual}}`.
- Service walks the user's transactions in 1000-row chunks (cursor by id), wrapping each chunk in its own DB transaction. `manual` rows are always skipped. Re-runs are idempotent (no-op when the current state already matches the rule decision).
- New repo method `TransactionRepository.ListForCategorizationScope(userID, scope, afterID, limit)` and `CategorizationScope*` constants.
- `CategorizationRuleService.WithBulkApply(txRepo, db)` wires the chunked-write dependencies — CRUD continues to work without them.
- Tests on a real Postgres fixture: 100-row scope=all run (50 matches updated, 20 manual skipped, idempotent on re-run), `uncategorized` scope leaves pre-categorized rows alone, tenant isolation, bad-scope rejection.

Closes #91.

## Test plan
- [x] `go test ./... -race -p 1` (all green)
- [x] `go vet ./...` (clean)
- [ ] Manual smoke: `curl -X POST .../api/v1/categorization-rules/apply -d '{"scope":"uncategorized"}'` (deferred — covered by integration tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)