### PR TITLE
feat(dashboard): spend-by-category, cash flow, net worth charts (#105)

### DIFF
--- a/backend/internal/handler/dashboard_handler.go
+++ b/backend/internal/handler/dashboard_handler.go
@@ -3,6 +3,8 @@ package handler
 import (
 	"errors"
 	"net/http"
+	"strconv"
+	"time"
 
 	"github.com/gin-gonic/gin"
 
@@ -22,6 +24,82 @@ func NewDashboardHandler(s *service.DashboardService, b *service.BudgetService) 
 func (h *DashboardHandler) Register(g *gin.RouterGroup) {
 	g.GET("/dashboard/summary", h.Summary)
 	g.GET("/dashboard/budget-alerts", h.BudgetAlerts)
+	g.GET("/dashboard/spend-by-category", h.SpendByCategory)
+	g.GET("/dashboard/cash-flow", h.CashFlow)
+	g.GET("/dashboard/net-worth", h.NetWorth)
+}
+
+// SpendByCategory handles ?from=YYYY-MM-DD&to=YYYY-MM-DD. Either bound
+// can be omitted to default to the current calendar month.
+func (h *DashboardHandler) SpendByCategory(c *gin.Context) {
+	var from, to time.Time
+	if v := c.Query("from"); v != "" {
+		d, err := time.Parse("2006-01-02", v)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "from must be YYYY-MM-DD", "code": "INVALID_REQUEST"})
+			return
+		}
+		from = d
+	}
+	if v := c.Query("to"); v != "" {
+		d, err := time.Parse("2006-01-02", v)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "to must be YYYY-MM-DD", "code": "INVALID_REQUEST"})
+			return
+		}
+		to = d
+	}
+	items, err := h.svc.SpendByCategory(c.Request.Context(), auth.MustUserID(c.Request.Context()), from, to)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error(), "code": "INTERNAL"})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"data": items, "total": int64(len(items))})
+}
+
+// CashFlow handles ?months=12. Cap to a sane upper bound to keep the
+// query bounded.
+func (h *DashboardHandler) CashFlow(c *gin.Context) {
+	months := readMonthsParam(c, 12, 36)
+	if months < 0 {
+		return // handler already responded
+	}
+	items, err := h.svc.CashFlow(c.Request.Context(), auth.MustUserID(c.Request.Context()), months)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error(), "code": "INTERNAL"})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"data": items, "total": int64(len(items))})
+}
+
+// NetWorth handles ?months=12 (same cap as CashFlow).
+func (h *DashboardHandler) NetWorth(c *gin.Context) {
+	months := readMonthsParam(c, 12, 36)
+	if months < 0 {
+		return
+	}
+	items, err := h.svc.NetWorth(c.Request.Context(), auth.MustUserID(c.Request.Context()), months)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error(), "code": "INTERNAL"})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"data": items, "total": int64(len(items))})
+}
+
+func readMonthsParam(c *gin.Context, def, max int) int {
+	v := c.Query("months")
+	if v == "" {
+		return def
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil || n <= 0 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "months must be a positive integer", "code": "INVALID_REQUEST"})
+		return -1
+	}
+	if n > max {
+		n = max
+	}
+	return n
 }
 
 // BudgetAlerts returns the user's active budgets at ≥80% spend for the

--- a/backend/internal/repository/dashboard_repo.go
+++ b/backend/internal/repository/dashboard_repo.go
@@ -28,10 +28,51 @@ type CategoryAggregate struct {
 	Amount     decimal.Decimal
 }
 
+// CategorySpendItem is one row of the spend-by-category chart, enriched
+// with the category's color so the frontend pie slices stay consistent
+// with the budget bars.
+type CategorySpendItem struct {
+	CategoryID *int64
+	Name       string // "Uncategorized" when CategoryID is nil
+	Color      string // empty string when not set
+	Amount     decimal.Decimal
+}
+
+// CashFlowMonth is one row of the monthly cash-flow chart. Month is the
+// first-of-month timestamp (UTC). Inflow + Outflow are both positive;
+// Net = Inflow - Outflow.
+type CashFlowMonth struct {
+	Month   time.Time
+	Inflow  decimal.Decimal
+	Outflow decimal.Decimal
+	Net     decimal.Decimal
+}
+
+// NetWorthMonth is one row of the net-worth trend chart. Date is the
+// month-end day (e.g. 2026-05-31 for May 2026). Total is the
+// back-derived account-balance total at that point.
+type NetWorthMonth struct {
+	Date  time.Time
+	Total decimal.Decimal
+}
+
 // DashboardRepository runs the read-only aggregation queries that power the
 // dashboard. All queries are scoped to the requesting user_id.
 type DashboardRepository interface {
 	Summarize(ctx context.Context, userID int64, from, to time.Time) (*DashboardSummaryAggregates, error)
+	// SpendByCategory returns SUM(-amount) FILTER (amount < 0) grouped by
+	// category over [from, to). Outflows only — inflows excluded. Transfers
+	// excluded (internal moves are not spending). Ordered by amount DESC.
+	SpendByCategory(ctx context.Context, userID int64, from, to time.Time) ([]CategorySpendItem, error)
+	// CashFlowByMonth returns one row per month for the last `months`
+	// calendar months ending at the month containing `now`. Income/outflow
+	// are positive; transfers excluded.
+	CashFlowByMonth(ctx context.Context, userID int64, now time.Time, months int) ([]CashFlowMonth, error)
+	// NetWorthByMonth returns approximated month-end account totals for the
+	// last `months` months ending at `now`. The current month's row uses
+	// the current persisted balance; older months back-derive by undoing
+	// transactions between the row's month-end and now.
+	NetWorthByMonth(ctx context.Context, userID int64, now time.Time, months int) ([]NetWorthMonth, error)
 }
 
 type dashboardRepo struct {
@@ -133,5 +174,186 @@ func (r *dashboardRepo) Summarize(ctx context.Context, userID int64, from, to ti
 		})
 	}
 
