### PR TITLE
feat(rules): create-rule shortcut from transactions table (#93)

### DIFF
--- a/frontend/src/components/RuleFormModal.tsx
+++ b/frontend/src/components/RuleFormModal.tsx
@@ -1,0 +1,182 @@
+import { useState, type ReactNode } from 'react'
+import type { Category } from '../types/category'
+import {
+  MATCH_TYPES,
+  type CategorizationRule,
+  type CreateRuleInput,
+  type MatchType,
+  type UpdateRuleInput,
+} from '../types/categorizationRule'
+
+// Defaults used in 'create' mode. Edit mode ignores defaults and reads
+// initial values from the rule itself. Every field is optional so callers
+// can pre-fill as much or as little as makes sense (e.g. the transactions-
+// table "create rule from this txn" shortcut fills pattern + match_type +
+// category_id but leaves the rest at sensible defaults).
+export type RuleFormDefaults = {
+  pattern?: string
+  match_type?: MatchType
+  category_id?: number
+  priority?: number
+  is_active?: boolean
+}
+
+type Props = {
+  mode: 'create' | 'edit'
+  categories: Category[]
+  rule?: CategorizationRule
+  defaults?: RuleFormDefaults
+  onClose: () => void
+  onSubmit: (input: CreateRuleInput | UpdateRuleInput) => Promise<void>
+}
+
+export function RuleFormModal({ mode, categories, rule, defaults, onClose, onSubmit }: Props) {
+  const [pattern, setPattern] = useState(rule?.pattern ?? defaults?.pattern ?? '')
+  const [matchType, setMatchType] = useState<MatchType>(
+    rule?.match_type ?? defaults?.match_type ?? 'contains',
+  )
+  const [categoryID, setCategoryID] = useState<number | ''>(
+    rule?.category_id ?? defaults?.category_id ?? '',
+  )
+  const [priority, setPriority] = useState<number>(
+    rule?.priority ?? defaults?.priority ?? 10,
+  )
+  const [isActive, setIsActive] = useState(rule?.is_active ?? defaults?.is_active ?? true)
+  const [submitting, setSubmitting] = useState(false)
+  // We split form errors by field when the backend gives us a code; otherwise
+  // surface as a generic banner above the form.
+  const [error, setError] = useState<string | null>(null)
+  const [patternError, setPatternError] = useState<string | null>(null)
+  const [categoryError, setCategoryError] = useState<string | null>(null)
+
+  const submit = async () => {
+    setError(null)
+    setPatternError(null)
+    setCategoryError(null)
+    if (!pattern.trim()) {
+      setPatternError('Pattern is required.')
+      return
+    }
+    if (categoryID === '' || !Number.isInteger(categoryID) || categoryID <= 0) {
+      setCategoryError('Pick a category.')
+      return
+    }
+    if (priority < 0) {
+      setError('Priority must be >= 0.')
+      return
+    }
+    setSubmitting(true)
+    try {
+      await onSubmit({
+        pattern: pattern.trim(),
+        match_type: matchType,
+        category_id: Number(categoryID),
+        priority,
+        is_active: isActive,
+      })
+    } catch (err) {
+      const { code, message } = extractErr(err)
+      if (code === 'INVALID_REGEX') {
+        setPatternError(message)
+      } else if (code === 'UNKNOWN_CATEGORY') {
+        setCategoryError(message)
+      } else {
+        setError(message)
+      }
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-20 flex items-center justify-center bg-black/40 p-4">
+      <div className="w-full max-w-lg rounded-lg bg-white shadow-xl">
+        <div className="border-b border-gray-200 px-5 py-3 text-lg font-semibold text-gray-900">
+          {mode === 'create' ? 'New rule' : `Edit "${rule?.pattern}"`}
+        </div>
+        <div className="space-y-3 px-5 py-4">
+          {error && <div className="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">{error}</div>}
+          <Field label="Pattern" error={patternError}>
+            <input
+              className={inputClass}
+              value={pattern}
+              onChange={(e) => setPattern(e.target.value)}
+              placeholder={matchType === 'regex' ? 'e.g. ^AMZN\\s' : 'e.g. WHOLEFDS'}
+            />
+            <p className="mt-1 text-xs text-gray-500">
+              {matchType === 'contains' && 'Case-insensitive substring match on description or merchant.'}
+              {matchType === 'exact' && 'Case-insensitive exact match on description or merchant.'}
+              {matchType === 'regex' && 'Go regexp; case-sensitive unless you prefix (?i).'}
+            </p>
+          </Field>
+          <div className="grid grid-cols-2 gap-3">
+            <Field label="Match type">
+              <select className={inputClass} value={matchType} onChange={(e) => setMatchType(e.target.value as MatchType)}>
+                {MATCH_TYPES.map((m) => (
+                  <option key={m} value={m}>{m}</option>
+                ))}
+              </select>
+            </Field>
+            <Field label="Priority">
+              <input
+                className={inputClass}
+                type="number"
+                min={0}
+                value={priority}
+                onChange={(e) => setPriority(Number(e.target.value))}
+              />
+            </Field>
+          </div>
+          <Field label="Category" error={categoryError}>
+            <select
+              className={inputClass}
+              value={categoryID === '' ? '' : String(categoryID)}
+              onChange={(e) => setCategoryID(e.target.value === '' ? '' : Number(e.target.value))}
+            >
+              <option value="">— pick one —</option>
+              {categories.map((c) => (
+                <option key={c.id} value={c.id}>{c.name}</option>
+              ))}
+            </select>
+          </Field>
+          <label className="flex items-center gap-2 text-sm text-gray-700">
+            <input type="checkbox" checked={isActive} onChange={(e) => setIsActive(e.target.checked)} />
+            Active
+          </label>
+        </div>
+        <div className="flex justify-end gap-2 border-t border-gray-200 px-5 py-3">
+          <button type="button" onClick={onClose} className="rounded-md border border-gray-300 px-3 py-1.5 text-sm">Cancel</button>
+          <button
+            type="button"
+            onClick={submit}
+            disabled={submitting}
+            className="rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-indigo-700 disabled:opacity-50"
+          >
+            {submitting ? 'Saving…' : mode === 'create' ? 'Create' : 'Save'}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+const inputClass = 'w-full rounded border border-gray-300 px-2 py-1 text-sm'
+
+function Field({ label, error, children }: { label: string; error?: string | null; children: ReactNode }) {
+  return (
+    <label className="block text-sm">
+      <span className="mb-1 block text-xs font-medium text-gray-600">{label}</span>
+      {children}
+      {error && <span className="mt-1 block text-xs text-red-600">{error}</span>}
+    </label>
+  )
+}
+
+function extractErr(err: unknown): { code: string | null; message: string } {
+  if (err && typeof err === 'object' && 'response' in err) {
+    const r = (err as { response?: { data?: { error?: string; code?: string } } }).response
+    if (r?.data?.error) return { code: r.data.code ?? null, message: r.data.error }
+  }
+  if (err instanceof Error) return { code: null, message: err.message }
+  return { code: null, message: 'request failed' }
+}

--- a/frontend/src/pages/RulesPage.tsx
+++ b/frontend/src/pages/RulesPage.tsx
@@ -1,15 +1,13 @@
-import { useEffect, useMemo, useState, type ReactNode } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { Pencil, Plus, RefreshCw, Trash2 } from 'lucide-react'
+import { RuleFormModal } from '../components/RuleFormModal'
 import { useCategoriesStore } from '../store/categoriesStore'
 import { useRulesStore } from '../store/rulesStore'
 import type { Category } from '../types/category'
-import {
-  MATCH_TYPES,
-  type ApplyResult,
-  type CategorizationRule,
-  type CreateRuleInput,
-  type MatchType,
-  type UpdateRuleInput,
+import type {
+  ApplyResult,
+  CategorizationRule,
+  CreateRuleInput,
 } from '../types/categorizationRule'
 
 export function RulesPage() {
@@ -181,164 +179,10 @@ export function RulesPage() {
   )
 }
 
-type FormProps = {
-  mode: 'create' | 'edit'
-  categories: Category[]
-  rule?: CategorizationRule
-  defaults?: { priority?: number }
-  onClose: () => void
-  onSubmit: (input: CreateRuleInput | UpdateRuleInput) => Promise<void>
-}
-
-function RuleFormModal({ mode, categories, rule, defaults, onClose, onSubmit }: FormProps) {
-  const [pattern, setPattern] = useState(rule?.pattern ?? '')
-  const [matchType, setMatchType] = useState<MatchType>(rule?.match_type ?? 'contains')
-  const [categoryID, setCategoryID] = useState<number | ''>(rule?.category_id ?? '')
-  const [priority, setPriority] = useState<number>(rule?.priority ?? defaults?.priority ?? 10)
-  const [isActive, setIsActive] = useState(rule?.is_active ?? true)
-  const [submitting, setSubmitting] = useState(false)
-  // We split form errors by field when the backend gives us a code; otherwise
-  // generic banner.
-  const [error, setError] = useState<string | null>(null)
-  const [patternError, setPatternError] = useState<string | null>(null)
-  const [categoryError, setCategoryError] = useState<string | null>(null)
-
-  const submit = async () => {
-    setError(null)
-    setPatternError(null)
-    setCategoryError(null)
-    if (!pattern.trim()) {
-      setPatternError('Pattern is required.')
-      return
-    }
-    if (categoryID === '' || !Number.isInteger(categoryID) || categoryID <= 0) {
-      setCategoryError('Pick a category.')
-      return
-    }
-    if (priority < 0) {
-      setError('Priority must be >= 0.')
-      return
-    }
-    setSubmitting(true)
-    try {
-      await onSubmit({
-        pattern: pattern.trim(),
-        match_type: matchType,
-        category_id: Number(categoryID),
-        priority,
-        is_active: isActive,
-      })
-    } catch (err) {
-      const { code, message } = extractErr(err)
-      if (code === 'INVALID_REGEX') {
-        setPatternError(message)
-      } else if (code === 'UNKNOWN_CATEGORY') {
-        setCategoryError(message)
-      } else {
-        setError(message)
-      }
-    } finally {
-      setSubmitting(false)
-    }
-  }
-
-  return (
-    <div className="fixed inset-0 z-20 flex items-center justify-center bg-black/40 p-4">
-      <div className="w-full max-w-lg rounded-lg bg-white shadow-xl">
-        <div className="border-b border-gray-200 px-5 py-3 text-lg font-semibold text-gray-900">
-          {mode === 'create' ? 'New rule' : `Edit "${rule?.pattern}"`}
-        </div>
-        <div className="space-y-3 px-5 py-4">
-          {error && <div className="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">{error}</div>}
-          <Field label="Pattern" error={patternError}>
-            <input
-              className={inputClass}
-              value={pattern}
-              onChange={(e) => setPattern(e.target.value)}
-              placeholder={matchType === 'regex' ? 'e.g. ^AMZN\\s' : 'e.g. WHOLEFDS'}
-            />
-            <p className="mt-1 text-xs text-gray-500">
-              {matchType === 'contains' && 'Case-insensitive substring match on description or merchant.'}
-              {matchType === 'exact' && 'Case-insensitive exact match on description or merchant.'}
-              {matchType === 'regex' && 'Go regexp; case-sensitive unless you prefix (?i).'}
-            </p>
-          </Field>
-          <div className="grid grid-cols-2 gap-3">
-            <Field label="Match type">
-              <select className={inputClass} value={matchType} onChange={(e) => setMatchType(e.target.value as MatchType)}>
-                {MATCH_TYPES.map((m) => (
-                  <option key={m} value={m}>{m}</option>
-                ))}
-              </select>
-            </Field>
-            <Field label="Priority">
-              <input
-                className={inputClass}
-                type="number"
-                min={0}
-                value={priority}
-                onChange={(e) => setPriority(Number(e.target.value))}
-              />
-            </Field>
-          </div>
-          <Field label="Category" error={categoryError}>
-            <select
-              className={inputClass}
-              value={categoryID === '' ? '' : String(categoryID)}
-              onChange={(e) => setCategoryID(e.target.value === '' ? '' : Number(e.target.value))}
-            >
-              <option value="">— pick one —</option>
-              {categories.map((c) => (
-                <option key={c.id} value={c.id}>{c.name}</option>
-              ))}
-            </select>
-          </Field>
-          <label className="flex items-center gap-2 text-sm text-gray-700">
-            <input type="checkbox" checked={isActive} onChange={(e) => setIsActive(e.target.checked)} />
-            Active
-          </label>
-        </div>
-        <div className="flex justify-end gap-2 border-t border-gray-200 px-5 py-3">
-          <button type="button" onClick={onClose} className="rounded-md border border-gray-300 px-3 py-1.5 text-sm">Cancel</button>
-          <button
-            type="button"
-            onClick={submit}
-            disabled={submitting}
-            className="rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-indigo-700 disabled:opacity-50"
-          >
-            {submitting ? 'Saving…' : mode === 'create' ? 'Create' : 'Save'}
-          </button>
-        </div>
-      </div>
-    </div>
-  )
-}
-
-const inputClass = 'w-full rounded border border-gray-300 px-2 py-1 text-sm'
-
-function Field({ label, error, children }: { label: string; error?: string | null; children: ReactNode }) {
-  return (
-    <label className="block text-sm">
-      <span className="mb-1 block text-xs font-medium text-gray-600">{label}</span>
-      {children}
-      {error && <span className="mt-1 block text-xs text-red-600">{error}</span>}
-    </label>
-  )
-}
-
 function formatApplyResult(r: ApplyResult): string {
   const parts = [`Scanned ${r.scanned}`, `updated ${r.updated}`]
   if (r.skipped_manual > 0) {
     parts.push(`skipped ${r.skipped_manual} manual`)
   }
   return parts.join(', ') + '.'
-}
-
-function extractErr(err: unknown): { code: string | null; message: string } {
-  if (err && typeof err === 'object' && 'response' in err) {
-    const r = (err as { response?: { data?: { error?: string; code?: string } } }).response
-    if (r?.data?.error) return { code: r.data.code ?? null, message: r.data.error }
-  }
-  if (err instanceof Error) return { code: null, message: err.message }
-  return { code: null, message: 'request failed' }
 }

--- a/frontend/src/pages/TransactionsPage.tsx
+++ b/frontend/src/pages/TransactionsPage.tsx
@@ -1,12 +1,16 @@
 import { useEffect, useMemo, useState, type ReactNode } from 'react'
-import { Plus, Trash2 } from 'lucide-react'
+import { Plus, Sparkles, Trash2 } from 'lucide-react'
+import { Link } from 'react-router-dom'
 import { AmountDisplay } from '../components/AmountDisplay'
+import { RuleFormModal, type RuleFormDefaults } from '../components/RuleFormModal'
 import { useAccountsStore } from '../store/accountsStore'
 import { useCategoriesStore } from '../store/categoriesStore'
+import { useRulesStore } from '../store/rulesStore'
 import { useTransactionsStore } from '../store/transactionsStore'
 import { useDebounce } from '../hooks/useDebounce'
 import type { Account } from '../types/account'
 import type { Category } from '../types/category'
+import type { CreateRuleInput } from '../types/categorizationRule'
 import type { CreateTransactionInput, Transaction, TransactionSource } from '../types/transaction'
 import { TRANSACTION_SOURCES } from '../types/transaction'
 
@@ -18,6 +22,17 @@ export function TransactionsPage() {
   } = useTransactionsStore()
   const { accounts, fetch: fetchAccounts } = useAccountsStore()
   const { categories, fetch: fetchCategories } = useCategoriesStore()
+  const {
+    rules,
+    fetch: fetchRules,
+    create: createRule,
+    apply: applyRules,
+  } = useRulesStore()
+  const [ruleSeed, setRuleSeed] = useState<RuleFormDefaults | null>(null)
+  // After a successful rule create from a txn, surface a toast with two
+  // actions: jump to /rules, or re-apply to existing transactions.
+  const [createdRuleToast, setCreatedRuleToast] = useState<string | null>(null)
+  const [applyToastBusy, setApplyToastBusy] = useState(false)
 
   // Local filter inputs — synced into the store via setFilter on change.
   const [accountID, setAccountID] = useState<string>(String(filter.account_id ?? ''))
@@ -33,8 +48,31 @@ export function TransactionsPage() {
   useEffect(() => {
     void fetchAccounts()
     void fetchCategories()
+    void fetchRules()
     void fetch()
-  }, [fetch, fetchAccounts, fetchCategories])
+  }, [fetch, fetchAccounts, fetchCategories, fetchRules])
+
+  // Same priority heuristic as RulesPage — new rules outrank existing ones
+  // by default so the "create from this txn" shortcut wins immediately on
+  // the next sync.
+  const nextPriority = useMemo(() => {
+    if (rules.length === 0) return 10
+    return rules.reduce((m, r) => Math.max(m, r.priority), 0) + 10
+  }, [rules])
+
+  const openRuleFromTxn = (t: Transaction) => {
+    const pattern =
+      (t.merchant_name && t.merchant_name.trim()) ||
+      (t.description_clean && t.description_clean.trim()) ||
+      (t.description && t.description.trim()) ||
+      ''
+    setRuleSeed({
+      pattern,
+      match_type: 'contains',
+      category_id: t.category_id ?? undefined,
+      priority: nextPriority,
+    })
+  }
 
   // Propagate the typed inputs into the store filter. setFilter resets page to 0.
   useEffect(() => {
@@ -125,6 +163,7 @@ export function TransactionsPage() {
                 categories={categories}
                 currentCategory={t.category_id ? categoryByID.get(t.category_id) : undefined}
                 onCategoryChange={(catID) => { void setCategory(t.id, catID) }}
+                onCreateRule={() => openRuleFromTxn(t)}
                 onDelete={async () => {
                   if (window.confirm('Delete this transaction?')) {
                     await remove(t.id)
@@ -163,6 +202,67 @@ export function TransactionsPage() {
           }}
         />
       )}
+
+      {ruleSeed && (
+        <RuleFormModal
+          mode="create"
+          categories={categories}
+          defaults={ruleSeed}
+          onClose={() => setRuleSeed(null)}
+          onSubmit={async (input) => {
+            await createRule(input as CreateRuleInput)
+            setRuleSeed(null)
+            setCreatedRuleToast(`Rule "${(input as CreateRuleInput).pattern}" created.`)
+          }}
+        />
+      )}
+
+      {createdRuleToast && (
+        <div className="fixed bottom-4 right-4 z-30 flex max-w-md items-start gap-3 rounded-md border border-emerald-200 bg-white px-4 py-3 text-sm shadow-lg">
+          <Sparkles size={18} className="mt-0.5 text-emerald-600" />
+          <div className="flex-1">
+            <div className="font-medium text-gray-900">{createdRuleToast}</div>
+            <div className="mt-2 flex gap-2">
+              <Link
+                to="/rules"
+                className="rounded-md border border-gray-300 px-2 py-1 text-xs text-gray-700 hover:bg-gray-50"
+                onClick={() => setCreatedRuleToast(null)}
+              >
+                View rules
+              </Link>
+              <button
+                type="button"
+                disabled={applyToastBusy}
+                onClick={async () => {
+                  setApplyToastBusy(true)
+                  try {
+                    const result = await applyRules()
+                    setCreatedRuleToast(
+                      `Re-applied: scanned ${result.scanned}, updated ${result.updated}` +
+                        (result.skipped_manual > 0 ? `, skipped ${result.skipped_manual} manual.` : '.'),
+                    )
+                    // Refresh the transactions list so the new categorization shows up.
+                    await fetch()
+                  } catch {
+                    // ignore — error toast handled by rules store
+                  } finally {
+                    setApplyToastBusy(false)
+                  }
+                }}
+                className="rounded-md bg-emerald-600 px-2 py-1 text-xs font-medium text-white hover:bg-emerald-700 disabled:opacity-50"
+              >
+                {applyToastBusy ? 'Applying…' : 'Apply to existing transactions'}
+              </button>
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={() => setCreatedRuleToast(null)}
+            className="ml-1 text-gray-400 hover:text-gray-700"
+            aria-label="Dismiss"
+          >×</button>
+        </div>
+      )}
     </div>
   )
 }
@@ -173,10 +273,11 @@ type RowProps = {
   categories: Category[]
   currentCategory?: Category
   onCategoryChange: (catID: number | null) => void
+  onCreateRule: () => void
   onDelete: () => Promise<void>
 }
 
-function TransactionRow({ tx, account, categories, currentCategory, onCategoryChange, onDelete }: RowProps) {
+function TransactionRow({ tx, account, categories, currentCategory, onCategoryChange, onCreateRule, onDelete }: RowProps) {
   return (
     <tr className="hover:bg-gray-50">
       <td className="px-3 py-2 text-gray-700">{tx.transaction_date}</td>
@@ -200,6 +301,15 @@ function TransactionRow({ tx, account, categories, currentCategory, onCategoryCh
         </select>
       </td>
       <td className="px-3 py-2 text-right">
+        <button
+          type="button"
+          onClick={onCreateRule}
+          className="mr-2 text-gray-500 hover:text-indigo-700"
+          aria-label="Create rule from this transaction"
+          title="Create rule from this transaction"
+        >
+          <Sparkles size={16} />
+        </button>
         <button
           type="button"
           onClick={onDelete}


### PR DESCRIPTION
## Summary
- New Sparkles row action on the Transactions table: "Create rule from this transaction".
- Opens the shared `RuleFormModal` pre-filled with `pattern = merchant_name ?? description_clean ?? description`, `match_type = contains`, `category_id = row's current category`, `priority = max(existing) + 10`. User can edit any field before submitting.
- After successful create, a bottom-right toast surfaces "View rules" (→ `/rules`) and "Apply to existing transactions" (→ `POST /categorization-rules/apply` then re-fetch the txn list).
- Refactor: moved `RuleFormModal` from `pages/RulesPage.tsx` to `components/RuleFormModal.tsx` and extended its `defaults` prop to accept `pattern`, `match_type`, `category_id`, `priority`, `is_active`. `RulesPage` behavior unchanged.

Closes #93.

## Test plan
- [x] `pnpm lint` (clean)
- [x] `pnpm build` (clean)
- [ ] Manual browser smoke (not run — same caveat as #97; functional behavior covered by existing backend integration tests for the underlying endpoints).

🤖 Generated with [Claude Code](https://claude.com/claude-code)