### PR TITLE
feat(investments): CSV import for Vanguard / Fidelity (#115)

### DIFF
--- a/backend/internal/handler/investment_handler.go
+++ b/backend/internal/handler/investment_handler.go
@@ -23,6 +23,7 @@ func NewInvestmentHandler(s *service.InvestmentService) *InvestmentHandler {
 
 func (h *InvestmentHandler) Register(g *gin.RouterGroup) {
 	g.POST("/investments", h.Create)
+	g.POST("/investments/import-csv", h.ImportCSV)
 	g.GET("/investments", h.List)
 	// /portfolio sits above /:id so the literal segment wins the route match.
 	g.GET("/investments/portfolio", h.Portfolio)
@@ -119,6 +120,61 @@ func (h *InvestmentHandler) List(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{"data": rows, "total": int64(len(rows))})
 }
 
+// ImportCSV accepts a multipart "file" upload + optional ?account_id=N
+// and returns counts + per-row errors. When account_id is missing we
+// fall back to the user's lone investment-typed account; 0 or >1 such
+// accounts → 400 MISSING_ACCOUNT_ID.
+func (h *InvestmentHandler) ImportCSV(c *gin.Context) {
+	userID := auth.MustUserID(c.Request.Context())
+
+	// Cap the upload at 5 MiB — brokerage holdings CSVs are KB-scale.
+	// Anything larger is almost certainly the wrong file.
+	const maxUpload = 5 << 20
+	if err := c.Request.ParseMultipartForm(maxUpload); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error(), "code": "INVALID_UPLOAD"})
+		return
+	}
+	fileHdr, err := c.FormFile("file")
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "missing form field 'file'", "code": "INVALID_UPLOAD"})
+		return
+	}
+	if fileHdr.Size > maxUpload {
+		c.JSON(http.StatusRequestEntityTooLarge, gin.H{"error": "file too large", "code": "FILE_TOO_LARGE"})
+		return
+	}
+	f, err := fileHdr.Open()
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error(), "code": "INVALID_UPLOAD"})
+		return
+	}
+	defer f.Close()
+
+	var accountID int64
+	if q := c.Query("account_id"); q != "" {
+		id, err := strconv.ParseInt(q, 10, 64)
+		if err != nil || id <= 0 {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "account_id must be a positive integer", "code": "INVALID_REQUEST"})
+			return
+		}
+		accountID = id
+	} else {
+		id, err := h.svc.ResolveInvestmentAccount(c.Request.Context(), userID)
+		if err != nil {
+			h.writeServiceError(c, err)
+			return
+		}
+		accountID = id
+	}
+
+	result, err := h.svc.ImportCSV(c.Request.Context(), userID, accountID, f)
+	if err != nil {
+		h.writeServiceError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"data": result})
+}
+
 func (h *InvestmentHandler) Portfolio(c *gin.Context) {
 	summary, err := h.svc.PortfolioSummary(c.Request.Context(), auth.MustUserID(c.Request.Context()))
 	if err != nil {
@@ -139,6 +195,10 @@ func (h *InvestmentHandler) writeServiceError(c *gin.Context, err error) {
 		errors.Is(err, service.ErrNegativeCostBasis),
 		errors.Is(err, service.ErrNegativeMarketValue):
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error(), "code": "INVALID_INVESTMENT"})
+	case errors.Is(err, service.ErrMissingAccountID):
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error(), "code": "MISSING_ACCOUNT_ID"})
+	case errors.Is(err, service.ErrUnknownCSVFormat):
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error(), "code": "UNKNOWN_CSV_FORMAT"})
 	case errors.Is(err, service.ErrInvalidInvestmentSrc):
 		c.JSON(http.StatusBadRequest, gin.H{
 			"error":   err.Error(),

--- a/backend/internal/handler/investment_handler.go
+++ b/backend/internal/handler/investment_handler.go
@@ -148,7 +148,7 @@ func (h *InvestmentHandler) ImportCSV(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error(), "code": "INVALID_UPLOAD"})
 		return
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	var accountID int64
 	if q := c.Query("account_id"); q != "" {

--- a/backend/internal/service/ingestion/csv_investment.go
+++ b/backend/internal/service/ingestion/csv_investment.go
@@ -1,0 +1,302 @@
+// Package ingestion turns external statement files into Investment
+// snapshots. The CSV parser here detects the brokerage format from the
+// header row and produces a parsed result + per-row errors. The caller
+// (InvestmentService) decides whether to persist them.
+//
+// Format detection rationale: Vanguard and Fidelity both ship "positions"
+// exports with stable column names, but the surrounding rows differ —
+// Fidelity prepends metadata, Vanguard sometimes has a trailing
+// disclosure. We skip lines until we see a recognized header, then
+// parse columns by header name (not index) so a re-ordering on the
+// brokerage side doesn't silently corrupt data.
+package ingestion
+
+import (
+	"encoding/csv"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"github.com/shopspring/decimal"
+)
+
+// ErrUnknownCSVFormat is returned when no supported header row is found
+// in the file. Surfaced as a 400 to the user so they can correct the
+// file rather than silently dropping rows.
+var ErrUnknownCSVFormat = errors.New("unknown CSV format: expected Vanguard or Fidelity holdings export")
+
+// ParsedHolding is one row from the CSV, normalized. Money + quantity
+// arrive as decimal strings so service-layer NUMERIC arithmetic stays
+// exact. AssetClass mirrors what the broker says (Fidelity provides
+// "Type"; Vanguard doesn't include one — left empty).
+type ParsedHolding struct {
+	Ticker      string
+	Name        string
+	AssetClass  string
+	Quantity    decimal.Decimal
+	CostBasis   *decimal.Decimal
+	MarketValue *decimal.Decimal
+}
+
+// RowError captures one CSV row that failed to parse. Line is the 1-based
+// line number in the original file (not the data-row index) so users can
+// jump to the offending row in a spreadsheet.
+type RowError struct {
+	Line    int    `json:"line"`
+	Message string `json:"message"`
+}
+
+// ParseResult is the full output of one CSV parse. SnapshotDate is the
+// date we'll stamp on each created snapshot — derived from the CSV's
+// own "Date downloaded" header when present, otherwise today's UTC date.
+type ParseResult struct {
+	Format       string // "vanguard" | "fidelity"
+	SnapshotDate time.Time
+	Holdings     []ParsedHolding
+	Errors       []RowError
+}
+
+// ParseHoldingsCSV reads from r and returns a ParseResult. Returns
+// ErrUnknownCSVFormat if no supported header is detected.
+func ParseHoldingsCSV(r io.Reader) (*ParseResult, error) {
+	// Use a Reader configured with FieldsPerRecord=-1 so trailing
+	// disclosure rows with shorter fields don't kill the parse.
+	cr := csv.NewReader(r)
+	cr.FieldsPerRecord = -1
+	cr.LazyQuotes = true
+
+	res := &ParseResult{
+		SnapshotDate: time.Now().UTC().Truncate(24 * time.Hour),
+		Holdings:     []ParsedHolding{},
+		Errors:       []RowError{},
+	}
+
+	var headers []string
+	var format string
+
+	lineNum := 0
+	for {
+		row, err := cr.Read()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			// Hard CSV error (e.g. unmatched quote) — fail the whole parse.
+			return nil, fmt.Errorf("read csv: %w", err)
+		}
+		lineNum++
+
+		// Try to lift the snapshot date from any pre-header row that looks
+		// like "Date downloaded: 5/13/2026" or "As of 2026-05-13". Cheap to
+		// check on every pre-header row.
+		if format == "" {
+			if d, ok := tryParseDate(row); ok {
+				res.SnapshotDate = d
+			}
+			if f := detectFormat(row); f != "" {
+				format = f
+				headers = normalizeHeaders(row)
+				continue
+			}
+			// Not a header — keep scanning.
+			continue
+		}
+
+		// Past the header — every row should be a holding (or trailing
+		// disclosure). Trailing rows usually have empty Symbol; we skip
+		// silently rather than logging an error per disclosure line.
+		holding, err := parseRow(format, headers, row)
+		if err != nil {
+			if errors.Is(err, errSkipRow) {
+				continue
+			}
+			res.Errors = append(res.Errors, RowError{Line: lineNum, Message: err.Error()})
+			continue
+		}
+		res.Holdings = append(res.Holdings, holding)
+	}
+
+	if format == "" {
+		return nil, ErrUnknownCSVFormat
+	}
+	res.Format = format
+	return res, nil
+}
+
+// errSkipRow signals a row is intentionally not an error — usually a
+// trailing disclosure or all-empty line.
+var errSkipRow = errors.New("skip row")
+
+// detectFormat looks for the canonical first column of each broker's
+// positions export. Header detection is case-insensitive and trims
+// whitespace; brokers occasionally pad cells.
+func detectFormat(row []string) string {
+	hdr := normalizeHeaders(row)
+	// Vanguard: starts with "Investment Name" and includes "Symbol",
+	// "Shares", "Share Price", "Total Value".
+	if has(hdr, "investment name") && has(hdr, "symbol") && has(hdr, "shares") {
+		return "vanguard"
+	}
+	// Fidelity: "Symbol", "Description", "Quantity", "Last Price",
+	// "Current Value", "Cost Basis Total", "Type".
+	if has(hdr, "symbol") && has(hdr, "quantity") && has(hdr, "current value") {
+		return "fidelity"
+	}
+	return ""
+}
+
+func normalizeHeaders(row []string) []string {
+	out := make([]string, len(row))
+	for i, c := range row {
+		out[i] = strings.ToLower(strings.TrimSpace(c))
+	}
+	return out
+}
+
+func has(headers []string, want string) bool {
+	for _, h := range headers {
+		if h == want {
+			return true
+		}
+	}
+	return false
+}
+
+func col(headers []string, row []string, name string) string {
+	for i, h := range headers {
+		if h == name {
+			if i < len(row) {
+				return strings.TrimSpace(row[i])
+			}
+			return ""
+		}
+	}
+	return ""
+}
+
+func parseRow(format string, headers []string, row []string) (ParsedHolding, error) {
+	switch format {
+	case "vanguard":
+		return parseVanguardRow(headers, row)
+	case "fidelity":
+		return parseFidelityRow(headers, row)
+	default:
+		return ParsedHolding{}, fmt.Errorf("unknown format %q", format)
+	}
+}
+
+func parseVanguardRow(headers, row []string) (ParsedHolding, error) {
+	symbol := strings.ToUpper(col(headers, row, "symbol"))
+	if symbol == "" {
+		return ParsedHolding{}, errSkipRow
+	}
+	qtyStr := cleanNumeric(col(headers, row, "shares"))
+	qty, err := decimal.NewFromString(qtyStr)
+	if err != nil {
+		return ParsedHolding{}, fmt.Errorf("shares %q: %w", qtyStr, err)
+	}
+	h := ParsedHolding{
+		Ticker:   symbol,
+		Name:     col(headers, row, "investment name"),
+		Quantity: qty,
+	}
+	if mvStr := cleanNumeric(col(headers, row, "total value")); mvStr != "" {
+		mv, err := decimal.NewFromString(mvStr)
+		if err != nil {
+			return ParsedHolding{}, fmt.Errorf("total value %q: %w", mvStr, err)
+		}
+		h.MarketValue = &mv
+	}
+	return h, nil
+}
+
+func parseFidelityRow(headers, row []string) (ParsedHolding, error) {
+	symbol := strings.ToUpper(col(headers, row, "symbol"))
+	if symbol == "" {
+		return ParsedHolding{}, errSkipRow
+	}
+	// Fidelity sometimes uses prefix markers like "**" on pending tickers;
+	// strip those so they don't trip the service-layer ticker check.
+	symbol = strings.Trim(symbol, "* ")
+	if symbol == "" {
+		return ParsedHolding{}, errSkipRow
+	}
+	qtyStr := cleanNumeric(col(headers, row, "quantity"))
+	qty, err := decimal.NewFromString(qtyStr)
+	if err != nil {
+		return ParsedHolding{}, fmt.Errorf("quantity %q: %w", qtyStr, err)
+	}
+	h := ParsedHolding{
+		Ticker:     symbol,
+		Name:       col(headers, row, "description"),
+		AssetClass: col(headers, row, "type"),
+		Quantity:   qty,
+	}
+	if mvStr := cleanNumeric(col(headers, row, "current value")); mvStr != "" {
+		mv, err := decimal.NewFromString(mvStr)
+		if err != nil {
+			return ParsedHolding{}, fmt.Errorf("current value %q: %w", mvStr, err)
+		}
+		h.MarketValue = &mv
+	}
+	if cbStr := cleanNumeric(col(headers, row, "cost basis total")); cbStr != "" {
+		cb, err := decimal.NewFromString(cbStr)
+		if err != nil {
+			return ParsedHolding{}, fmt.Errorf("cost basis total %q: %w", cbStr, err)
+		}
+		h.CostBasis = &cb
+	}
+	return h, nil
+}
+
+// cleanNumeric strips currency symbols, thousands separators, and
+// surrounding whitespace. Returns "" for empty or "--" / "N/A" markers.
+func cleanNumeric(s string) string {
+	t := strings.TrimSpace(s)
+	if t == "" || t == "--" || strings.EqualFold(t, "n/a") {
+		return ""
+	}
+	// Parentheses around a number = negative (accounting style).
+	negative := false
+	if strings.HasPrefix(t, "(") && strings.HasSuffix(t, ")") {
+		negative = true
+		t = t[1 : len(t)-1]
+	}
+	t = strings.ReplaceAll(t, "$", "")
+	t = strings.ReplaceAll(t, ",", "")
+	t = strings.TrimSpace(t)
+	if negative && !strings.HasPrefix(t, "-") {
+		t = "-" + t
+	}
+	return t
+}
+
+// tryParseDate scans the row for a "Date downloaded: ..." or "As of ..."
+// pattern and returns the parsed UTC midnight. Returns ok=false if
+// nothing matches — caller falls back to today.
+func tryParseDate(row []string) (time.Time, bool) {
+	for _, cell := range row {
+		c := strings.TrimSpace(cell)
+		for _, prefix := range []string{"Date downloaded:", "Date downloaded ", "As of:", "As of "} {
+			if strings.HasPrefix(c, prefix) {
+				val := strings.TrimSpace(strings.TrimPrefix(c, prefix))
+				if t, ok := parseFlexibleDate(val); ok {
+					return t, true
+				}
+			}
+		}
+	}
+	return time.Time{}, false
+}
+
+func parseFlexibleDate(s string) (time.Time, bool) {
+	layouts := []string{"2006-01-02", "1/2/2006", "01/02/2006", "1/2/06"}
+	for _, l := range layouts {
+		if t, err := time.Parse(l, s); err == nil {
+			return t.UTC().Truncate(24 * time.Hour), true
+		}
+	}
+	return time.Time{}, false
+}

--- a/backend/internal/service/ingestion/csv_investment_test.go
+++ b/backend/internal/service/ingestion/csv_investment_test.go
@@ -1,0 +1,147 @@
+package ingestion_test
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/shopspring/decimal"
+
+	"github.com/gregwym/offbook/backend/internal/service/ingestion"
+)
+
+// Vanguard sample shape: a brief disclaimer/date row, blank line, then
+// the header. This mirrors what a real Positions export looks like.
+const vanguardCSV = `Date downloaded: 5/13/2026
+Account Summary
+
+Investment Name,Symbol,Shares,Share Price,Total Value
+Vanguard Total Stock Market Index Fund,VTSAX,142.0000,$112.45,"$15,967.90"
+Vanguard Total Bond Market Index Fund,VBTLX,89.5000,$10.21,$913.80
+
+Important disclosures: returns are illustrative.
+`
+
+// Fidelity sample shape: header on the first line, holdings, trailing
+// blank line + disclaimer. Includes a row with "**" prefix on the symbol
+// (Fidelity uses this for pending settlements) — should be stripped.
+const fidelityCSV = `Symbol,Description,Quantity,Last Price,Current Value,Cost Basis Total,Average Cost Basis,Type
+AAPL,APPLE INC,28.0000,$184.12,"$5,155.36","$3,000.00",$107.14,Cash
+**TSLA,TESLA INC,5.0000,$612.40,"$3,062.00","$2,500.00",$500.00,Cash
+"BTCUSD","Bitcoin","0.05123456789012345",$104210.00,"$5,341.22",,,Crypto
+
+The data above is for informational purposes only.
+`
+
+func TestParseHoldingsCSV_Vanguard(t *testing.T) {
+	res, err := ingestion.ParseHoldingsCSV(strings.NewReader(vanguardCSV))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if res.Format != "vanguard" {
+		t.Errorf("format = %q, want vanguard", res.Format)
+	}
+	if len(res.Holdings) != 2 {
+		t.Fatalf("len(holdings) = %d, want 2", len(res.Holdings))
+	}
+	if res.SnapshotDate.Format("2006-01-02") != "2026-05-13" {
+		t.Errorf("snapshot date = %s, want 2026-05-13", res.SnapshotDate.Format("2006-01-02"))
+	}
+	vtsax := res.Holdings[0]
+	if vtsax.Ticker != "VTSAX" {
+		t.Errorf("ticker = %q, want VTSAX", vtsax.Ticker)
+	}
+	if !vtsax.Quantity.Equal(decimal.NewFromFloat(142.0)) {
+		t.Errorf("quantity = %s, want 142", vtsax.Quantity)
+	}
+	if vtsax.MarketValue == nil || !vtsax.MarketValue.Equal(decimal.NewFromFloat(15967.90)) {
+		t.Errorf("market value = %v, want 15967.90", vtsax.MarketValue)
+	}
+	if vtsax.Name == "" {
+		t.Errorf("name empty; expected Vanguard Total Stock Market Index Fund")
+	}
+	if vtsax.CostBasis != nil {
+		t.Errorf("Vanguard layout has no cost basis col; got %v", vtsax.CostBasis)
+	}
+}
+
+func TestParseHoldingsCSV_Fidelity(t *testing.T) {
+	res, err := ingestion.ParseHoldingsCSV(strings.NewReader(fidelityCSV))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if res.Format != "fidelity" {
+		t.Errorf("format = %q, want fidelity", res.Format)
+	}
+	if len(res.Holdings) != 3 {
+		t.Fatalf("len(holdings) = %d, want 3 (AAPL, TSLA, BTCUSD)", len(res.Holdings))
+	}
+	// AAPL
+	if h := res.Holdings[0]; h.Ticker != "AAPL" || h.AssetClass != "Cash" {
+		t.Errorf("AAPL row = %+v", h)
+	}
+	if h := res.Holdings[0]; h.CostBasis == nil || !h.CostBasis.Equal(decimal.NewFromInt(3000)) {
+		t.Errorf("AAPL cost basis = %v, want 3000", h.CostBasis)
+	}
+	// TSLA: "**TSLA" → "TSLA" after stripping the pending-settlement marker.
+	if h := res.Holdings[1]; h.Ticker != "TSLA" {
+		t.Errorf("TSLA row ticker = %q, want TSLA (after stripping **)", h.Ticker)
+	}
+	// Crypto: 18-decimal quantity round-trip is the literal M6 acceptance criterion.
+	if h := res.Holdings[2]; h.Ticker != "BTCUSD" {
+		t.Errorf("BTC row ticker = %q", h.Ticker)
+	}
+	wantBTCQty, _ := decimal.NewFromString("0.05123456789012345")
+	if !res.Holdings[2].Quantity.Equal(wantBTCQty) {
+		t.Errorf("BTC quantity = %s, want 0.05123456789012345 (precision)",
+			res.Holdings[2].Quantity.String())
+	}
+}
+
+func TestParseHoldingsCSV_UnknownFormat(t *testing.T) {
+	// Header doesn't match either broker's canonical fields.
+	bad := `Account,Asset,Units,Worth
+ABC,Foo,10,100
+`
+	_, err := ingestion.ParseHoldingsCSV(strings.NewReader(bad))
+	if !errors.Is(err, ingestion.ErrUnknownCSVFormat) {
+		t.Errorf("err = %v, want ErrUnknownCSVFormat", err)
+	}
+}
+
+func TestParseHoldingsCSV_PerRowError(t *testing.T) {
+	// One row has a junk quantity. The good row should still parse.
+	mixed := `Symbol,Description,Quantity,Last Price,Current Value,Cost Basis Total,Average Cost Basis,Type
+AAPL,APPLE INC,10,$184,$1840,$1500,$150,Cash
+BAD,FAILS HERE,notanumber,$10,$10,$10,$10,Cash
+`
+	res, err := ingestion.ParseHoldingsCSV(strings.NewReader(mixed))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if len(res.Holdings) != 1 || res.Holdings[0].Ticker != "AAPL" {
+		t.Errorf("expected only AAPL to land, got %+v", res.Holdings)
+	}
+	if len(res.Errors) != 1 {
+		t.Errorf("expected 1 row error, got %d (%+v)", len(res.Errors), res.Errors)
+	}
+}
+
+func TestParseHoldingsCSV_AccountingNegatives(t *testing.T) {
+	// Fidelity reports an unrealized loss as a parenthesized number on
+	// some exports. We don't ingest G/L itself, but cost-basis-total
+	// uses the same numeric cleaner, so the round-trip must work.
+	csv := `Symbol,Description,Quantity,Last Price,Current Value,Cost Basis Total,Average Cost Basis,Type
+XYZ,Test,1,$10,"$5","($10.00)",$10,Cash
+`
+	res, err := ingestion.ParseHoldingsCSV(strings.NewReader(csv))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if len(res.Holdings) != 1 {
+		t.Fatalf("len = %d, want 1", len(res.Holdings))
+	}
+	if res.Holdings[0].CostBasis == nil || !res.Holdings[0].CostBasis.Equal(decimal.NewFromFloat(-10.0)) {
+		t.Errorf("cost basis = %v, want -10 (accounting parens)", res.Holdings[0].CostBasis)
+	}
+}

