### PR TITLE
feat(investments): holdings CRUD + latest-snapshot read (#113)

### DIFF
--- a/backend/internal/handler/investment_handler.go
+++ b/backend/internal/handler/investment_handler.go
@@ -1,0 +1,140 @@
+package handler
+
+import (
+	"errors"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/shopspring/decimal"
+
+	"github.com/gregwym/offbook/backend/internal/service"
+	"github.com/gregwym/offbook/backend/internal/service/auth"
+)
+
+type InvestmentHandler struct {
+	svc *service.InvestmentService
+}
+
+func NewInvestmentHandler(s *service.InvestmentService) *InvestmentHandler {
+	return &InvestmentHandler{svc: s}
+}
+
+func (h *InvestmentHandler) Register(g *gin.RouterGroup) {
+	g.POST("/investments", h.Create)
+	g.GET("/investments", h.List)
+	g.GET("/investments/:id", h.Get)
+}
+
+type createInvestmentRequest struct {
+	AccountID    int64            `json:"account_id"`
+	Ticker       string           `json:"ticker"`
+	Name         *string          `json:"name"`
+	AssetClass   *string          `json:"asset_class"`
+	Quantity     decimal.Decimal  `json:"quantity"`
+	CostBasis    *decimal.Decimal `json:"cost_basis"`
+	MarketValue  *decimal.Decimal `json:"market_value"`
+	SnapshotDate *string          `json:"snapshot_date"` // YYYY-MM-DD
+	Source       string           `json:"source"`
+}
+
+func (h *InvestmentHandler) Create(c *gin.Context) {
+	var req createInvestmentRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error(), "code": "INVALID_REQUEST"})
+		return
+	}
+	in := service.CreateInvestmentInput{
+		AccountID:   req.AccountID,
+		Ticker:      req.Ticker,
+		Name:        req.Name,
+		AssetClass:  req.AssetClass,
+		Quantity:    req.Quantity,
+		CostBasis:   req.CostBasis,
+		MarketValue: req.MarketValue,
+		Source:      req.Source,
+	}
+	if req.SnapshotDate != nil && *req.SnapshotDate != "" {
+		d, err := time.Parse("2006-01-02", *req.SnapshotDate)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "snapshot_date must be YYYY-MM-DD", "code": "INVALID_REQUEST"})
+			return
+		}
+		in.SnapshotDate = d
+	}
+	inv, err := h.svc.Create(c.Request.Context(), auth.MustUserID(c.Request.Context()), in)
+	if err != nil {
+		h.writeServiceError(c, err)
+		return
+	}
+	c.JSON(http.StatusCreated, gin.H{"data": inv})
+}
+
+func (h *InvestmentHandler) Get(c *gin.Context) {
+	id, ok := parseID(c)
+	if !ok {
+		return
+	}
+	inv, err := h.svc.Get(c.Request.Context(), auth.MustUserID(c.Request.Context()), id)
+	if err != nil {
+		h.writeServiceError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"data": inv})
+}
+
+// List dispatches on query params:
+//   - No params → latest snapshot per holding for the user.
+//   - ?account_id=N&ticker=AAPL → snapshot history for one holding.
+func (h *InvestmentHandler) List(c *gin.Context) {
+	userID := auth.MustUserID(c.Request.Context())
+	accountQ := c.Query("account_id")
+	tickerQ := c.Query("ticker")
+	if accountQ != "" && tickerQ != "" {
+		acctID, err := strconv.ParseInt(accountQ, 10, 64)
+		if err != nil || acctID <= 0 {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "account_id must be a positive integer", "code": "INVALID_REQUEST"})
+			return
+		}
+		rows, err := h.svc.ListSnapshots(c.Request.Context(), userID, acctID, tickerQ)
+		if err != nil {
+			h.writeServiceError(c, err)
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"data": rows, "total": int64(len(rows))})
+		return
+	}
+	if accountQ != "" || tickerQ != "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "account_id and ticker must be provided together", "code": "INVALID_REQUEST"})
+		return
+	}
+	rows, err := h.svc.ListLatest(c.Request.Context(), userID)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error(), "code": "INTERNAL"})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"data": rows, "total": int64(len(rows))})
+}
+
+func (h *InvestmentHandler) writeServiceError(c *gin.Context, err error) {
+	switch {
+	case errors.Is(err, service.ErrInvestmentNotFound):
+		c.JSON(http.StatusNotFound, gin.H{"error": err.Error(), "code": "INVESTMENT_NOT_FOUND"})
+	case errors.Is(err, service.ErrAccountNotFound):
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error(), "code": "ACCOUNT_MISMATCH"})
+	case errors.Is(err, service.ErrInvalidTicker),
+		errors.Is(err, service.ErrZeroQuantity),
+		errors.Is(err, service.ErrNegativeCostBasis),
+		errors.Is(err, service.ErrNegativeMarketValue):
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error(), "code": "INVALID_INVESTMENT"})
+	case errors.Is(err, service.ErrInvalidInvestmentSrc):
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error":   err.Error(),
+			"code":    "INVALID_SOURCE",
+			"allowed": []string{service.InvestmentSourcePlaid, service.InvestmentSourceCSV, service.InvestmentSourceManual},
+		})
+	default:
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error(), "code": "INTERNAL"})
+	}
+}