+	return out, nil
+}
+
+// SpendByCategory: outflows only, transfers excluded, grouped + sorted.
+func (r *dashboardRepo) SpendByCategory(ctx context.Context, userID int64, from, to time.Time) ([]CategorySpendItem, error) {
+	type rawRow struct {
+		CategoryID *int64
+		Name       *string
+		Color      *string
+		Amount     string
+	}
+	var rows []rawRow
+	err := r.db.WithContext(ctx).Raw(`
+		SELECT
+			t.category_id                                       AS category_id,
+			c.name                                              AS name,
+			c.color                                             AS color,
+			COALESCE(SUM(-t.amount), 0)::text                    AS amount
+		FROM transactions t
+		LEFT JOIN categories c ON c.id = t.category_id
+		WHERE t.deleted_at IS NULL
+		  AND t.user_id = ?
+		  AND t.is_transfer = FALSE
+		  AND t.amount < 0
+		  AND t.transaction_date >= ?
+		  AND t.transaction_date <  ?
+		GROUP BY t.category_id, c.name, c.color
+		ORDER BY SUM(-t.amount) DESC
+	`, userID, from, to).Scan(&rows).Error
+	if err != nil {
+		return nil, err
+	}
+	out := make([]CategorySpendItem, 0, len(rows))
+	for _, row := range rows {
+		amt, _ := decimal.NewFromString(row.Amount)
+		name := "Uncategorized"
+		if row.Name != nil {
+			name = *row.Name
+		}
+		color := ""
+		if row.Color != nil {
+			color = *row.Color
+		}
+		out = append(out, CategorySpendItem{
+			CategoryID: row.CategoryID,
+			Name:       name,
+			Color:      color,
+			Amount:     amt,
+		})
+	}
+	return out, nil
+}
+
+// CashFlowByMonth: bucket transactions by month for the trailing `months`
+// calendar months. Inflow = SUM(amount) WHERE amount > 0; Outflow =
+// SUM(-amount) WHERE amount < 0; both positive. Transfers excluded.
+//
+// We pre-build the month skeleton in Go so empty months still appear with
+// zeros — a chart that drops a flat month is a UX regression.
+func (r *dashboardRepo) CashFlowByMonth(ctx context.Context, userID int64, now time.Time, months int) ([]CashFlowMonth, error) {
+	if months <= 0 {
+		months = 12
+	}
+	// First-of-current-month in UTC; window starts (months-1) months earlier.
+	now = now.UTC()
+	end := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC).AddDate(0, 1, 0)
+	start := end.AddDate(0, -months, 0)
+
+	type rawRow struct {
+		Month   time.Time
+		Inflow  string
+		Outflow string
+	}
+	var rows []rawRow
+	err := r.db.WithContext(ctx).Raw(`
+		SELECT
+			date_trunc('month', transaction_date)::timestamptz   AS month,
+			COALESCE(SUM(amount) FILTER (WHERE amount > 0), 0)::text   AS inflow,
+			COALESCE(SUM(-amount) FILTER (WHERE amount < 0), 0)::text  AS outflow
+		FROM transactions
+		WHERE deleted_at IS NULL
+		  AND user_id = ?
+		  AND is_transfer = FALSE
+		  AND transaction_date >= ?
+		  AND transaction_date <  ?
+		GROUP BY date_trunc('month', transaction_date)
+	`, userID, start, end).Scan(&rows).Error
+	if err != nil {
+		return nil, err
+	}
+	byMonth := make(map[time.Time]CashFlowMonth, len(rows))
+	for _, row := range rows {
+		in, _ := decimal.NewFromString(row.Inflow)
+		out, _ := decimal.NewFromString(row.Outflow)
+		byMonth[row.Month.UTC()] = CashFlowMonth{
+			Month: row.Month.UTC(), Inflow: in, Outflow: out, Net: in.Sub(out),
+		}
+	}
+	out := make([]CashFlowMonth, 0, months)
+	for i := 0; i < months; i++ {
+		m := start.AddDate(0, i, 0)
+		if r, ok := byMonth[m]; ok {
+			out = append(out, r)
+		} else {
+			out = append(out, CashFlowMonth{Month: m, Inflow: decimal.Zero, Outflow: decimal.Zero, Net: decimal.Zero})
+		}
+	}
+	return out, nil
+}
+
+// NetWorthByMonth approximates month-end balances by walking backwards
+// from the current persisted total. Methodology: today's net worth is the
+// sum of live accounts.balance. Subtract all transactions dated after
+// month-end to back-derive the balance at month-end.
+//
+// This is an approximation — non-transactional balance changes (manual
+// edits to accounts.balance, currency conversion gaps, etc.) won't be
+// reflected. Documented in the chart caption. A future enhancement could
+// snapshot daily balances; for M5 this gets us a trendline.
+func (r *dashboardRepo) NetWorthByMonth(ctx context.Context, userID int64, now time.Time, months int) ([]NetWorthMonth, error) {
+	if months <= 0 {
+		months = 12
+	}
+	now = now.UTC()
+	// Current net worth.
+	var cur string
+	if err := r.db.WithContext(ctx).Raw(`
+		SELECT COALESCE(SUM(balance), 0)::text
+		FROM accounts
+		WHERE deleted_at IS NULL
+		  AND user_id = ?
+	`, userID).Scan(&cur).Error; err != nil {
+		return nil, err
+	}
+	curD, _ := decimal.NewFromString(cur)
+
+	// Month boundaries: monthEnd[i] is the last day of the i-th month
+	// (oldest first). For "last 12 months ending now", the newest row is
+	// the current month-end (today's date capped at month-end).
+	startMonth := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC).AddDate(0, -months+1, 0)
+	out := make([]NetWorthMonth, 0, months)
+	for i := 0; i < months; i++ {
+		first := startMonth.AddDate(0, i, 0)
+		// Day before next month-first = month-end.
+		monthEnd := first.AddDate(0, 1, 0).AddDate(0, 0, -1)
+		out = append(out, NetWorthMonth{Date: monthEnd})
+	}
+
+	// For every month, sum transactions with transaction_date > monthEnd
+	// → those are the moves that happened between that point and now.
+	// Subtract from current total. We issue ONE query that fetches all
+	// transactions newer than the oldest month boundary, then bucket in Go.
+	type txRow struct {
+		Date   time.Time
+		Amount string
+	}
+	var txns []txRow
+	if err := r.db.WithContext(ctx).Raw(`
+		SELECT transaction_date AS date, amount::text AS amount
+		FROM transactions
+		WHERE deleted_at IS NULL
+		  AND user_id = ?
+		  AND transaction_date > ?
+	`, userID, out[0].Date).Scan(&txns).Error; err != nil {
+		return nil, err
+	}
+
+	// Compute cumulative "since" sum per boundary by sorting boundaries and
+	// transactions, walking through. For len(out) ≤ 24 a quadratic loop
+	// is fine; not bothering to optimize.
+	for i := range out {
+		boundary := out[i].Date
+		undo := decimal.Zero
+		for _, t := range txns {
+			if t.Date.UTC().After(boundary) {
+				amt, _ := decimal.NewFromString(t.Amount)
+				undo = undo.Add(amt)
+			}
+		}
+		out[i].Total = curD.Sub(undo)
+	}
 	return out, nil
 }