--- a/backend/internal/service/investment_service.go
+++ b/backend/internal/service/investment_service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"sort"
 	"strings"
 	"time"
@@ -12,6 +13,7 @@ import (
 
 	"github.com/gregwym/offbook/backend/internal/model"
 	"github.com/gregwym/offbook/backend/internal/repository"
+	"github.com/gregwym/offbook/backend/internal/service/ingestion"
 )
 
 // Investment source enum. Mirrors the CHECK constraint on
@@ -35,6 +37,8 @@ var (
 	ErrInvalidInvestmentSrc = errors.New("source must be one of: plaid, csv, manual")
 	ErrNegativeCostBasis    = errors.New("cost_basis must be >= 0")
 	ErrNegativeMarketValue  = errors.New("market_value must be >= 0")
+	ErrMissingAccountID     = errors.New("account_id is required: user has no unique investment account")
+	ErrUnknownCSVFormat     = errors.New("unknown CSV format: expected Vanguard or Fidelity holdings export")
 )
 
 // CreateInvestmentInput is the validated payload for snapshot creation.
@@ -239,4 +243,90 @@ func (s *InvestmentService) PortfolioSummary(ctx context.Context, userID int64) 
 	}
 
 	return out, nil
+}
+
+// ImportResult mirrors the JSON contract for the CSV import endpoint.
+type ImportResult struct {
+	Imported int                  `json:"imported"`
+	Skipped  int                  `json:"skipped"`
+	Errors   []ingestion.RowError `json:"errors"`
+	Format   string               `json:"format"`
+}
+
+// ResolveInvestmentAccount picks an account for an import when the caller
+// didn't supply one. Returns the lone investment-typed account or
+// ErrMissingAccountID when there are 0 or >1 matches. Used by both the
+// handler and CSV import to honor the "single investment account =
+// implicit destination" UX from #115.
+func (s *InvestmentService) ResolveInvestmentAccount(ctx context.Context, userID int64) (int64, error) {
+	accounts, _, err := s.acctRepo.List(ctx, userID, repository.AccountFilter{AccountType: "investment", Limit: 2})
+	if err != nil {
+		return 0, fmt.Errorf("list investment accounts: %w", err)
+	}
+	if len(accounts) != 1 {
+		return 0, ErrMissingAccountID
+	}
+	return accounts[0].ID, nil
+}
+
+// ImportCSV parses a Vanguard or Fidelity holdings export and creates one
+// snapshot per row (source='csv'). Each row is validated and persisted
+// independently; per-row errors are accumulated into the result instead
+// of aborting the whole import, so a single bad row doesn't lose the
+// good ones. Each row is its own single-row insert (no cross-row
+// invariant), so the GORM connection's SkipDefaultTransaction is fine
+// and we don't wrap in db.Transaction.
+func (s *InvestmentService) ImportCSV(ctx context.Context, userID, accountID int64, r io.Reader) (*ImportResult, error) {
+	// Confirm the destination account belongs to the user before parsing.
+	if _, err := s.acctRepo.GetByID(ctx, userID, accountID); err != nil {
+		if errors.Is(err, repository.ErrNotFound) {
+			return nil, ErrAccountNotFound
+		}
+		return nil, fmt.Errorf("validate account: %w", err)
+	}
+
+	parsed, err := ingestion.ParseHoldingsCSV(r)
+	if err != nil {
+		if errors.Is(err, ingestion.ErrUnknownCSVFormat) {
+			return nil, ErrUnknownCSVFormat
+		}
+		return nil, fmt.Errorf("parse csv: %w", err)
+	}
+
+	result := &ImportResult{
+		Format: parsed.Format,
+		Errors: append([]ingestion.RowError{}, parsed.Errors...),
+	}
+
+	for i, h := range parsed.Holdings {
+		in := CreateInvestmentInput{
+			AccountID:    accountID,
+			Ticker:       h.Ticker,
+			Quantity:     h.Quantity,
+			CostBasis:    h.CostBasis,
+			MarketValue:  h.MarketValue,
+			SnapshotDate: parsed.SnapshotDate,
+			Source:       InvestmentSourceCSV,
+		}
+		if h.Name != "" {
+			n := h.Name
+			in.Name = &n
+		}
+		if h.AssetClass != "" {
+			c := h.AssetClass
+			in.AssetClass = &c
+		}
+		if _, err := s.Create(ctx, userID, in); err != nil {
+			// Surface the broker symbol + the validation error so the
+			// frontend can render a list of offending rows.
+			result.Errors = append(result.Errors, ingestion.RowError{
+				Line:    i + 1, // 1-based holding index within parsed set
+				Message: fmt.Sprintf("%s: %s", h.Ticker, err.Error()),
+			})
+			result.Skipped++
+			continue
+		}
+		result.Imported++
+	}
+	return result, nil
 }