--- a/backend/internal/repository/investment_repo.go
+++ b/backend/internal/repository/investment_repo.go
@@ -1,0 +1,90 @@
+package repository
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	"gorm.io/gorm"
+
+	"github.com/gregwym/offbook/backend/internal/model"
+)
+
+// InvestmentRepository is the data-access contract for investment snapshots.
+// All reads are scoped by user_id. The table is append-only by design —
+// there is no Update or SoftDelete (see docs/ARCHITECTURE.md: snapshot
+// tables don't carry deleted_at because silently corrupting historical
+// state is worse than keeping a wrong row).
+type InvestmentRepository interface {
+	Create(ctx context.Context, inv *model.Investment) error
+	GetByID(ctx context.Context, userID, id int64) (*model.Investment, error)
+	// ListLatestPerHolding returns the most-recent snapshot for each
+	// (account_id, ticker) pair belonging to the user. One Postgres query
+	// via DISTINCT ON.
+	ListLatestPerHolding(ctx context.Context, userID int64) ([]model.Investment, error)
+	// ListSnapshotsByHolding returns every snapshot for a single
+	// (user_id, account_id, ticker), oldest first. ticker matching is
+	// case-insensitive (we always store uppercase, but defend against
+	// callers that send lowercase).
+	ListSnapshotsByHolding(ctx context.Context, userID, accountID int64, ticker string) ([]model.Investment, error)
+}
+
+type investmentRepo struct {
+	db *gorm.DB
+}
+
+func NewInvestmentRepository(db *gorm.DB) InvestmentRepository {
+	return &investmentRepo{db: db}
+}
+
+func (r *investmentRepo) Create(ctx context.Context, inv *model.Investment) error {
+	return r.db.WithContext(ctx).Create(inv).Error
+}
+
+func (r *investmentRepo) GetByID(ctx context.Context, userID, id int64) (*model.Investment, error) {
+	var inv model.Investment
+	if err := r.db.WithContext(ctx).
+		Where("user_id = ?", userID).
+		First(&inv, id).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, ErrNotFound
+		}
+		return nil, err
+	}
+	return &inv, nil
+}
+
+func (r *investmentRepo) ListLatestPerHolding(ctx context.Context, userID int64) ([]model.Investment, error) {
+	// DISTINCT ON over (account_id, ticker) ordered by snapshot_date DESC,
+	// id DESC picks the freshest snapshot per holding. Wrap in an outer
+	// SELECT so the final result can be ordered however we like (here:
+	// stable by account_id, then ticker) without breaking the DISTINCT ON
+	// requirement that its ORDER BY start with the same columns.
+	var out []model.Investment
+	err := r.db.WithContext(ctx).Raw(`
+		SELECT * FROM (
+			SELECT DISTINCT ON (account_id, ticker) *
+			FROM investments
+			WHERE user_id = ?
+			ORDER BY account_id, ticker, snapshot_date DESC, id DESC
+		) latest
+		ORDER BY account_id, ticker
+	`, userID).Scan(&out).Error
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (r *investmentRepo) ListSnapshotsByHolding(ctx context.Context, userID, accountID int64, ticker string) ([]model.Investment, error) {
+	tk := strings.ToUpper(strings.TrimSpace(ticker))
+	var out []model.Investment
+	err := r.db.WithContext(ctx).
+		Where("user_id = ? AND account_id = ? AND UPPER(ticker) = ?", userID, accountID, tk).
+		Order("snapshot_date ASC, id ASC").
+		Find(&out).Error
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -67,6 +67,10 @@ func New(cfg config.Config, gormDB *gorm.DB) *gin.Engine {
 	savingsGoalSvc := service.NewSavingsGoalService(savingsGoalRepo, accountRepo)
 	savingsGoalHandler := handler.NewSavingsGoalHandler(savingsGoalSvc)
 
+	investmentRepo := repository.NewInvestmentRepository(gormDB)
+	investmentSvc := service.NewInvestmentService(investmentRepo, accountRepo)
+	investmentHandler := handler.NewInvestmentHandler(investmentSvc)
+
 	householdRepo := repository.NewHouseholdRepository(gormDB)
 	memberRepo := repository.NewHouseholdMemberRepository(gormDB)
 	userRepo := repository.NewUserRepository(gormDB)
@@ -117,6 +121,7 @@ func New(cfg config.Config, gormDB *gorm.DB) *gin.Engine {
 		dashboardHandler.Register(secured)
 		budgetHandler.Register(secured)
 		savingsGoalHandler.Register(secured)
+		investmentHandler.Register(secured)
 		householdHandler.Register(secured)
 		aggregatorHandler.Register(secured)
 		scopeHandler.Register(secured)

--- a/backend/internal/service/investment_service.go
+++ b/backend/internal/service/investment_service.go
@@ -1,0 +1,137 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/shopspring/decimal"
+
+	"github.com/gregwym/offbook/backend/internal/model"
+	"github.com/gregwym/offbook/backend/internal/repository"
+)
+
+// Investment source enum. Mirrors the CHECK constraint on
+// investments.source from migration 000001.
+const (
+	InvestmentSourcePlaid  = "plaid"
+	InvestmentSourceCSV    = "csv"
+	InvestmentSourceManual = "manual"
+)
+
+var validInvestmentSources = map[string]struct{}{
+	InvestmentSourcePlaid:  {},
+	InvestmentSourceCSV:    {},
+	InvestmentSourceManual: {},
+}
+
+var (
+	ErrInvestmentNotFound   = errors.New("investment snapshot not found")
+	ErrInvalidTicker        = errors.New("ticker must not be empty")
+	ErrZeroQuantity         = errors.New("quantity must not be zero")
+	ErrInvalidInvestmentSrc = errors.New("source must be one of: plaid, csv, manual")
+	ErrNegativeCostBasis    = errors.New("cost_basis must be >= 0")
+	ErrNegativeMarketValue  = errors.New("market_value must be >= 0")
+)
+
+// CreateInvestmentInput is the validated payload for snapshot creation.
+type CreateInvestmentInput struct {
+	AccountID    int64
+	Ticker       string
+	Name         *string
+	AssetClass   *string
+	Quantity     decimal.Decimal
+	CostBasis    *decimal.Decimal
+	MarketValue  *decimal.Decimal
+	SnapshotDate time.Time
+	Source       string
+}
+
+// InvestmentService owns snapshot validation + the append-only CRUD.
+type InvestmentService struct {
+	repo     repository.InvestmentRepository
+	acctRepo repository.AccountRepository
+}
+
+func NewInvestmentService(repo repository.InvestmentRepository, acctRepo repository.AccountRepository) *InvestmentService {
+	return &InvestmentService{repo: repo, acctRepo: acctRepo}
+}
+
+func (s *InvestmentService) Create(ctx context.Context, userID int64, in CreateInvestmentInput) (*model.Investment, error) {
+	ticker := strings.ToUpper(strings.TrimSpace(in.Ticker))
+	if ticker == "" {
+		return nil, ErrInvalidTicker
+	}
+	if in.Quantity.IsZero() {
+		return nil, ErrZeroQuantity
+	}
+	src := strings.TrimSpace(in.Source)
+	if src == "" {
+		src = InvestmentSourceManual
+	}
+	if _, ok := validInvestmentSources[src]; !ok {
+		return nil, ErrInvalidInvestmentSrc
+	}
+	if in.CostBasis != nil && in.CostBasis.IsNegative() {
+		return nil, ErrNegativeCostBasis
+	}
+	if in.MarketValue != nil && in.MarketValue.IsNegative() {
+		return nil, ErrNegativeMarketValue
+	}
+	// Account ownership check — block cross-user account linkage.
+	if _, err := s.acctRepo.GetByID(ctx, userID, in.AccountID); err != nil {
+		if errors.Is(err, repository.ErrNotFound) {
+			return nil, ErrAccountNotFound
+		}
+		return nil, fmt.Errorf("validate account: %w", err)
+	}
+	snapshotDate := in.SnapshotDate
+	if snapshotDate.IsZero() {
+		snapshotDate = time.Now().UTC().Truncate(24 * time.Hour)
+	}
+	inv := &model.Investment{
+		UserID:       userID,
+		AccountID:    in.AccountID,
+		Ticker:       ticker,
+		Name:         trimPtr(in.Name),
+		AssetClass:   trimPtr(in.AssetClass),
+		Quantity:     in.Quantity,
+		CostBasis:    in.CostBasis,
+		MarketValue:  in.MarketValue,
+		SnapshotDate: snapshotDate,
+		Source:       src,
+	}
+	if err := s.repo.Create(ctx, inv); err != nil {
+		return nil, fmt.Errorf("create investment: %w", err)
+	}
+	return inv, nil
+}
+
+func (s *InvestmentService) Get(ctx context.Context, userID, id int64) (*model.Investment, error) {
+	inv, err := s.repo.GetByID(ctx, userID, id)
+	if err != nil {
+		if errors.Is(err, repository.ErrNotFound) {
+			return nil, ErrInvestmentNotFound
+		}
+		return nil, err
+	}
+	return inv, nil
+}
+
+func (s *InvestmentService) ListLatest(ctx context.Context, userID int64) ([]model.Investment, error) {
+	return s.repo.ListLatestPerHolding(ctx, userID)
+}
+
+func (s *InvestmentService) ListSnapshots(ctx context.Context, userID, accountID int64, ticker string) ([]model.Investment, error) {
+	// Verify the account belongs to the user before exposing snapshots —
+	// otherwise a leak via an enumeration loop is possible.
+	if _, err := s.acctRepo.GetByID(ctx, userID, accountID); err != nil {
+		if errors.Is(err, repository.ErrNotFound) {
+			return nil, ErrAccountNotFound
+		}
+		return nil, fmt.Errorf("validate account: %w", err)
+	}
+	return s.repo.ListSnapshotsByHolding(ctx, userID, accountID, ticker)
+}

--- a/backend/internal/service/investment_service_test.go
+++ b/backend/internal/service/investment_service_test.go
@@ -1,0 +1,288 @@
+package service_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/shopspring/decimal"
+	"gorm.io/gorm"
+
+	"github.com/gregwym/offbook/backend/internal/model"
+	"github.com/gregwym/offbook/backend/internal/repository"
+	"github.com/gregwym/offbook/backend/internal/service"
+)
+
+func newInvestmentSvc(t *testing.T) (svc *service.InvestmentService, userID, accountID int64, g *gorm.DB) {
+	t.Helper()
+	g = openTestDB(t)
+	userID = seedTestUser(t, g)
+
+	suffix := time.Now().Format("150405.000000")
+	acc := &model.Account{
+		UserID: userID, Name: "InvFixture-" + suffix, InstitutionSlug: "fixture",
+		AccountType: "investment", Currency: "USD",
+	}
+	if err := g.Create(acc).Error; err != nil {
+		t.Fatalf("seed account: %v", err)
+	}
+	t.Cleanup(func() {
+		g.Unscoped().Where("user_id = ?", userID).Delete(&model.Investment{})
+		g.Unscoped().Delete(&model.Account{}, acc.ID)
+	})
+
+	svc = service.NewInvestmentService(
+		repository.NewInvestmentRepository(g),
+		repository.NewAccountRepository(g),
+	)
+	return svc, userID, acc.ID, g
+}
+
+func TestInvestmentService_Create_Validation(t *testing.T) {
+	svc, userID, accountID, _ := newInvestmentSvc(t)
+	ctx := context.Background()
+
+	costBasis := decimal.NewFromInt(100)
+	negative := decimal.NewFromInt(-5)
+	marketValue := decimal.NewFromInt(150)
+
+	cases := []struct {
+		name    string
+		in      service.CreateInvestmentInput
+		wantErr error
+	}{
+		{
+			"valid manual",
+			service.CreateInvestmentInput{
+				AccountID:    accountID,
+				Ticker:       "vti",
+				Quantity:     decimal.NewFromInt(10),
+				CostBasis:    &costBasis,
+				MarketValue:  &marketValue,
+				SnapshotDate: time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC),
+				Source:       "manual",
+			},
+			nil,
+		},
+		{
+			"empty ticker",
+			service.CreateInvestmentInput{
+				AccountID: accountID, Ticker: "  ", Quantity: decimal.NewFromInt(1), Source: "manual",
+			},
+			service.ErrInvalidTicker,
+		},
+		{
+			"zero quantity",
+			service.CreateInvestmentInput{
+				AccountID: accountID, Ticker: "AAPL", Quantity: decimal.Zero, Source: "manual",
+			},
+			service.ErrZeroQuantity,
+		},
+		{
+			"bad source",
+			service.CreateInvestmentInput{
+				AccountID: accountID, Ticker: "AAPL", Quantity: decimal.NewFromInt(1), Source: "ofx",
+			},
+			service.ErrInvalidInvestmentSrc,
+		},
+		{
+			"negative cost basis",
+			service.CreateInvestmentInput{
+				AccountID: accountID, Ticker: "AAPL", Quantity: decimal.NewFromInt(1),
+				CostBasis: &negative, Source: "manual",
+			},
+			service.ErrNegativeCostBasis,
+		},
+		{
+			"negative market value",
+			service.CreateInvestmentInput{
+				AccountID: accountID, Ticker: "AAPL", Quantity: decimal.NewFromInt(1),
+				MarketValue: &negative, Source: "manual",
+			},
+			service.ErrNegativeMarketValue,
+		},
+		{
+			"unknown account",
+			service.CreateInvestmentInput{
+				AccountID: 9_999_999, Ticker: "AAPL", Quantity: decimal.NewFromInt(1), Source: "manual",
+			},
+			service.ErrAccountNotFound,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			inv, err := svc.Create(ctx, userID, tc.in)
+			if tc.wantErr != nil {
+				if !errors.Is(err, tc.wantErr) {
+					t.Errorf("err = %v, want %v", err, tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected err: %v", err)
+			}
+			if inv == nil || inv.ID == 0 {
+				t.Fatalf("got %+v, want created snapshot", inv)
+			}
+			if inv.Ticker != "VTI" {
+				t.Errorf("ticker = %q, want %q (should be uppercased)", inv.Ticker, "VTI")
+			}
+		})
+	}
+}
+
+func TestInvestmentService_Create_CryptoPrecisionPreserved(t *testing.T) {
+	svc, userID, accountID, _ := newInvestmentSvc(t)
+	ctx := context.Background()
+
+	// 18 decimal places — example from the issue. Floats would lose digits.
+	qty, err := decimal.NewFromString("0.051234567890123450")
+	if err != nil {
+		t.Fatalf("decimal parse: %v", err)
+	}
+
+	inv, err := svc.Create(ctx, userID, service.CreateInvestmentInput{
+		AccountID:    accountID,
+		Ticker:       "BTC",
+		Quantity:     qty,
+		SnapshotDate: time.Date(2026, 5, 10, 0, 0, 0, 0, time.UTC),
+		Source:       "manual",
+	})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	got, err := svc.Get(ctx, userID, inv.ID)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if !got.Quantity.Equal(qty) {
+		t.Errorf("quantity round-trip: got %s, want %s", got.Quantity.String(), qty.String())
+	}
+}
+
+func TestInvestmentService_ListLatest_PicksFreshestPerHolding(t *testing.T) {
+	svc, userID, accountID, _ := newInvestmentSvc(t)
+	ctx := context.Background()
+
+	mk := func(ticker string, qty int64, day int) {
+		t.Helper()
+		_, err := svc.Create(ctx, userID, service.CreateInvestmentInput{
+			AccountID:    accountID,
+			Ticker:       ticker,
+			Quantity:     decimal.NewFromInt(qty),
+			SnapshotDate: time.Date(2026, 5, day, 0, 0, 0, 0, time.UTC),
+			Source:       "manual",
+		})
+		if err != nil {
+			t.Fatalf("seed %s @ day %d: %v", ticker, day, err)
+		}
+	}
+	// VTI: 3 snapshots; newest (day 10) qty=15
+	mk("VTI", 10, 1)
+	mk("VTI", 12, 5)
+	mk("VTI", 15, 10)
+	// AAPL: 2 snapshots; newest (day 8) qty=20
+	mk("AAPL", 5, 3)
+	mk("AAPL", 20, 8)
+
+	rows, err := svc.ListLatest(ctx, userID)
+	if err != nil {
+		t.Fatalf("list latest: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("len = %d, want 2 (one per ticker)", len(rows))
+	}
+	got := map[string]decimal.Decimal{}
+	for _, r := range rows {
+		got[r.Ticker] = r.Quantity
+	}
+	if v, ok := got["VTI"]; !ok || !v.Equal(decimal.NewFromInt(15)) {
+		t.Errorf("VTI latest = %v, want 15", v)
+	}
+	if v, ok := got["AAPL"]; !ok || !v.Equal(decimal.NewFromInt(20)) {
+		t.Errorf("AAPL latest = %v, want 20", v)
+	}
+}
+
+func TestInvestmentService_ListSnapshots_ReturnsHistoryAscending(t *testing.T) {
+	svc, userID, accountID, _ := newInvestmentSvc(t)
+	ctx := context.Background()
+
+	for i, day := range []int{5, 1, 10, 3} {
+		_, err := svc.Create(ctx, userID, service.CreateInvestmentInput{
+			AccountID:    accountID,
+			Ticker:       "VTI",
+			Quantity:     decimal.NewFromInt(int64(10 + i)),
+			SnapshotDate: time.Date(2026, 5, day, 0, 0, 0, 0, time.UTC),
+			Source:       "manual",
+		})
+		if err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+	}
+	// Case-insensitive ticker match.
+	rows, err := svc.ListSnapshots(ctx, userID, accountID, "vti")
+	if err != nil {
+		t.Fatalf("list snapshots: %v", err)
+	}
+	if len(rows) != 4 {
+		t.Fatalf("len = %d, want 4", len(rows))
+	}
+	for i := 1; i < len(rows); i++ {
+		if rows[i].SnapshotDate.Before(rows[i-1].SnapshotDate) {
+			t.Errorf("rows not ascending: idx %d (%s) before idx %d (%s)",
+				i, rows[i].SnapshotDate, i-1, rows[i-1].SnapshotDate)
+		}
+	}
+}
+
+// TestInvestmentService_MultiTenant_ReadIsolation verifies that one user
+// cannot see another user's snapshots — neither via GetByID, ListLatest, nor
+// ListSnapshots.
+func TestInvestmentService_MultiTenant_ReadIsolation(t *testing.T) {
+	svc, userA, accountA, g := newInvestmentSvc(t)
+	ctx := context.Background()
+
+	// Seed user A's snapshot.
+	invA, err := svc.Create(ctx, userA, service.CreateInvestmentInput{
+		AccountID:    accountA,
+		Ticker:       "VTI",
+		Quantity:     decimal.NewFromInt(10),
+		SnapshotDate: time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC),
+		Source:       "manual",
+	})
+	if err != nil {
+		t.Fatalf("seed user A: %v", err)
+	}
+
+	// Build a parallel user B with their own account.
+	userB := seedTestUser(t, g)
+	acctB := &model.Account{
+		UserID: userB, Name: "InvFixture-B-" + time.Now().Format("150405.000000"),
+		InstitutionSlug: "fixture", AccountType: "investment", Currency: "USD",
+	}
+	if err := g.Create(acctB).Error; err != nil {
+		t.Fatalf("seed account B: %v", err)
+	}
+	t.Cleanup(func() {
+		g.Unscoped().Where("user_id = ?", userB).Delete(&model.Investment{})
+		g.Unscoped().Delete(&model.Account{}, acctB.ID)
+	})
+
+	// GetByID — user B reading user A's snapshot must 404.
+	if _, err := svc.Get(ctx, userB, invA.ID); !errors.Is(err, service.ErrInvestmentNotFound) {
+		t.Errorf("Get cross-user: err = %v, want ErrInvestmentNotFound", err)
+	}
+
+	// ListLatest — user B sees none.
+	if rows, err := svc.ListLatest(ctx, userB); err != nil || len(rows) != 0 {
+		t.Errorf("ListLatest user B: rows=%d err=%v, want empty", len(rows), err)
+	}
+
+	// ListSnapshots — user B passing user A's account_id must fail account
+	// ownership check before touching investment data.
+	if _, err := svc.ListSnapshots(ctx, userB, accountA, "VTI"); !errors.Is(err, service.ErrAccountNotFound) {
+		t.Errorf("ListSnapshots cross-user account: err = %v, want ErrAccountNotFound", err)
+	}
+}


### PR DESCRIPTION
## Summary
- Append-only investment snapshot repo + service + handlers backing M6.
- `ListLatestPerHolding` uses Postgres `DISTINCT ON (account_id, ticker)` to fetch one row per holding in a single query.
- Service validates ticker (non-empty + uppercased), non-zero quantity, source enum (plaid/csv/manual), non-negative cost basis / market value, and account ownership.
- Routes: `POST /api/v1/investments`, `GET /api/v1/investments` (latest per holding), `GET /api/v1/investments/:id`, `GET /api/v1/investments?account_id=&ticker=` (snapshot history).

## Test plan
- [x] `go vet ./...` clean
- [x] `make test` (race, p=1) green — including new investment service tests
- [x] Validation matrix: ticker, quantity, source, cost basis, market value, account ownership
- [x] 18-decimal-place crypto quantity round-trips without precision loss
- [x] `ListLatestPerHolding` returns freshest snapshot per (account_id, ticker)
- [x] `ListSnapshots` returns history ascending, ticker match is case-insensitive
- [x] Multi-tenant isolation: user B cannot read user A's snapshot via Get / ListLatest / ListSnapshots
- [x] Frontend lint + build green

Lint via Docker (`make lint`) crashes with the documented Colima OOM (`signal: killed during compile`) — unrelated to this change.

Closes #113

🤖 Generated with [Claude Code](https://claude.com/claude-code)