### PR TITLE
feat(budgets): user-scoped CRUD + current-period spend (#101)

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -5,8 +5,10 @@ go 1.26.3
 require (
 	github.com/gin-gonic/gin v1.12.0
 	github.com/golang-migrate/migrate/v4 v4.19.1
+	github.com/jackc/pgx/v5 v5.6.0
 	github.com/joho/godotenv v1.5.1
 	github.com/lib/pq v1.10.9
+	github.com/plaid/plaid-go/v40 v40.1.0
 	github.com/shopspring/decimal v1.4.0
 	golang.org/x/crypto v0.48.0
 	gorm.io/driver/postgres v1.6.0
@@ -27,7 +29,6 @@ require (
 	github.com/goccy/go-yaml v1.19.2 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
-	github.com/jackc/pgx/v5 v5.6.0 // indirect
 	github.com/jackc/puddle/v2 v2.2.2 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect
@@ -38,7 +39,6 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
-	github.com/plaid/plaid-go/v40 v40.1.0 // indirect
 	github.com/quic-go/qpack v0.6.0 // indirect
 	github.com/quic-go/quic-go v0.59.0 // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect

--- a/backend/internal/handler/budget_handler.go
+++ b/backend/internal/handler/budget_handler.go
@@ -1,0 +1,151 @@
+package handler
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/shopspring/decimal"
+
+	"github.com/gregwym/offbook/backend/internal/service"
+	"github.com/gregwym/offbook/backend/internal/service/auth"
+)
+
+type BudgetHandler struct {
+	svc *service.BudgetService
+}
+
+func NewBudgetHandler(s *service.BudgetService) *BudgetHandler {
+	return &BudgetHandler{svc: s}
+}
+
+func (h *BudgetHandler) Register(g *gin.RouterGroup) {
+	g.POST("/budgets", h.Create)
+	g.GET("/budgets", h.List)
+	g.GET("/budgets/:id", h.Get)
+	g.GET("/budgets/:id/spend", h.Spend)
+	g.PATCH("/budgets/:id", h.Update)
+	g.DELETE("/budgets/:id", h.Delete)
+}
+
+type createBudgetRequest struct {
+	CategoryID int64           `json:"category_id"`
+	Period     string          `json:"period"`
+	Amount     decimal.Decimal `json:"amount"`
+	Rollover   *bool           `json:"rollover"`
+	IsActive   *bool           `json:"is_active"`
+}
+
+func (h *BudgetHandler) Create(c *gin.Context) {
+	var req createBudgetRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error(), "code": "INVALID_REQUEST"})
+		return
+	}
+	b, err := h.svc.Create(c.Request.Context(), auth.MustUserID(c.Request.Context()), service.CreateBudgetInput{
+		CategoryID: req.CategoryID,
+		Period:     req.Period,
+		Amount:     req.Amount,
+		Rollover:   req.Rollover,
+		IsActive:   req.IsActive,
+	})
+	if err != nil {
+		h.writeServiceError(c, err)
+		return
+	}
+	c.JSON(http.StatusCreated, gin.H{"data": b})
+}
+
+func (h *BudgetHandler) Get(c *gin.Context) {
+	id, ok := parseID(c)
+	if !ok {
+		return
+	}
+	b, err := h.svc.Get(c.Request.Context(), auth.MustUserID(c.Request.Context()), id)
+	if err != nil {
+		h.writeServiceError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"data": b})
+}
+
+func (h *BudgetHandler) List(c *gin.Context) {
+	items, err := h.svc.List(c.Request.Context(), auth.MustUserID(c.Request.Context()))
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error(), "code": "INTERNAL"})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"data": items, "total": int64(len(items))})
+}
+
+type updateBudgetRequest struct {
+	CategoryID *int64           `json:"category_id"`
+	Period     *string          `json:"period"`
+	Amount     *decimal.Decimal `json:"amount"`
+	Rollover   *bool            `json:"rollover"`
+	IsActive   *bool            `json:"is_active"`
+}
+
+func (h *BudgetHandler) Update(c *gin.Context) {
+	id, ok := parseID(c)
+	if !ok {
+		return
+	}
+	var req updateBudgetRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error(), "code": "INVALID_REQUEST"})
+		return
+	}
+	b, err := h.svc.Update(c.Request.Context(), auth.MustUserID(c.Request.Context()), id, service.UpdateBudgetInput(req))
+	if err != nil {
+		h.writeServiceError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"data": b})
+}
+
+func (h *BudgetHandler) Delete(c *gin.Context) {
+	id, ok := parseID(c)
+	if !ok {
+		return
+	}
+	if err := h.svc.SoftDelete(c.Request.Context(), auth.MustUserID(c.Request.Context()), id); err != nil {
+		h.writeServiceError(c, err)
+		return
+	}
+	c.Status(http.StatusNoContent)
+}
+
+func (h *BudgetHandler) Spend(c *gin.Context) {
+	id, ok := parseID(c)
+	if !ok {
+		return
+	}
+	view, err := h.svc.Spend(c.Request.Context(), auth.MustUserID(c.Request.Context()), id)
+	if err != nil {
+		h.writeServiceError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"data": view})
+}
+
+func (h *BudgetHandler) writeServiceError(c *gin.Context, err error) {
+	switch {
+	case errors.Is(err, service.ErrBudgetNotFound):
+		c.JSON(http.StatusNotFound, gin.H{"error": err.Error(), "code": "BUDGET_NOT_FOUND"})
+	case errors.Is(err, service.ErrDuplicateActiveBudget):
+		c.JSON(http.StatusConflict, gin.H{"error": err.Error(), "code": "DUPLICATE_ACTIVE_BUDGET"})
+	case errors.Is(err, service.ErrUnknownCategory):
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error(), "code": "UNKNOWN_CATEGORY"})
+	case errors.Is(err, service.ErrInvalidBudgetPeriod):
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error":   err.Error(),
+			"code":    "INVALID_PERIOD",
+			"allowed": []string{service.BudgetPeriodMonthly, service.BudgetPeriodWeekly, service.BudgetPeriodAnnual},
+		})
+	case errors.Is(err, service.ErrInvalidBudgetAmount):
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error(), "code": "INVALID_BUDGET_AMOUNT"})
+	default:
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error(), "code": "INTERNAL"})
+	}
+}