--- a/backend/internal/service/investment_service_test.go
+++ b/backend/internal/service/investment_service_test.go
@@ -3,6 +3,7 @@ package service_test
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -422,6 +423,69 @@ func TestInvestmentService_PortfolioSummary_MultiTenant(t *testing.T) {
 	}
 	if got.HoldingsCount != 0 || !got.TotalMarketValue.IsZero() {
 		t.Errorf("user B saw user A's data: %+v", got)
+	}
+}
+
+func TestInvestmentService_ImportCSV_EndToEnd(t *testing.T) {
+	svc, userID, accountID, _ := newInvestmentSvc(t)
+	csv := `Symbol,Description,Quantity,Last Price,Current Value,Cost Basis Total,Average Cost Basis,Type
+AAPL,APPLE INC,10,$184,"$1,840.00","$1,500.00",$150,Cash
+VTI,VANGUARD TOTAL,50,$240,"$12,000.00","$10,000.00",$200,Cash
+`
+	res, err := svc.ImportCSV(context.Background(), userID, accountID, strings.NewReader(csv))
+	if err != nil {
+		t.Fatalf("import: %v", err)
+	}
+	if res.Imported != 2 || res.Skipped != 0 || len(res.Errors) != 0 {
+		t.Fatalf("got %+v, want imported=2 skipped=0", res)
+	}
+	holdings, err := svc.ListLatest(context.Background(), userID)
+	if err != nil {
+		t.Fatalf("list latest: %v", err)
+	}
+	if len(holdings) != 2 {
+		t.Fatalf("len(holdings) = %d, want 2", len(holdings))
+	}
+	for _, h := range holdings {
+		if h.Source != "csv" {
+			t.Errorf("source = %q, want csv", h.Source)
+		}
+	}
+}
+
+func TestInvestmentService_ImportCSV_UnknownFormat(t *testing.T) {
+	svc, userID, accountID, _ := newInvestmentSvc(t)
+	_, err := svc.ImportCSV(context.Background(), userID, accountID, strings.NewReader("Foo,Bar\n1,2\n"))
+	if !errors.Is(err, service.ErrUnknownCSVFormat) {
+		t.Errorf("err = %v, want ErrUnknownCSVFormat", err)
+	}
+}
+
+func TestInvestmentService_ResolveInvestmentAccount(t *testing.T) {
+	svc, userID, _, g := newInvestmentSvc(t)
+	ctx := context.Background()
+
+	// The fixture seeds one investment-typed account → should resolve.
+	id, err := svc.ResolveInvestmentAccount(ctx, userID)
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if id == 0 {
+		t.Errorf("got id 0, want fixture id")
+	}
+
+	// Add a second investment-typed account → should fail with ErrMissingAccountID.
+	second := &model.Account{
+		UserID: userID, Name: "Second-" + time.Now().Format("150405.000000"),
+		InstitutionSlug: "fixture", AccountType: "investment", Currency: "USD",
+	}
+	if err := g.Create(second).Error; err != nil {
+		t.Fatalf("seed second: %v", err)
+	}
+	t.Cleanup(func() { g.Unscoped().Delete(&model.Account{}, second.ID) })
+
+	if _, err := svc.ResolveInvestmentAccount(ctx, userID); !errors.Is(err, service.ErrMissingAccountID) {
+		t.Errorf("err = %v, want ErrMissingAccountID", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- New `service/ingestion` package with a header-driven CSV parser. Detects Vanguard (`Investment Name + Symbol + Shares + Total Value`) and Fidelity (`Symbol + Quantity + Current Value + Cost Basis Total + Type`) holdings exports from the header row — parses columns by name so column reordering on the brokerage side doesn't silently corrupt data.
- Numeric cleaner strips \`$\`, thousands separators, and treats accounting parens as negatives. Pre-header lines like \`Date downloaded: 5/13/2026\` seed the snapshot date so the import lands at the file's reporting date.
- `InvestmentService.ImportCSV` writes one snapshot per row with `source='csv'`. Per-row failures accumulate into the result rather than aborting the import.
- `ResolveInvestmentAccount` picks the user's lone investment-typed account when `account_id` is omitted; 0 or >1 such accounts → `MISSING_ACCOUNT_ID`.
- `POST /api/v1/investments/import-csv` accepts `multipart/form-data` `file` + optional `?account_id=N`. 5 MiB upload cap. Returns `{data: {imported, skipped, errors, format}}`.

## Test plan
- [x] `go vet ./...` clean
- [x] `make test` (race, p=1) green — including 5 new ingestion tests + 3 new service tests
- [x] `gofmt` clean
- [x] Both broker layouts parse correctly
- [x] 18-decimal-place crypto quantity (0.05123456789012345 BTC) round-trips through the parser
- [x] Unknown header → ErrUnknownCSVFormat
- [x] Per-row parse failure accumulates without dropping siblings
- [x] Accounting parens negative round-trip
- [x] End-to-end: CSV → ImportCSV → ListLatest returns 2 holdings with source='csv'
- [x] ResolveInvestmentAccount: lone investment account resolved; multiple → MISSING_ACCOUNT_ID
- [x] Frontend lint + build green (no FE changes in this PR)

## Out of scope
- Frontend upload UI (filed as follow-up if needed).
- Schwab / Robinhood / other brokerages (per-broker follow-ups).
- Live price refresh.

Closes #115

🤖 Generated with [Claude Code](https://claude.com/claude-code)