--- a/backend/internal/service/dashboard_charts_test.go
+++ b/backend/internal/service/dashboard_charts_test.go
@@ -1,0 +1,238 @@
+package service_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/shopspring/decimal"
+	"gorm.io/gorm"
+
+	"github.com/gregwym/offbook/backend/internal/model"
+	"github.com/gregwym/offbook/backend/internal/repository"
+	"github.com/gregwym/offbook/backend/internal/service"
+)
+
+func newDashboardSvc(t *testing.T) (svc *service.DashboardService, userID, accountID int64, g *gorm.DB) {
+	t.Helper()
+	g = openTestDB(t)
+	userID = seedTestUser(t, g)
+	acc := &model.Account{
+		UserID: userID, Name: "DashAcct-" + time.Now().Format("150405.000000"),
+		InstitutionSlug: "fixture", AccountType: "checking", Currency: "USD",
+		Balance: decimal.NewFromInt(0),
+	}
+	if err := g.Create(acc).Error; err != nil {
+		t.Fatalf("seed account: %v", err)
+	}
+	t.Cleanup(func() {
+		g.Unscoped().Where("account_id = ?", acc.ID).Delete(&model.Transaction{})
+		g.Unscoped().Delete(&model.Account{}, acc.ID)
+	})
+	svc = service.NewDashboardService(repository.NewDashboardRepository(g))
+	svc.SetClock(func() time.Time { return time.Date(2026, 5, 15, 12, 0, 0, 0, time.UTC) })
+	return svc, userID, acc.ID, g
+}
+
+func seedChartTxn(t *testing.T, g *gorm.DB, userID, accountID int64, categoryID *int64, date time.Time, amt decimal.Decimal, isTransfer bool) {
+	t.Helper()
+	tx := &model.Transaction{
+		UserID: userID, AccountID: accountID, CategoryID: categoryID,
+		Amount: amt, Currency: "USD",
+		TransactionDate: date, Source: "manual",
+		IsTransfer: isTransfer,
+	}
+	if err := g.Create(tx).Error; err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+}
+
+// TestDashboard_SpendByCategory_OutflowsOnlyAndTransfersExcluded.
+func TestDashboard_SpendByCategory_OutflowsOnlyAndTransfersExcluded(t *testing.T) {
+	svc, userID, accountID, g := newDashboardSvc(t)
+	ctx := context.Background()
+
+	suffix := time.Now().Format("150405.000000")
+	groceries := &model.Category{Name: "ChartGroceries-" + suffix, Slug: "chart-g-" + suffix, Color: ptrStr("#84CC16")}
+	dining := &model.Category{Name: "ChartDining-" + suffix, Slug: "chart-d-" + suffix, Color: ptrStr("#F59E0B")}
+	for _, c := range []*model.Category{groceries, dining} {
+		if err := g.Create(c).Error; err != nil {
+			t.Fatalf("seed cat: %v", err)
+		}
+	}
+	t.Cleanup(func() {
+		g.Unscoped().Delete(&model.Category{}, groceries.ID)
+		g.Unscoped().Delete(&model.Category{}, dining.ID)
+	})
+
+	d1 := time.Date(2026, 5, 10, 0, 0, 0, 0, time.UTC)
+	seedChartTxn(t, g, userID, accountID, &groceries.ID, d1, decimal.NewFromInt(-50), false) // outflow → counts
+	seedChartTxn(t, g, userID, accountID, &groceries.ID, d1, decimal.NewFromInt(-25), false) // outflow → counts
+	seedChartTxn(t, g, userID, accountID, &groceries.ID, d1, decimal.NewFromInt(200), false) // inflow → excluded
+	seedChartTxn(t, g, userID, accountID, &dining.ID, d1, decimal.NewFromInt(-30), false)    // outflow → counts
+	seedChartTxn(t, g, userID, accountID, &dining.ID, d1, decimal.NewFromInt(-999), true)    // transfer → excluded
+
+	items, err := svc.SpendByCategory(ctx, userID, time.Time{}, time.Time{})
+	if err != nil {
+		t.Fatalf("SpendByCategory: %v", err)
+	}
+	if len(items) != 2 {
+		t.Fatalf("got %d items, want 2", len(items))
+	}
+	// Ordered DESC by amount → groceries (75) first, dining (30) second.
+	if items[0].Name != groceries.Name {
+		t.Errorf("first item = %q, want %q (largest)", items[0].Name, groceries.Name)
+	}
+	if items[0].Amount != "75" {
+		t.Errorf("groceries amount = %s, want 75", items[0].Amount)
+	}
+	if items[1].Amount != "30" {
+		t.Errorf("dining amount = %s, want 30", items[1].Amount)
+	}
+	if items[0].Color != "#84CC16" {
+		t.Errorf("groceries color = %s, want #84CC16", items[0].Color)
+	}
+}
+
+// TestDashboard_SpendByCategory_TenantIsolation.
+func TestDashboard_SpendByCategory_TenantIsolation(t *testing.T) {
+	svc, userA, _, g := newDashboardSvc(t)
+	ctx := context.Background()
+
+	userB := seedTestUser(t, g)
+	accB := &model.Account{
+		UserID: userB, Name: "B-" + time.Now().Format("150405.000000"),
+		InstitutionSlug: "fixture", AccountType: "checking", Currency: "USD",
+	}
+	if err := g.Create(accB).Error; err != nil {
+		t.Fatalf("seed B account: %v", err)
+	}
+	t.Cleanup(func() {
+		g.Unscoped().Where("account_id = ?", accB.ID).Delete(&model.Transaction{})
+		g.Unscoped().Delete(&model.Account{}, accB.ID)
+	})
+	cat := &model.Category{Name: "BCat-" + time.Now().Format("150405.000000"), Slug: "b-cat-" + time.Now().Format("150405.000000")}
+	if err := g.Create(cat).Error; err != nil {
+		t.Fatalf("seed cat: %v", err)
+	}
+	t.Cleanup(func() { g.Unscoped().Delete(&model.Category{}, cat.ID) })
+
+	seedChartTxn(t, g, userB, accB.ID, &cat.ID, time.Date(2026, 5, 10, 0, 0, 0, 0, time.UTC), decimal.NewFromInt(-9999), false)
+
+	items, err := svc.SpendByCategory(ctx, userA, time.Time{}, time.Time{})
+	if err != nil {
+		t.Fatalf("SpendByCategory: %v", err)
+	}
+	if len(items) != 0 {
+		t.Errorf("user A got %d items, want 0 — user B's spend leaked", len(items))
+	}
+}
+
+// TestDashboard_CashFlow_EmptyMonthsPaddedZeros: a quiet month still
+// appears as a zero row so the chart doesn't drop the gap.
+func TestDashboard_CashFlow_EmptyMonthsPaddedZeros(t *testing.T) {
+	svc, userID, accountID, g := newDashboardSvc(t)
+	ctx := context.Background()
+
+	// 12 months trailing May 2026 → window starts June 2025.
+	// Put one txn in May 2026, one in March 2026; April 2026 must come out
+	// as a zero row.
+	seedChartTxn(t, g, userID, accountID, nil, time.Date(2026, 5, 10, 0, 0, 0, 0, time.UTC), decimal.NewFromInt(-50), false)
+	seedChartTxn(t, g, userID, accountID, nil, time.Date(2026, 3, 10, 0, 0, 0, 0, time.UTC), decimal.NewFromInt(-30), false)
+	seedChartTxn(t, g, userID, accountID, nil, time.Date(2026, 5, 5, 0, 0, 0, 0, time.UTC), decimal.NewFromInt(500), false)
+	// Transfer in May must NOT count.
+	seedChartTxn(t, g, userID, accountID, nil, time.Date(2026, 5, 7, 0, 0, 0, 0, time.UTC), decimal.NewFromInt(-9999), true)
+
+	rows, err := svc.CashFlow(ctx, userID, 12)
+	if err != nil {
+		t.Fatalf("CashFlow: %v", err)
+	}
+	if len(rows) != 12 {
+		t.Fatalf("got %d rows, want 12", len(rows))
+	}
+	// Find the rows by month.
+	byMonth := map[string]service.CashFlowMonth{}
+	for _, r := range rows {
+		byMonth[r.Month] = r
+	}
+	may := byMonth["2026-05-01"]
+	if may.Inflow != "500" || may.Outflow != "50" || may.Net != "450" {
+		t.Errorf("May 2026 = %+v, want inflow=500, outflow=50, net=450 (transfer must be excluded)", may)
+	}
+	apr := byMonth["2026-04-01"]
+	if apr.Inflow != "0" || apr.Outflow != "0" {
+		t.Errorf("April 2026 should be zero-padded, got %+v", apr)
+	}
+	mar := byMonth["2026-03-01"]
+	if mar.Outflow != "30" {
+		t.Errorf("March 2026 outflow = %s, want 30", mar.Outflow)
+	}
+}
+
+// TestDashboard_NetWorth_BackDerives: today's balance is $1000. Two
+// outflows ($-100 each) happened on May 5 and May 10. The month-end
+// rows for April and earlier should back-derive to $1200 (current +
+// undone $200 of spending).
+func TestDashboard_NetWorth_BackDerives(t *testing.T) {
+	svc, userID, accountID, g := newDashboardSvc(t)
+	ctx := context.Background()
+
+	// Update the seeded account balance to 1000 — newDashboardSvc creates
+	// it at 0.
+	if err := g.Model(&model.Account{}).Where("id = ?", accountID).
+		Update("balance", decimal.NewFromInt(1000)).Error; err != nil {
+		t.Fatalf("set balance: %v", err)
+	}
+	seedChartTxn(t, g, userID, accountID, nil, time.Date(2026, 5, 5, 0, 0, 0, 0, time.UTC), decimal.NewFromInt(-100), false)
+	seedChartTxn(t, g, userID, accountID, nil, time.Date(2026, 5, 10, 0, 0, 0, 0, time.UTC), decimal.NewFromInt(-100), false)
+
+	rows, err := svc.NetWorth(ctx, userID, 3) // March, April, May
+	if err != nil {
+		t.Fatalf("NetWorth: %v", err)
+	}
+	if len(rows) != 3 {
+		t.Fatalf("got %d rows, want 3", len(rows))
+	}
+	// rows[0] = March 2026 end (2026-03-31): subtract all transactions
+	// after that → -200 worth of outflows → balance at end-March was 1200.
+	// rows[1] = April 2026 end (2026-04-30): same, also 1200 (no April txns).
+	// rows[2] = May 2026 end (2026-05-31): no txns after that → 1000.
+	if rows[0].Total != "1200" {
+		t.Errorf("March 2026 net worth = %s, want 1200", rows[0].Total)
+	}
+	if rows[1].Total != "1200" {
+		t.Errorf("April 2026 net worth = %s, want 1200", rows[1].Total)
+	}
+	if rows[2].Total != "1000" {
+		t.Errorf("May 2026 net worth = %s, want 1000", rows[2].Total)
+	}
+}
+
+// TestDashboard_NetWorth_TenantIsolation: user B's balance and txns
+// don't appear in user A's net-worth trend.
+func TestDashboard_NetWorth_TenantIsolation(t *testing.T) {
+	svc, userA, _, g := newDashboardSvc(t)
+	ctx := context.Background()
+	userB := seedTestUser(t, g)
+	accB := &model.Account{
+		UserID: userB, Name: "B-" + time.Now().Format("150405.000000"),
+		InstitutionSlug: "fixture", AccountType: "checking", Currency: "USD",
+		Balance: decimal.NewFromInt(9999),
+	}
+	if err := g.Create(accB).Error; err != nil {
+		t.Fatalf("seed B: %v", err)
+	}
+	t.Cleanup(func() { g.Unscoped().Delete(&model.Account{}, accB.ID) })
+
+	rows, err := svc.NetWorth(ctx, userA, 3)
+	if err != nil {
+		t.Fatalf("NetWorth: %v", err)
+	}
+	for _, r := range rows {
+		if r.Total != "0" {
+			t.Errorf("user A net worth row = %s, want 0 (user B's $9999 must not leak)", r.Total)
+		}
+	}
+}
+
+func ptrStr(s string) *string { return &s }