--- a/backend/internal/repository/budget_repo.go
+++ b/backend/internal/repository/budget_repo.go
@@ -1,0 +1,116 @@
+package repository
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/shopspring/decimal"
+	"gorm.io/gorm"
+
+	"github.com/gregwym/offbook/backend/internal/model"
+)
+
+// BudgetRepository is the data-access contract for budgets. All read/write
+// paths are scoped by user_id — budgets are user-private and never shared
+// across tenants. Cross-household sharing lives in the separate
+// `shared_budgets` table (deferred to M8).
+type BudgetRepository interface {
+	Create(ctx context.Context, b *model.Budget) error
+	GetByID(ctx context.Context, userID, id int64) (*model.Budget, error)
+	List(ctx context.Context, userID int64) ([]model.Budget, error)
+	Update(ctx context.Context, b *model.Budget) error
+	SoftDelete(ctx context.Context, userID, id int64) error
+	// CurrentPeriodSpend returns the sum of -amount (i.e. positive spending)
+	// over [from, to) for transactions matching (userID, categoryID). Outflows
+	// only: amount < 0 in the codebase's sign convention. Returns 0 (not an
+	// error) when no transactions match.
+	CurrentPeriodSpend(ctx context.Context, userID, categoryID int64, from, to time.Time) (decimal.Decimal, error)
+}
+
+type budgetRepo struct {
+	db *gorm.DB
+}
+
+func NewBudgetRepository(db *gorm.DB) BudgetRepository {
+	return &budgetRepo{db: db}
+}
+
+func (r *budgetRepo) Create(ctx context.Context, b *model.Budget) error {
+	return r.db.WithContext(ctx).Create(b).Error
+}
+
+func (r *budgetRepo) GetByID(ctx context.Context, userID, id int64) (*model.Budget, error) {
+	var b model.Budget
+	if err := r.db.WithContext(ctx).
+		Where("user_id = ?", userID).
+		First(&b, id).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, ErrNotFound
+		}
+		return nil, err
+	}
+	return &b, nil
+}
+
+func (r *budgetRepo) List(ctx context.Context, userID int64) ([]model.Budget, error) {
+	var out []model.Budget
+	if err := r.db.WithContext(ctx).
+		Where("user_id = ?", userID).
+		Order("is_active DESC, id ASC").
+		Find(&out).Error; err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (r *budgetRepo) Update(ctx context.Context, b *model.Budget) error {
+	res := r.db.WithContext(ctx).
+		Where("user_id = ?", b.UserID).
+		Save(b)
+	if res.Error != nil {
+		return res.Error
+	}
+	if res.RowsAffected == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+func (r *budgetRepo) SoftDelete(ctx context.Context, userID, id int64) error {
+	res := r.db.WithContext(ctx).
+		Where("user_id = ?", userID).
+		Delete(&model.Budget{}, id)
+	if res.Error != nil {
+		return res.Error
+	}
+	if res.RowsAffected == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+func (r *budgetRepo) CurrentPeriodSpend(ctx context.Context, userID, categoryID int64, from, to time.Time) (decimal.Decimal, error) {
+	// Sign convention: outflows are negative; we want a positive "spent"
+	// total. SUM(-amount) FILTER (amount < 0) mirrors dashboard_repo.
+	// Transfers are excluded so internal moves don't count as spend.
+	var s string
+	err := r.db.WithContext(ctx).Raw(`
+		SELECT COALESCE(SUM(-amount) FILTER (WHERE amount < 0), 0)::text
+		FROM transactions
+		WHERE deleted_at IS NULL
+		  AND user_id = ?
+		  AND category_id = ?
+		  AND is_transfer = FALSE
+		  AND transaction_date >= ?
+		  AND transaction_date <  ?
+	`, userID, categoryID, from, to).Scan(&s).Error
+	if err != nil {
+		return decimal.Zero, err
+	}
+	d, err := decimal.NewFromString(s)
+	if err != nil {
+		return decimal.Zero, err
+	}
+	return d, nil
+}

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -58,6 +58,10 @@ func New(cfg config.Config, gormDB *gorm.DB) *gin.Engine {
 	dashboardSvc := service.NewDashboardService(dashboardRepo)
 	dashboardHandler := handler.NewDashboardHandler(dashboardSvc)
 
+	budgetRepo := repository.NewBudgetRepository(gormDB)
+	budgetSvc := service.NewBudgetService(budgetRepo, categoryRepo)
+	budgetHandler := handler.NewBudgetHandler(budgetSvc)
+
 	householdRepo := repository.NewHouseholdRepository(gormDB)
 	memberRepo := repository.NewHouseholdMemberRepository(gormDB)
 	userRepo := repository.NewUserRepository(gormDB)
@@ -106,6 +110,7 @@ func New(cfg config.Config, gormDB *gorm.DB) *gin.Engine {
 		categoryHandler.Register(secured)
 		ruleHandler.Register(secured)
 		dashboardHandler.Register(secured)
+		budgetHandler.Register(secured)
 		householdHandler.Register(secured)
 		aggregatorHandler.Register(secured)
 		scopeHandler.Register(secured)

--- a/backend/internal/service/budget_service.go
+++ b/backend/internal/service/budget_service.go
@@ -1,0 +1,263 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/shopspring/decimal"
+
+	"github.com/gregwym/offbook/backend/internal/model"
+	"github.com/gregwym/offbook/backend/internal/repository"
+)
+
+// Period names mirror the CHECK constraint on budgets.period (migration
+// 000001). Keep these in sync if the schema changes.
+const (
+	BudgetPeriodMonthly = "monthly"
+	BudgetPeriodWeekly  = "weekly"
+	BudgetPeriodAnnual  = "annual"
+)
+
+var validBudgetPeriods = map[string]struct{}{
+	BudgetPeriodMonthly: {},
+	BudgetPeriodWeekly:  {},
+	BudgetPeriodAnnual:  {},
+}
+
+var (
+	ErrBudgetNotFound        = errors.New("budget not found")
+	ErrInvalidBudgetPeriod   = errors.New("period must be one of: monthly, weekly, annual")
+	ErrInvalidBudgetAmount   = errors.New("amount must be > 0")
+	ErrDuplicateActiveBudget = errors.New("an active budget already exists for this user, category, and period")
+)
+
+// CreateBudgetInput is the validated payload for budget creation.
+type CreateBudgetInput struct {
+	CategoryID int64
+	Period     string
+	Amount     decimal.Decimal
+	Rollover   *bool
+	IsActive   *bool
+}
+
+// UpdateBudgetInput is a sparse patch.
+type UpdateBudgetInput struct {
+	CategoryID *int64
+	Period     *string
+	Amount     *decimal.Decimal
+	Rollover   *bool
+	IsActive   *bool
+}
+
+// BudgetSpend is the computed view of a budget against the current period's
+// transactions. Spent is a positive decimal (the codebase's sign convention
+// stores outflows as negative amounts; we flip the sign at the boundary).
+type BudgetSpend struct {
+	BudgetID    int64           `json:"budget_id"`
+	CategoryID  int64           `json:"category_id"`
+	Period      string          `json:"period"`
+	PeriodStart time.Time       `json:"period_start"`
+	PeriodEnd   time.Time       `json:"period_end"` // exclusive
+	Limit       decimal.Decimal `json:"limit"`
+	Spent       decimal.Decimal `json:"spent"`
+	Remaining   decimal.Decimal `json:"remaining"`
+	Pct         float64         `json:"pct"` // 0.0 — 1.0+ (uncapped; can exceed 1 when over budget)
+}
+
+// BudgetService owns budget validation, CRUD, and current-period spend
+// calculation. now() is injectable so tests can drive period boundaries
+// deterministically.
+type BudgetService struct {
+	repo    repository.BudgetRepository
+	catRepo repository.CategoryRepository
+	now     func() time.Time
+}
+
+func NewBudgetService(repo repository.BudgetRepository, catRepo repository.CategoryRepository) *BudgetService {
+	return &BudgetService{repo: repo, catRepo: catRepo, now: time.Now}
+}
+
+// WithNow overrides the clock for tests. Returns the receiver for chaining.
+func (s *BudgetService) WithNow(now func() time.Time) *BudgetService {
+	s.now = now
+	return s
+}
+
+func (s *BudgetService) Create(ctx context.Context, userID int64, in CreateBudgetInput) (*model.Budget, error) {
+	period := strings.TrimSpace(in.Period)
+	if _, ok := validBudgetPeriods[period]; !ok {
+		return nil, ErrInvalidBudgetPeriod
+	}
+	if !in.Amount.IsPositive() {
+		return nil, ErrInvalidBudgetAmount
+	}
+	if _, err := s.catRepo.GetByID(ctx, in.CategoryID); err != nil {
+		if errors.Is(err, repository.ErrNotFound) {
+			return nil, ErrUnknownCategory
+		}
+		return nil, err
+	}
+	b := &model.Budget{
+		UserID:     userID,
+		CategoryID: in.CategoryID,
+		Period:     period,
+		Amount:     in.Amount,
+		Rollover:   in.Rollover != nil && *in.Rollover,
+		IsActive:   true,
+	}
+	if in.IsActive != nil {
+		b.IsActive = *in.IsActive
+	}
+	if err := s.repo.Create(ctx, b); err != nil {
+		if isUniqueViolation(err) {
+			return nil, ErrDuplicateActiveBudget
+		}
+		return nil, fmt.Errorf("create budget: %w", err)
+	}
+	return b, nil
+}
+
+func (s *BudgetService) Get(ctx context.Context, userID, id int64) (*model.Budget, error) {
+	b, err := s.repo.GetByID(ctx, userID, id)
+	if err != nil {
+		if errors.Is(err, repository.ErrNotFound) {
+			return nil, ErrBudgetNotFound
+		}
+		return nil, err
+	}
+	return b, nil
+}
+
+func (s *BudgetService) List(ctx context.Context, userID int64) ([]model.Budget, error) {
+	return s.repo.List(ctx, userID)
+}
+
+func (s *BudgetService) Update(ctx context.Context, userID, id int64, in UpdateBudgetInput) (*model.Budget, error) {
+	b, err := s.repo.GetByID(ctx, userID, id)
+	if err != nil {
+		if errors.Is(err, repository.ErrNotFound) {
+			return nil, ErrBudgetNotFound
+		}
+		return nil, err
+	}
+	if in.CategoryID != nil {
+		if _, err := s.catRepo.GetByID(ctx, *in.CategoryID); err != nil {
+			if errors.Is(err, repository.ErrNotFound) {
+				return nil, ErrUnknownCategory
+			}
+			return nil, err
+		}
+		b.CategoryID = *in.CategoryID
+	}
+	if in.Period != nil {
+		p := strings.TrimSpace(*in.Period)
+		if _, ok := validBudgetPeriods[p]; !ok {
+			return nil, ErrInvalidBudgetPeriod
+		}
+		b.Period = p
+	}
+	if in.Amount != nil {
+		if !in.Amount.IsPositive() {
+			return nil, ErrInvalidBudgetAmount
+		}
+		b.Amount = *in.Amount
+	}
+	if in.Rollover != nil {
+		b.Rollover = *in.Rollover
+	}
+	if in.IsActive != nil {
+		b.IsActive = *in.IsActive
+	}
+	if err := s.repo.Update(ctx, b); err != nil {
+		if errors.Is(err, repository.ErrNotFound) {
+			return nil, ErrBudgetNotFound
+		}
+		if isUniqueViolation(err) {
+			return nil, ErrDuplicateActiveBudget
+		}
+		return nil, fmt.Errorf("update budget: %w", err)
+	}
+	return b, nil
+}
+
+func (s *BudgetService) SoftDelete(ctx context.Context, userID, id int64) error {
+	if err := s.repo.SoftDelete(ctx, userID, id); err != nil {
+		if errors.Is(err, repository.ErrNotFound) {
+			return ErrBudgetNotFound
+		}
+		return fmt.Errorf("soft delete budget: %w", err)
+	}
+	return nil
+}
+
+// Spend returns the current-period spend view for a budget. The period
+// window depends on the budget's `period` field; see budgetPeriodWindow.
+func (s *BudgetService) Spend(ctx context.Context, userID, id int64) (*BudgetSpend, error) {
+	b, err := s.Get(ctx, userID, id)
+	if err != nil {
+		return nil, err
+	}
+	from, to := budgetPeriodWindow(b.Period, s.now())
+	spent, err := s.repo.CurrentPeriodSpend(ctx, userID, b.CategoryID, from, to)
+	if err != nil {
+		return nil, fmt.Errorf("compute spend: %w", err)
+	}
+	remaining := b.Amount.Sub(spent)
+	pct := 0.0
+	if b.Amount.IsPositive() {
+		p, _ := spent.Div(b.Amount).Float64()
+		pct = p
+	}
+	return &BudgetSpend{
+		BudgetID:    b.ID,
+		CategoryID:  b.CategoryID,
+		Period:      b.Period,
+		PeriodStart: from,
+		PeriodEnd:   to,
+		Limit:       b.Amount,
+		Spent:       spent,
+		Remaining:   remaining,
+		Pct:         pct,
+	}, nil
+}
+
+// budgetPeriodWindow returns [from, to) for the budget's current period
+// relative to `now`. UTC throughout — budgets are user-private and a
+// stable definition beats per-user time-zone gymnastics.
+//
+//	monthly: first → first of next month
+//	weekly:  ISO week (Monday-start) → Monday of the following week
+//	annual:  Jan 1 → Jan 1 of next year
+func budgetPeriodWindow(period string, now time.Time) (time.Time, time.Time) {
+	now = now.UTC()
+	switch period {
+	case BudgetPeriodWeekly:
+		// Monday-start ISO week. Go's Weekday returns Sunday=0..Saturday=6;
+		// shift so Monday=0..Sunday=6.
+		wd := int(now.Weekday()+6) % 7
+		monday := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC).AddDate(0, 0, -wd)
+		return monday, monday.AddDate(0, 0, 7)
+	case BudgetPeriodAnnual:
+		from := time.Date(now.Year(), time.January, 1, 0, 0, 0, 0, time.UTC)
+		return from, from.AddDate(1, 0, 0)
+	default: // monthly (and any unknown value — caller should have validated)
+		from := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC)
+		return from, from.AddDate(0, 1, 0)
+	}
+}
+
+// isUniqueViolation matches the Postgres "unique_violation" SQLSTATE 23505
+// — the only path the budgets repo can hit it on is the partial unique
+// index on (user_id, category_id, period) WHERE deleted_at IS NULL AND
+// is_active = TRUE (migration 000001).
+func isUniqueViolation(err error) bool {
+	var pgErr *pgconn.PgError
+	if errors.As(err, &pgErr) {
+		return pgErr.Code == "23505"
+	}
+	return false
+}

--- a/backend/internal/service/budget_service_test.go
+++ b/backend/internal/service/budget_service_test.go
@@ -1,0 +1,376 @@
+package service_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/shopspring/decimal"
+	"gorm.io/gorm"
+
+	"github.com/gregwym/offbook/backend/internal/model"
+	"github.com/gregwym/offbook/backend/internal/repository"
+	"github.com/gregwym/offbook/backend/internal/service"
+)
+
+// newBudgetSvc returns a real BudgetService + a seeded user + a fixture
+// category. The clock is fixed to 2026-05-15 12:00 UTC so period tests are
+// deterministic.
+func newBudgetSvc(t *testing.T) (svc *service.BudgetService, userID, categoryID int64, g *gorm.DB) {
+	t.Helper()
+	g = openTestDB(t)
+	userID = seedTestUser(t, g)
+
+	suffix := time.Now().Format("150405.000000")
+	cat := &model.Category{
+		Name:     "BudgetFixture",
+		Slug:     "budget-fixture-" + suffix,
+		IsSystem: false,
+	}
+	if err := g.Create(cat).Error; err != nil {
+		t.Fatalf("seed category: %v", err)
+	}
+	t.Cleanup(func() {
+		g.Unscoped().Where("user_id = ?", userID).Delete(&model.Budget{})
+		g.Unscoped().Delete(&model.Category{}, cat.ID)
+	})
+
+	svc = service.NewBudgetService(
+		repository.NewBudgetRepository(g),
+		repository.NewCategoryRepository(g),
+	).WithNow(func() time.Time {
+		return time.Date(2026, 5, 15, 12, 0, 0, 0, time.UTC)
+	})
+	return svc, userID, cat.ID, g
+}
+
+func TestBudgetService_Create_Validation(t *testing.T) {
+	svc, userID, categoryID, _ := newBudgetSvc(t)
+	ctx := context.Background()
+
+	cases := []struct {
+		name    string
+		in      service.CreateBudgetInput
+		wantErr error
+	}{
+		{
+			"valid monthly",
+			service.CreateBudgetInput{CategoryID: categoryID, Period: "monthly", Amount: decimal.NewFromInt(700)},
+			nil,
+		},
+		{
+			"bad period",
+			service.CreateBudgetInput{CategoryID: categoryID, Period: "biweekly", Amount: decimal.NewFromInt(700)},
+			service.ErrInvalidBudgetPeriod,
+		},
+		{
+			"zero amount",
+			service.CreateBudgetInput{CategoryID: categoryID, Period: "monthly", Amount: decimal.Zero},
+			service.ErrInvalidBudgetAmount,
+		},
+		{
+			"negative amount",
+			service.CreateBudgetInput{CategoryID: categoryID, Period: "monthly", Amount: decimal.NewFromInt(-1)},
+			service.ErrInvalidBudgetAmount,
+		},
+		{
+			"unknown category",
+			service.CreateBudgetInput{CategoryID: 9_999_999, Period: "monthly", Amount: decimal.NewFromInt(100)},
+			service.ErrUnknownCategory,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			b, err := svc.Create(ctx, userID, tc.in)
+			if tc.wantErr != nil {
+				if !errors.Is(err, tc.wantErr) {
+					t.Errorf("err = %v, want %v", err, tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected err: %v", err)
+			}
+			if b == nil || b.ID == 0 {
+				t.Fatalf("got %+v, want created budget", b)
+			}
+			t.Cleanup(func() { _ = svc.SoftDelete(ctx, userID, b.ID) })
+		})
+	}
+}
+
+// TestBudgetService_Create_DuplicateActiveConflicts: the partial unique
+// index on (user_id, category_id, period) WHERE deleted_at IS NULL AND
+// is_active = TRUE must surface as ErrDuplicateActiveBudget.
+func TestBudgetService_Create_DuplicateActiveConflicts(t *testing.T) {
+	svc, userID, categoryID, _ := newBudgetSvc(t)
+	ctx := context.Background()
+
+	first, err := svc.Create(ctx, userID, service.CreateBudgetInput{
+		CategoryID: categoryID, Period: "monthly", Amount: decimal.NewFromInt(500),
+	})
+	if err != nil {
+		t.Fatalf("first create: %v", err)
+	}
+	t.Cleanup(func() { _ = svc.SoftDelete(ctx, userID, first.ID) })
+
+	_, err = svc.Create(ctx, userID, service.CreateBudgetInput{
+		CategoryID: categoryID, Period: "monthly", Amount: decimal.NewFromInt(900),
+	})
+	if !errors.Is(err, service.ErrDuplicateActiveBudget) {
+		t.Errorf("duplicate err = %v, want ErrDuplicateActiveBudget", err)
+	}
+}
+
+// TestBudgetService_TenantIsolation: user B cannot read, update, or delete
+// user A's budget.
+func TestBudgetService_TenantIsolation(t *testing.T) {
+	svc, userA, categoryID, g := newBudgetSvc(t)
+	ctx := context.Background()
+
+	b, err := svc.Create(ctx, userA, service.CreateBudgetInput{
+		CategoryID: categoryID, Period: "monthly", Amount: decimal.NewFromInt(300),
+	})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	t.Cleanup(func() { _ = svc.SoftDelete(ctx, userA, b.ID) })
+
+	userB := seedTestUser(t, g)
+	if _, err := svc.Get(ctx, userB, b.ID); !errors.Is(err, service.ErrBudgetNotFound) {
+		t.Errorf("cross-tenant Get err = %v, want ErrBudgetNotFound", err)
+	}
+	if err := svc.SoftDelete(ctx, userB, b.ID); !errors.Is(err, service.ErrBudgetNotFound) {
+		t.Errorf("cross-tenant SoftDelete err = %v, want ErrBudgetNotFound", err)
+	}
+	newAmt := decimal.NewFromInt(1)
+	if _, err := svc.Update(ctx, userB, b.ID, service.UpdateBudgetInput{Amount: &newAmt}); !errors.Is(err, service.ErrBudgetNotFound) {
+		t.Errorf("cross-tenant Update err = %v, want ErrBudgetNotFound", err)
+	}
+}
+
+// TestBudgetService_Spend_PeriodBoundary: a transaction on the LAST day of
+// April is NOT counted in May's monthly period. A May 1 transaction IS.
+// Verifies the [from, to) window covers the right rows.
+func TestBudgetService_Spend_PeriodBoundary(t *testing.T) {
+	svc, userID, categoryID, g := newBudgetSvc(t)
+	ctx := context.Background()
+
+	suffix := time.Now().Format("150405.000000")
+	acc := &model.Account{
+		UserID: userID, Name: "BudgetSpend-" + suffix, InstitutionSlug: "fixture",
+		AccountType: "checking", Currency: "USD",
+	}
+	if err := g.Create(acc).Error; err != nil {
+		t.Fatalf("seed account: %v", err)
+	}
+	t.Cleanup(func() {
+		g.Unscoped().Where("account_id = ?", acc.ID).Delete(&model.Transaction{})
+		g.Unscoped().Delete(&model.Account{}, acc.ID)
+	})
+
+	mkSpend := func(date time.Time, amt decimal.Decimal) {
+		cat := categoryID
+		tx := &model.Transaction{
+			UserID:          userID,
+			AccountID:       acc.ID,
+			CategoryID:      &cat,
+			Amount:          amt,
+			Currency:        "USD",
+			TransactionDate: date,
+			Source:          "manual",
+		}
+		if err := g.Create(tx).Error; err != nil {
+			t.Fatalf("seed txn: %v", err)
+		}
+	}
+	// Clock fixed at 2026-05-15 → monthly window = [May 1, Jun 1).
+	mkSpend(time.Date(2026, 4, 30, 0, 0, 0, 0, time.UTC), decimal.NewFromInt(-100)) // out of period
+	mkSpend(time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC), decimal.NewFromInt(-50))   // in period
+	mkSpend(time.Date(2026, 5, 14, 0, 0, 0, 0, time.UTC), decimal.NewFromInt(-25))  // in period
+	mkSpend(time.Date(2026, 5, 14, 0, 0, 0, 0, time.UTC), decimal.NewFromInt(200))  // inflow — not spend
+	mkSpend(time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC), decimal.NewFromInt(-999))  // out of period
+
+	b, err := svc.Create(ctx, userID, service.CreateBudgetInput{
+		CategoryID: categoryID, Period: "monthly", Amount: decimal.NewFromInt(700),
+	})
+	if err != nil {
+		t.Fatalf("create budget: %v", err)
+	}
+	t.Cleanup(func() { _ = svc.SoftDelete(ctx, userID, b.ID) })
+
+	view, err := svc.Spend(ctx, userID, b.ID)
+	if err != nil {
+		t.Fatalf("spend: %v", err)
+	}
+	want := decimal.NewFromInt(75) // 50 + 25
+	if !view.Spent.Equal(want) {
+		t.Errorf("Spent = %s, want %s", view.Spent, want)
+	}
+	if !view.Limit.Equal(decimal.NewFromInt(700)) {
+		t.Errorf("Limit = %s, want 700", view.Limit)
+	}
+	if !view.Remaining.Equal(decimal.NewFromInt(625)) {
+		t.Errorf("Remaining = %s, want 625", view.Remaining)
+	}
+	if view.PeriodStart != (time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)) {
+		t.Errorf("PeriodStart = %v, want 2026-05-01", view.PeriodStart)
+	}
+	if view.PeriodEnd != (time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)) {
+		t.Errorf("PeriodEnd = %v, want 2026-06-01", view.PeriodEnd)
+	}
+	// 75/700 ≈ 0.107
+	if view.Pct < 0.1 || view.Pct > 0.12 {
+		t.Errorf("Pct = %v, want ≈0.107", view.Pct)
+	}
+}
+
+// TestBudgetService_Spend_TransfersExcluded: is_transfer=true rows are NOT
+// counted toward spend (internal moves shouldn't pop a budget).
+func TestBudgetService_Spend_TransfersExcluded(t *testing.T) {
+	svc, userID, categoryID, g := newBudgetSvc(t)
+	ctx := context.Background()
+
+	acc := &model.Account{
+		UserID: userID, Name: "BTransfer", InstitutionSlug: "fixture",
+		AccountType: "checking", Currency: "USD",
+	}
+	if err := g.Create(acc).Error; err != nil {
+		t.Fatalf("seed account: %v", err)
+	}
+	t.Cleanup(func() {
+		g.Unscoped().Where("account_id = ?", acc.ID).Delete(&model.Transaction{})
+		g.Unscoped().Delete(&model.Account{}, acc.ID)
+	})
+	cat := categoryID
+	if err := g.Create(&model.Transaction{
+		UserID: userID, AccountID: acc.ID, CategoryID: &cat,
+		Amount: decimal.NewFromInt(-200), Currency: "USD",
+		TransactionDate: time.Date(2026, 5, 10, 0, 0, 0, 0, time.UTC),
+		Source:          "manual",
+		IsTransfer:      true,
+	}).Error; err != nil {
+		t.Fatalf("seed transfer: %v", err)
+	}
+	if err := g.Create(&model.Transaction{
+		UserID: userID, AccountID: acc.ID, CategoryID: &cat,
+		Amount: decimal.NewFromInt(-30), Currency: "USD",
+		TransactionDate: time.Date(2026, 5, 10, 0, 0, 0, 0, time.UTC),
+		Source:          "manual",
+	}).Error; err != nil {
+		t.Fatalf("seed spend: %v", err)
+	}
+
+	b, err := svc.Create(ctx, userID, service.CreateBudgetInput{
+		CategoryID: categoryID, Period: "monthly", Amount: decimal.NewFromInt(100),
+	})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	t.Cleanup(func() { _ = svc.SoftDelete(ctx, userID, b.ID) })
+
+	view, err := svc.Spend(ctx, userID, b.ID)
+	if err != nil {
+		t.Fatalf("spend: %v", err)
+	}
+	if !view.Spent.Equal(decimal.NewFromInt(30)) {
+		t.Errorf("Spent = %s, want 30 (transfer must be excluded)", view.Spent)
+	}
+}
+
+// TestBudgetService_Spend_OnlyOwnUserCounted: user B's spending in the same
+// category does NOT count against user A's budget.
+func TestBudgetService_Spend_OnlyOwnUserCounted(t *testing.T) {
+	svc, userA, categoryID, g := newBudgetSvc(t)
+	ctx := context.Background()
+
+	userB := seedTestUser(t, g)
+	accB := &model.Account{
+		UserID: userB, Name: "BAcct", InstitutionSlug: "fixture",
+		AccountType: "checking", Currency: "USD",
+	}
+	if err := g.Create(accB).Error; err != nil {
+		t.Fatalf("seed account B: %v", err)
+	}
+	t.Cleanup(func() {
+		g.Unscoped().Where("account_id = ?", accB.ID).Delete(&model.Transaction{})
+		g.Unscoped().Delete(&model.Account{}, accB.ID)
+	})
+	cat := categoryID
+	if err := g.Create(&model.Transaction{
+		UserID: userB, AccountID: accB.ID, CategoryID: &cat,
+		Amount: decimal.NewFromInt(-9999), Currency: "USD",
+		TransactionDate: time.Date(2026, 5, 10, 0, 0, 0, 0, time.UTC),
+		Source:          "manual",
+	}).Error; err != nil {
+		t.Fatalf("seed B txn: %v", err)
+	}
+
+	b, err := svc.Create(ctx, userA, service.CreateBudgetInput{
+		CategoryID: categoryID, Period: "monthly", Amount: decimal.NewFromInt(100),
+	})
+	if err != nil {
+		t.Fatalf("create budget: %v", err)
+	}
+	t.Cleanup(func() { _ = svc.SoftDelete(ctx, userA, b.ID) })
+
+	view, err := svc.Spend(ctx, userA, b.ID)
+	if err != nil {
+		t.Fatalf("spend: %v", err)
+	}
+	if !view.Spent.IsZero() {
+		t.Errorf("Spent = %s, want 0 (user B's spend must not count)", view.Spent)
+	}
+}
+
+// TestBudgetService_PeriodWindow_Weekly checks Monday-start ISO weeks.
+func TestBudgetService_Spend_WeeklyMondayStart(t *testing.T) {
+	svc, userID, categoryID, g := newBudgetSvc(t)
+	ctx := context.Background()
+	// Clock is 2026-05-15 12:00 UTC = Friday. Weekly window = Mon May 11
+	// → Mon May 18.
+
+	acc := &model.Account{
+		UserID: userID, Name: "WeeklyAcct", InstitutionSlug: "fixture",
+		AccountType: "checking", Currency: "USD",
+	}
+	if err := g.Create(acc).Error; err != nil {
+		t.Fatalf("seed account: %v", err)
+	}
+	t.Cleanup(func() {
+		g.Unscoped().Where("account_id = ?", acc.ID).Delete(&model.Transaction{})
+		g.Unscoped().Delete(&model.Account{}, acc.ID)
+	})
+
+	cat := categoryID
+	mk := func(d time.Time, amt decimal.Decimal) {
+		if err := g.Create(&model.Transaction{
+			UserID: userID, AccountID: acc.ID, CategoryID: &cat,
+			Amount: amt, Currency: "USD",
+			TransactionDate: d, Source: "manual",
+		}).Error; err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+	}
+	mk(time.Date(2026, 5, 10, 0, 0, 0, 0, time.UTC), decimal.NewFromInt(-1000)) // Sunday May 10 — prior week
+	mk(time.Date(2026, 5, 11, 0, 0, 0, 0, time.UTC), decimal.NewFromInt(-20))   // Monday May 11 — in week
+	mk(time.Date(2026, 5, 17, 0, 0, 0, 0, time.UTC), decimal.NewFromInt(-30))   // Sunday May 17 — in week
+	mk(time.Date(2026, 5, 18, 0, 0, 0, 0, time.UTC), decimal.NewFromInt(-9999)) // Monday May 18 — next week
+
+	b, err := svc.Create(ctx, userID, service.CreateBudgetInput{
+		CategoryID: categoryID, Period: "weekly", Amount: decimal.NewFromInt(200),
+	})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	t.Cleanup(func() { _ = svc.SoftDelete(ctx, userID, b.ID) })
+
+	view, err := svc.Spend(ctx, userID, b.ID)
+	if err != nil {
+		t.Fatalf("spend: %v", err)
+	}
+	if !view.Spent.Equal(decimal.NewFromInt(50)) {
+		t.Errorf("Spent = %s, want 50 (20 + 30 within Mon-Sun window)", view.Spent)
+	}
+}


### PR DESCRIPTION
## Summary
- Full repo → service → handler stack for `/api/v1/budgets` (`POST/GET/PATCH/DELETE`) plus `GET /budgets/:id/spend`.
- Service validates amount > 0, period ∈ {monthly, weekly, annual}, category exists, no duplicate-active conflict on `(user, category, period)`. SQLSTATE 23505 from the partial unique index surfaces as `ErrDuplicateActiveBudget` → `409 / DUPLICATE_ACTIVE_BUDGET`.
- Period windows are UTC: monthly = first→first of next month; weekly = Monday-start ISO week; annual = Jan 1 → Jan 1.
- Spend math via shopspring/decimal end-to-end. Outflows returned positive. Transfers excluded.
- Clock is injectable via `BudgetService.WithNow` for deterministic tests.
- Tests (real Postgres): validation matrix, duplicate-active, tenant isolation, period-boundary (April 30 + June 1 excluded from May), transfers excluded, other-user spend excluded, weekly Monday-start.

Closes #101.

## Test plan
- [x] `go test ./... -race -p 1` (all green)
- [x] `go vet ./...` (clean)
- [ ] Manual smoke (deferred — covered by integration tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)