--- a/backend/internal/service/dashboard_service.go
+++ b/backend/internal/service/dashboard_service.go
@@ -48,6 +48,31 @@ type DashboardCategorySpendingItem struct {
 	Amount     string `json:"amount"`
 }
 
+// SpendByCategoryItem is one row of the spend-by-category chart payload.
+// Amount is a positive decimal string (outflow sign flipped).
+type SpendByCategoryItem struct {
+	CategoryID *int64 `json:"category_id"`
+	Name       string `json:"name"`
+	Color      string `json:"color,omitempty"`
+	Amount     string `json:"amount"`
+}
+
+// CashFlowMonth mirrors repository.CashFlowMonth for the API. Month is
+// the first-of-month timestamp (UTC), formatted as YYYY-MM-DD on the
+// wire.
+type CashFlowMonth struct {
+	Month   string `json:"month"`
+	Inflow  string `json:"inflow"`
+	Outflow string `json:"outflow"`
+	Net     string `json:"net"`
+}
+
+// NetWorthPoint mirrors repository.NetWorthMonth for the API.
+type NetWorthPoint struct {
+	Date  string `json:"date"`
+	Total string `json:"total"`
+}
+
 // DashboardService composes the summary from the dashboard repo.
 type DashboardService struct {
 	repo repository.DashboardRepository
@@ -92,6 +117,71 @@ func (s *DashboardService) Summarize(ctx context.Context, userID int64, period s
 		TransactionCount: agg.TransactionCount,
 		ByCategory:       items,
 	}, nil
+}
+
+// SpendByCategory returns the pie-chart payload for [from, to). Defaults
+// to the current month if either bound is zero.
+func (s *DashboardService) SpendByCategory(ctx context.Context, userID int64, from, to time.Time) ([]SpendByCategoryItem, error) {
+	if from.IsZero() || to.IsZero() {
+		f, t, _ := resolvePeriod(PeriodCurrentMonth, s.now())
+		from, to = f, t
+	}
+	rows, err := s.repo.SpendByCategory(ctx, userID, from, to)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]SpendByCategoryItem, 0, len(rows))
+	for _, r := range rows {
+		out = append(out, SpendByCategoryItem{
+			CategoryID: r.CategoryID,
+			Name:       r.Name,
+			Color:      r.Color,
+			Amount:     r.Amount.String(),
+		})
+	}
+	return out, nil
+}
+
+// CashFlow returns the trailing `months` months of in/out/net. Defaults
+// to 12.
+func (s *DashboardService) CashFlow(ctx context.Context, userID int64, months int) ([]CashFlowMonth, error) {
+	if months <= 0 {
+		months = 12
+	}
+	rows, err := s.repo.CashFlowByMonth(ctx, userID, s.now(), months)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]CashFlowMonth, 0, len(rows))
+	for _, r := range rows {
+		out = append(out, CashFlowMonth{
+			Month:   r.Month.Format("2006-01-02"),
+			Inflow:  r.Inflow.String(),
+			Outflow: r.Outflow.String(),
+			Net:     r.Net.String(),
+		})
+	}
+	return out, nil
+}
+
+// NetWorth returns the trailing `months` months of back-derived month-end
+// totals. Defaults to 12.
+func (s *DashboardService) NetWorth(ctx context.Context, userID int64, months int) ([]NetWorthPoint, error) {
+	if months <= 0 {
+		months = 12
+	}
+	rows, err := s.repo.NetWorthByMonth(ctx, userID, s.now(), months)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]NetWorthPoint, 0, len(rows))
+	for _, r := range rows {
+		out = append(out, NetWorthPoint{
+			Date:  r.Date.Format("2006-01-02"),
+			Total: r.Total.String(),
+		})
+	}
+	return out, nil
 }
 
 // resolvePeriod returns the [from, to) window for the named period.

--- a/frontend/src/api/dashboard.ts
+++ b/frontend/src/api/dashboard.ts
@@ -1,5 +1,12 @@
 import { apiClient, type ApiItem, type ApiList } from './client'
-import type { BudgetAlert, DashboardPeriod, DashboardSummary } from '../types/dashboard'
+import type {
+  BudgetAlert,
+  CashFlowMonth,
+  DashboardPeriod,
+  DashboardSummary,
+  NetWorthPoint,
+  SpendByCategoryItem,
+} from '../types/dashboard'
 
 export async function getDashboardSummary(period: DashboardPeriod): Promise<DashboardSummary> {
   const res = await apiClient.get<ApiItem<DashboardSummary>>('/dashboard/summary', {
@@ -10,5 +17,20 @@ export async function getDashboardSummary(period: DashboardPeriod): Promise<Dash
 
 export async function getBudgetAlerts(): Promise<BudgetAlert[]> {
   const res = await apiClient.get<ApiList<BudgetAlert>>('/dashboard/budget-alerts')
+  return res.data.data
+}
+
+export async function getSpendByCategory(): Promise<SpendByCategoryItem[]> {
+  const res = await apiClient.get<ApiList<SpendByCategoryItem>>('/dashboard/spend-by-category')
+  return res.data.data
+}
+
+export async function getCashFlow(months = 12): Promise<CashFlowMonth[]> {
+  const res = await apiClient.get<ApiList<CashFlowMonth>>('/dashboard/cash-flow', { params: { months } })
+  return res.data.data
+}
+
+export async function getNetWorth(months = 12): Promise<NetWorthPoint[]> {
+  const res = await apiClient.get<ApiList<NetWorthPoint>>('/dashboard/net-worth', { params: { months } })
   return res.data.data
 }

--- a/frontend/src/components/DashboardCharts.tsx
+++ b/frontend/src/components/DashboardCharts.tsx
@@ -1,0 +1,167 @@
+// Recharts is loaded eagerly here; the dashboard is the only consumer for
+// now. Each component fetches its own data — keeps the surface
+// independent so a transient failure on one chart doesn't blank the rest.
+import { useEffect, useState } from 'react'
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Cell,
+  Legend,
+  Line,
+  LineChart,
+  Pie,
+  PieChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts'
+import { getCashFlow, getNetWorth, getSpendByCategory } from '../api/dashboard'
+import type {
+  CashFlowMonth,
+  NetWorthPoint,
+  SpendByCategoryItem,
+} from '../types/dashboard'
+
+// Money strings come in as NUMERIC text. parseFloat is fine for chart
+// scaling; AmountDisplay handles user-facing precision elsewhere.
+const num = (s: string): number => Number.parseFloat(s) || 0
+
+const FALLBACK_PIE_COLORS = ['#6366F1', '#F59E0B', '#10B981', '#EC4899', '#3B82F6', '#EF4444', '#A855F7', '#64748B']
+
+export function SpendByCategoryChart() {
+  const [data, setData] = useState<SpendByCategoryItem[] | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    void getSpendByCategory()
+      .then((rows) => { if (!cancelled) setData(rows) })
+      .catch((e) => { if (!cancelled) setError(errMsg(e)) })
+    return () => { cancelled = true }
+  }, [])
+
+  return (
+    <ChartCard title="Spending by category (this month)">
+      {error && <div className="text-sm text-red-700">{error}</div>}
+      {!error && !data && <div className="text-sm text-gray-400">Loading…</div>}
+      {!error && data && data.length === 0 && (
+        <div className="text-sm text-gray-400">No outflows this month.</div>
+      )}
+      {!error && data && data.length > 0 && (
+        <ResponsiveContainer width="100%" height={260}>
+          <PieChart>
+            <Pie
+              data={data.map((d) => ({ name: d.name, value: num(d.amount), color: d.color }))}
+              dataKey="value"
+              nameKey="name"
+              cx="50%"
+              cy="50%"
+              outerRadius={90}
+              label={(p: { name?: string }) => p.name ?? ''}
+            >
+              {data.map((d, i) => (
+                <Cell key={i} fill={d.color && d.color.length > 0 ? d.color : FALLBACK_PIE_COLORS[i % FALLBACK_PIE_COLORS.length]} />
+              ))}
+            </Pie>
+            <Tooltip formatter={(v) => (typeof v === 'number' ? v.toFixed(2) : String(v))} />
+          </PieChart>
+        </ResponsiveContainer>
+      )}
+    </ChartCard>
+  )
+}
+
+export function CashFlowChart() {
+  const [data, setData] = useState<CashFlowMonth[] | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    void getCashFlow(12)
+      .then((rows) => { if (!cancelled) setData(rows) })
+      .catch((e) => { if (!cancelled) setError(errMsg(e)) })
+    return () => { cancelled = true }
+  }, [])
+
+  return (
+    <ChartCard title="Cash flow (last 12 months)">
+      {error && <div className="text-sm text-red-700">{error}</div>}
+      {!error && !data && <div className="text-sm text-gray-400">Loading…</div>}
+      {!error && data && (
+        <ResponsiveContainer width="100%" height={260}>
+          <BarChart
+            data={data.map((d) => ({
+              month: d.month.slice(0, 7), // YYYY-MM
+              inflow: num(d.inflow),
+              outflow: -num(d.outflow), // negative so it sits below the axis
+            }))}
+            stackOffset="sign"
+          >
+            <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
+            <XAxis dataKey="month" tick={{ fontSize: 11 }} />
+            <YAxis tick={{ fontSize: 11 }} />
+            <Tooltip formatter={(v) => (typeof v === 'number' ? v.toFixed(2) : String(v))} />
+            <Legend wrapperStyle={{ fontSize: 12 }} />
+            <Bar dataKey="inflow" stackId="0" fill="#10B981" name="Inflow" />
+            <Bar dataKey="outflow" stackId="0" fill="#EF4444" name="Outflow" />
+          </BarChart>
+        </ResponsiveContainer>
+      )}
+    </ChartCard>
+  )
+}
+
+export function NetWorthChart() {
+  const [data, setData] = useState<NetWorthPoint[] | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    void getNetWorth(12)
+      .then((rows) => { if (!cancelled) setData(rows) })
+      .catch((e) => { if (!cancelled) setError(errMsg(e)) })
+    return () => { cancelled = true }
+  }, [])
+
+  return (
+    <ChartCard
+      title="Net worth (last 12 months)"
+      footnote="Approximated by back-deriving from current balances. Manual balance edits won't be reflected."
+    >
+      {error && <div className="text-sm text-red-700">{error}</div>}
+      {!error && !data && <div className="text-sm text-gray-400">Loading…</div>}
+      {!error && data && (
+        <ResponsiveContainer width="100%" height={260}>
+          <LineChart data={data.map((d) => ({ date: d.date.slice(0, 7), total: num(d.total) }))}>
+            <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
+            <XAxis dataKey="date" tick={{ fontSize: 11 }} />
+            <YAxis tick={{ fontSize: 11 }} />
+            <Tooltip formatter={(v) => (typeof v === 'number' ? v.toFixed(2) : String(v))} />
+            <Line type="monotone" dataKey="total" stroke="#6366F1" strokeWidth={2} dot={false} />
+          </LineChart>
+        </ResponsiveContainer>
+      )}
+    </ChartCard>
+  )
+}
+
+function ChartCard({ title, footnote, children }: { title: string; footnote?: string; children: React.ReactNode }) {
+  return (
+    <div className="rounded-lg border border-gray-200 bg-white p-4">
+      <h3 className="mb-3 text-sm font-medium uppercase tracking-wider text-gray-500">{title}</h3>
+      {children}
+      {footnote && <p className="mt-2 text-xs text-gray-400">{footnote}</p>}
+    </div>
+  )
+}
+
+function errMsg(err: unknown): string {
+  if (err && typeof err === 'object' && 'response' in err) {
+    const r = (err as { response?: { data?: { error?: string } } }).response
+    if (r?.data?.error) return r.data.error
+  }
+  if (err instanceof Error) return err.message
+  return 'request failed'
+}

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { AlertTriangle } from 'lucide-react'
 import { AmountDisplay } from '../components/AmountDisplay'
+import { CashFlowChart, NetWorthChart, SpendByCategoryChart } from '../components/DashboardCharts'
 import { getBudgetAlerts, getDashboardSummary } from '../api/dashboard'
 import {
   DASHBOARD_PERIODS,
@@ -122,6 +123,14 @@ export function DashboardPage() {
           {summary.period.from.slice(0, 10)} → {summary.period.to.slice(0, 10)}
         </p>
       )}
+
+      <div className="mt-8 grid grid-cols-1 gap-4 lg:grid-cols-2">
+        <SpendByCategoryChart />
+        <NetWorthChart />
+      </div>
+      <div className="mt-4">
+        <CashFlowChart />
+      </div>
     </div>
   )
 }

--- a/frontend/src/types/dashboard.ts
+++ b/frontend/src/types/dashboard.ts
@@ -25,3 +25,25 @@ export type BudgetAlert = {
   pct: number
   severity: 'warning' | 'over'
 }
+
+// Chart payload types — mirror service.SpendByCategoryItem, CashFlowMonth,
+// NetWorthPoint. Money fields are decimal strings; parse to Number only at
+// the chart boundary.
+export type SpendByCategoryItem = {
+  category_id: number | null
+  name: string
+  color?: string
+  amount: string
+}
+
+export type CashFlowMonth = {
+  month: string // YYYY-MM-DD (first of month)
+  inflow: string
+  outflow: string
+  net: string
+}
+
+export type NetWorthPoint = {
+  date: string // YYYY-MM-DD (month-end)
+  total: string
+}


### PR DESCRIPTION
## Summary
Three new dashboard endpoints + Recharts components on `/dashboard`, all NUMERIC end-to-end via shopspring/decimal.

**Backend**
- `GET /api/v1/dashboard/spend-by-category?from=&to=` — outflows only, transfers excluded, joined to categories so each row carries its color; sorted by spend DESC; defaults to current calendar month.
- `GET /api/v1/dashboard/cash-flow?months=12` — trailing-12 stacked bar payload (inflow / outflow / net). Transfers excluded. Empty months zero-padded so the chart doesn't drop gaps.
- `GET /api/v1/dashboard/net-worth?months=12` — line payload, back-derives month-end totals from the current persisted account balance minus subsequent transactions. Documented as approximate; manual balance edits won't appear in the trend.
- Both `?months` endpoints cap at 36 to bound queries.

**Frontend**
- `components/DashboardCharts.tsx` exporting `SpendByCategoryChart` (pie with category-color fills), `CashFlowChart` (stacked bar, outflow flipped negative), `NetWorthChart` (line with approximation footnote).
- Independent fetches per chart so one failure doesn't blank the rest.
- Wired into `/dashboard` below the existing summary tiles.

**Tests (real Postgres)**
- SpendByCategory: inflows + transfers excluded, ordering DESC, category color passes through, tenant isolation.
- CashFlow: empty months zero-padded, transfers excluded, inflow/outflow/net math.
- NetWorth: back-derive math ($1000 current + two $-100 May outflows → $1200 March/April, $1000 May), tenant isolation.

**Note:** Recharts pushes the bundle past 500kB. Acceptable for now; can revisit with dynamic import when more chart-heavy pages land.

Closes #105.

## Test plan
- [x] `go test ./... -race -p 1`
- [x] `go vet ./...`
- [x] `pnpm lint` + `pnpm build`
- [ ] Manual browser smoke (deferred)

🤖 Generated with [Claude Code](https://claude.com/claude-code)