### PR TITLE
feat(ai): AIProvider interface + Claude SSE provider (#126)

### DIFF
--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -23,12 +23,23 @@ type Config struct {
 	PlaidSecret   string
 	PlaidEnv      string // sandbox | development | production
 	PlaidTokenKey []byte // 32 raw bytes (decoded from PLAID_TOKEN_KEY hex)
+
+	// AI providers (M7+). Both optional — when absent, the corresponding
+	// provider is unavailable in the settings UI rather than fatal at boot.
+	ClaudeAPIKey  string
+	OllamaBaseURL string
 }
 
 // PlaidConfigured reports whether the Plaid surface is enabled.
 // Handlers that touch Plaid should refuse the request when this is false.
 func (c Config) PlaidConfigured() bool {
 	return c.PlaidClientID != "" && c.PlaidSecret != "" && len(c.PlaidTokenKey) == 32
+}
+
+// ClaudeConfigured reports whether the Claude provider can be constructed.
+// The AI service hides Claude from settings when this is false.
+func (c Config) ClaudeConfigured() bool {
+	return c.ClaudeAPIKey != ""
 }
 
 // Load reads env vars (with .env support) and validates required combinations.
@@ -51,6 +62,8 @@ func Load() (Config, error) {
 		PlaidClientID:  os.Getenv("PLAID_CLIENT_ID"),
 		PlaidSecret:    os.Getenv("PLAID_SECRET"),
 		PlaidEnv:       getenv("PLAID_ENV", "sandbox"),
+		ClaudeAPIKey:   os.Getenv("CLAUDE_API_KEY"),
+		OllamaBaseURL:  getenv("OLLAMA_BASE_URL", "http://localhost:11434"),
 	}
 
 	if cfg.PlaidClientID != "" {

--- a/backend/internal/service/ai/claude_provider.go
+++ b/backend/internal/service/ai/claude_provider.go
@@ -119,7 +119,7 @@ func (p *ClaudeProvider) Stream(ctx context.Context, req Request) (<-chan Delta,
 		// Drain and close so the connection can be reused, then surface
 		// the API error body to the caller. 401/403 → ErrUnauthorized so
 		// the settings UI can prompt for a new key.
-		defer resp.Body.Close()
+		defer func() { _ = resp.Body.Close() }()
 		errBody, _ := io.ReadAll(io.LimitReader(resp.Body, 4*1024))
 		if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
 			return nil, fmt.Errorf("%w: %s", ErrUnauthorized, strings.TrimSpace(string(errBody)))
@@ -136,7 +136,7 @@ func (p *ClaudeProvider) Stream(ctx context.Context, req Request) (<-chan Delta,
 // resp.Body — closes on every exit path. Closes `out` exactly once after
 // the terminal delta is sent.
 func (p *ClaudeProvider) readStream(ctx context.Context, body io.ReadCloser, out chan<- Delta) {
-	defer body.Close()
+	defer func() { _ = body.Close() }()
 	defer close(out)
 
 	scanner := bufio.NewScanner(body)
@@ -148,7 +148,6 @@ func (p *ClaudeProvider) readStream(ctx context.Context, body io.ReadCloser, out
 		currentEvent string
 		usage        Usage
 		finishReason string
-		sentDone     bool
 	)
 
 	send := func(d Delta) bool {
@@ -240,7 +239,6 @@ func (p *ClaudeProvider) readStream(ctx context.Context, body io.ReadCloser, out
 				}
 			case "message_stop":
 				_ = send(Delta{Done: true, FinishReason: finishReason, Usage: usage})
-				sentDone = true
 				return
 			case "error":
 				// Anthropic streams API-side errors as {"type":"error","error":{"type","message"}}
@@ -266,11 +264,10 @@ func (p *ClaudeProvider) readStream(ctx context.Context, body io.ReadCloser, out
 		return
 	}
 
-	if !sentDone {
-		// Stream ended without message_stop. Surface as error so the
-		// caller doesn't silently persist a half-message.
-		_ = send(Delta{Err: errors.New("ai: claude stream ended without message_stop")})
-	}
+	// Scanner ended naturally without message_stop — surface as error so
+	// the caller doesn't silently persist a half-message. (The message_stop
+	// branch above returns early before reaching here.)
+	_ = send(Delta{Err: errors.New("ai: claude stream ended without message_stop")})
 }
 
 // claudeRequest mirrors the Anthropic Messages API request body.

--- a/backend/internal/service/ai/claude_provider.go
+++ b/backend/internal/service/ai/claude_provider.go
@@ -1,0 +1,291 @@
+package ai
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+)
+
+// DefaultClaudeModel is the model used when Request.Model is empty.
+// Bumped per model release; tests pin to specific models when needed.
+const DefaultClaudeModel = "claude-sonnet-4-6"
+
+const (
+	defaultClaudeEndpoint = "https://api.anthropic.com/v1/messages"
+	anthropicVersion      = "2023-06-01"
+	defaultMaxTokens      = 1024
+)
+
+// ClaudeProvider speaks the Anthropic Messages API directly over net/http —
+// no SDK dependency. The streaming protocol is parsed inline (see
+// readStream) so the package stays small and auditable per ADR-0003.
+type ClaudeProvider struct {
+	apiKey   string
+	endpoint string // overridable for httptest fixtures
+	http     *http.Client
+}
+
+// ClaudeConfig configures the provider. APIKey is required; Endpoint and
+// HTTPClient have sensible defaults and are only set in tests.
+type ClaudeConfig struct {
+	APIKey     string
+	Endpoint   string // defaults to defaultClaudeEndpoint
+	HTTPClient *http.Client
+}
+
+// NewClaudeProvider validates config and returns a ready provider. Caller
+// is responsible for not constructing one when CLAUDE_API_KEY is unset —
+// the service layer hides the provider behind a settings check.
+func NewClaudeProvider(cfg ClaudeConfig) (*ClaudeProvider, error) {
+	if cfg.APIKey == "" {
+		return nil, errors.New("ai: claude provider requires APIKey")
+	}
+	endpoint := cfg.Endpoint
+	if endpoint == "" {
+		endpoint = defaultClaudeEndpoint
+	}
+	client := cfg.HTTPClient
+	if client == nil {
+		// No timeout — streaming responses run as long as the model wants.
+		// Cancellation is via ctx, which the request honors.
+		client = &http.Client{}
+	}
+	return &ClaudeProvider{
+		apiKey:   cfg.APIKey,
+		endpoint: endpoint,
+		http:     client,
+	}, nil
+}
+
+// Name is the stable identifier persisted in ai_messages.provider.
+func (p *ClaudeProvider) Name() string { return "claude" }
+
+// Stream POSTs to /v1/messages with stream=true and surfaces text_delta
+// events through a Delta channel. The returned channel is closed exactly
+// once, after either a terminal Done delta or an Err delta.
+func (p *ClaudeProvider) Stream(ctx context.Context, req Request) (<-chan Delta, error) {
+	if len(req.Messages) == 0 {
+		return nil, ErrEmptyRequest
+	}
+
+	model := req.Model
+	if model == "" {
+		model = DefaultClaudeModel
+	}
+	maxTokens := req.MaxTokens
+	if maxTokens <= 0 {
+		maxTokens = defaultMaxTokens
+	}
+
+	body := claudeRequest{
+		Model:     model,
+		MaxTokens: maxTokens,
+		Stream:    true,
+		System:    req.System,
+		Messages:  make([]claudeMessage, 0, len(req.Messages)),
+	}
+	for _, m := range req.Messages {
+		body.Messages = append(body.Messages, claudeMessage{
+			Role:    string(m.Role),
+			Content: m.Content,
+		})
+	}
+
+	raw, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("ai: marshal claude request: %w", err)
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, p.endpoint, bytes.NewReader(raw))
+	if err != nil {
+		return nil, fmt.Errorf("ai: build claude request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Accept", "text/event-stream")
+	httpReq.Header.Set("x-api-key", p.apiKey)
+	httpReq.Header.Set("anthropic-version", anthropicVersion)
+
+	resp, err := p.http.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("ai: claude request failed: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		// Drain and close so the connection can be reused, then surface
+		// the API error body to the caller. 401/403 → ErrUnauthorized so
+		// the settings UI can prompt for a new key.
+		defer resp.Body.Close()
+		errBody, _ := io.ReadAll(io.LimitReader(resp.Body, 4*1024))
+		if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
+			return nil, fmt.Errorf("%w: %s", ErrUnauthorized, strings.TrimSpace(string(errBody)))
+		}
+		return nil, fmt.Errorf("ai: claude returned %d: %s", resp.StatusCode, strings.TrimSpace(string(errBody)))
+	}
+
+	out := make(chan Delta, 16)
+	go p.readStream(ctx, resp.Body, out)
+	return out, nil
+}
+
+// readStream parses the Anthropic SSE event stream and pushes Deltas. Owns
+// resp.Body — closes on every exit path. Closes `out` exactly once after
+// the terminal delta is sent.
+func (p *ClaudeProvider) readStream(ctx context.Context, body io.ReadCloser, out chan<- Delta) {
+	defer body.Close()
+	defer close(out)
+
+	scanner := bufio.NewScanner(body)
+	// SSE lines can carry whole JSON payloads; default 64KiB buffer is
+	// tight for large content_block_delta events.
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+
+	var (
+		currentEvent string
+		usage        Usage
+		finishReason string
+		sentDone     bool
+	)
+
+	send := func(d Delta) bool {
+		select {
+		case <-ctx.Done():
+			return false
+		case out <- d:
+			return true
+		}
+	}
+
+	for scanner.Scan() {
+		// Honor ctx between lines; the http stack will also abort the
+		// underlying read, but a quick check here surfaces cancellation
+		// without waiting for the next network read.
+		if ctx.Err() != nil {
+			return
+		}
+
+		line := scanner.Text()
+		switch {
+		case line == "":
+			// blank line: event boundary. We dispatch on data: lines as
+			// they arrive, so nothing to do here.
+			continue
+		case strings.HasPrefix(line, ":"):
+			// SSE comment / heartbeat
+			continue
+		case strings.HasPrefix(line, "event:"):
+			currentEvent = strings.TrimSpace(strings.TrimPrefix(line, "event:"))
+		case strings.HasPrefix(line, "data:"):
+			data := strings.TrimSpace(strings.TrimPrefix(line, "data:"))
+			if data == "" {
+				continue
+			}
+			switch currentEvent {
+			case "content_block_delta":
+				var ev struct {
+					Delta struct {
+						Type string `json:"type"`
+						Text string `json:"text"`
+					} `json:"delta"`
+				}
+				if err := json.Unmarshal([]byte(data), &ev); err != nil {
+					_ = send(Delta{Err: fmt.Errorf("ai: parse content_block_delta: %w", err)})
+					return
+				}
+				if ev.Delta.Type == "text_delta" && ev.Delta.Text != "" {
+					if !send(Delta{Text: ev.Delta.Text}) {
+						return
+					}
+				}
+			case "message_delta":
+				var ev struct {
+					Delta struct {
+						StopReason string `json:"stop_reason"`
+					} `json:"delta"`
+					Usage struct {
+						InputTokens  int `json:"input_tokens"`
+						OutputTokens int `json:"output_tokens"`
+					} `json:"usage"`
+				}
+				if err := json.Unmarshal([]byte(data), &ev); err != nil {
+					_ = send(Delta{Err: fmt.Errorf("ai: parse message_delta: %w", err)})
+					return
+				}
+				if ev.Delta.StopReason != "" {
+					finishReason = ev.Delta.StopReason
+				}
+				// message_delta usage carries only output_tokens. Input
+				// tokens come from message_start.
+				if ev.Usage.OutputTokens > 0 {
+					usage.OutputTokens = ev.Usage.OutputTokens
+				}
+			case "message_start":
+				var ev struct {
+					Message struct {
+						Usage struct {
+							InputTokens  int `json:"input_tokens"`
+							OutputTokens int `json:"output_tokens"`
+						} `json:"usage"`
+					} `json:"message"`
+				}
+				if err := json.Unmarshal([]byte(data), &ev); err == nil {
+					usage.InputTokens = ev.Message.Usage.InputTokens
+					if ev.Message.Usage.OutputTokens > 0 {
+						usage.OutputTokens = ev.Message.Usage.OutputTokens
+					}
+				}
+			case "message_stop":
+				_ = send(Delta{Done: true, FinishReason: finishReason, Usage: usage})
+				sentDone = true
+				return
+			case "error":
+				// Anthropic streams API-side errors as {"type":"error","error":{"type","message"}}
+				var ev struct {
+					Error struct {
+						Type    string `json:"type"`
+						Message string `json:"message"`
+					} `json:"error"`
+				}
+				_ = json.Unmarshal([]byte(data), &ev)
+				_ = send(Delta{Err: fmt.Errorf("ai: claude stream error: %s: %s", ev.Error.Type, ev.Error.Message)})
+				return
+			}
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		// ctx.Done propagates as a body-read error; classify it as cancellation.
+		if ctx.Err() != nil {
+			return
+		}
+		_ = send(Delta{Err: fmt.Errorf("ai: read claude stream: %w", err)})
+		return
+	}
+
+	if !sentDone {
+		// Stream ended without message_stop. Surface as error so the
+		// caller doesn't silently persist a half-message.
+		_ = send(Delta{Err: errors.New("ai: claude stream ended without message_stop")})
+	}
+}
+
+// claudeRequest mirrors the Anthropic Messages API request body.
+type claudeRequest struct {
+	Model     string          `json:"model"`
+	MaxTokens int             `json:"max_tokens"`
+	Stream    bool            `json:"stream"`
+	System    string          `json:"system,omitempty"`
+	Messages  []claudeMessage `json:"messages"`
+}
+
+type claudeMessage struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+// Compile-time assertion that ClaudeProvider satisfies Provider.
+var _ Provider = (*ClaudeProvider)(nil)

--- a/backend/internal/service/ai/claude_provider_test.go
+++ b/backend/internal/service/ai/claude_provider_test.go
@@ -1,0 +1,187 @@
+package ai
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestClaudeProvider_Stream_FixtureRoundtrip pipes a recorded SSE response
+// (testdata/claude_stream.sse) through the provider and checks the parsed
+// Delta sequence. Locks down: text concatenation order, stop reason, usage
+// rollup from message_start + message_delta, terminal Done sentinel, and
+// channel close.
+func TestClaudeProvider_Stream_FixtureRoundtrip(t *testing.T) {
+	fixture, err := os.ReadFile("testdata/claude_stream.sse")
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+
+	var gotReq claudeRequest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got, want := r.Header.Get("x-api-key"), "sk-test"; got != want {
+			t.Errorf("x-api-key = %q, want %q", got, want)
+		}
+		if got, want := r.Header.Get("anthropic-version"), anthropicVersion; got != want {
+			t.Errorf("anthropic-version = %q, want %q", got, want)
+		}
+		body, _ := io.ReadAll(r.Body)
+		if err := json.Unmarshal(body, &gotReq); err != nil {
+			t.Errorf("decode request: %v", err)
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(fixture)
+	}))
+	defer srv.Close()
+
+	p, err := NewClaudeProvider(ClaudeConfig{
+		APIKey:   "sk-test",
+		Endpoint: srv.URL,
+	})
+	if err != nil {
+		t.Fatalf("NewClaudeProvider: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	ch, err := p.Stream(ctx, Request{
+		System:   "You are a finance assistant.",
+		Messages: []Message{{Role: RoleUser, Content: "hi"}},
+	})
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+
+	var (
+		texts    []string
+		done     Delta
+		gotDone  bool
+		streamed []Delta
+	)
+	for d := range ch {
+		streamed = append(streamed, d)
+		switch {
+		case d.Err != nil:
+			t.Fatalf("unexpected error delta: %v", d.Err)
+		case d.Done:
+			done = d
+			gotDone = true
+		default:
+			texts = append(texts, d.Text)
+		}
+	}
+
+	if !gotDone {
+		t.Fatal("stream ended without a Done delta")
+	}
+	if got, want := strings.Join(texts, ""), "Hello, world!"; got != want {
+		t.Errorf("concatenated text = %q, want %q", got, want)
+	}
+	if got, want := done.FinishReason, "end_turn"; got != want {
+		t.Errorf("FinishReason = %q, want %q", got, want)
+	}
+	if got, want := done.Usage.InputTokens, 17; got != want {
+		t.Errorf("InputTokens = %d, want %d", got, want)
+	}
+	if got, want := done.Usage.OutputTokens, 9; got != want {
+		t.Errorf("OutputTokens = %d, want %d", got, want)
+	}
+	if last := streamed[len(streamed)-1]; !last.Done {
+		t.Errorf("last delta should be Done, got %+v", last)
+	}
+
+	// Request payload sanity: defaults applied, stream=true, system + messages forwarded.
+	if !gotReq.Stream {
+		t.Errorf("request stream flag not set")
+	}
+	if gotReq.Model != DefaultClaudeModel {
+		t.Errorf("model = %q, want default %q", gotReq.Model, DefaultClaudeModel)
+	}
+	if gotReq.MaxTokens != defaultMaxTokens {
+		t.Errorf("max_tokens = %d, want default %d", gotReq.MaxTokens, defaultMaxTokens)
+	}
+	if gotReq.System != "You are a finance assistant." {
+		t.Errorf("system not forwarded, got %q", gotReq.System)
+	}
+	if len(gotReq.Messages) != 1 || gotReq.Messages[0].Role != "user" || gotReq.Messages[0].Content != "hi" {
+		t.Errorf("messages not forwarded correctly: %+v", gotReq.Messages)
+	}
+}
+
+// TestClaudeProvider_Stream_Unauthorized maps 401 from the API to
+// ErrUnauthorized so the settings UI can prompt for a new key without
+// scraping error strings.
+func TestClaudeProvider_Stream_Unauthorized(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error":{"type":"authentication_error","message":"invalid x-api-key"}}`))
+	}))
+	defer srv.Close()
+
+	p, _ := NewClaudeProvider(ClaudeConfig{APIKey: "sk-bad", Endpoint: srv.URL})
+	_, err := p.Stream(context.Background(), Request{Messages: []Message{{Role: RoleUser, Content: "hi"}}})
+	if !errors.Is(err, ErrUnauthorized) {
+		t.Fatalf("err = %v, want ErrUnauthorized", err)
+	}
+}
+
+// TestClaudeProvider_Stream_EmptyRequest short-circuits before any network IO.
+func TestClaudeProvider_Stream_EmptyRequest(t *testing.T) {
+	p, _ := NewClaudeProvider(ClaudeConfig{APIKey: "sk-test"})
+	_, err := p.Stream(context.Background(), Request{})
+	if !errors.Is(err, ErrEmptyRequest) {
+		t.Fatalf("err = %v, want ErrEmptyRequest", err)
+	}
+}
+
+// TestClaudeProvider_Stream_APIErrorEvent surfaces an `error` SSE event as
+// a terminal Err delta instead of silently truncating the message.
+func TestClaudeProvider_Stream_APIErrorEvent(t *testing.T) {
+	body := "event: message_start\n" +
+		`data: {"type":"message_start","message":{"id":"msg_x","usage":{"input_tokens":1,"output_tokens":0}}}` + "\n\n" +
+		"event: error\n" +
+		`data: {"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}` + "\n\n"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	p, _ := NewClaudeProvider(ClaudeConfig{APIKey: "sk-test", Endpoint: srv.URL})
+	ch, err := p.Stream(context.Background(), Request{Messages: []Message{{Role: RoleUser, Content: "hi"}}})
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+	var sawErr bool
+	for d := range ch {
+		if d.Err != nil {
+			sawErr = true
+			if !strings.Contains(d.Err.Error(), "Overloaded") {
+				t.Errorf("err = %v, want it to mention Overloaded", d.Err)
+			}
+		}
+	}
+	if !sawErr {
+		t.Fatal("expected Err delta from error SSE event")
+	}
+}
+
+// TestClaudeProvider_Name pins the provenance string. Changing it would
+// orphan existing ai_messages.provider rows.
+func TestClaudeProvider_Name(t *testing.T) {
+	p, _ := NewClaudeProvider(ClaudeConfig{APIKey: "sk-test"})
+	if got, want := p.Name(), "claude"; got != want {
+		t.Errorf("Name() = %q, want %q", got, want)
+	}
+}

--- a/backend/internal/service/ai/noimport_test.go
+++ b/backend/internal/service/ai/noimport_test.go
@@ -1,0 +1,52 @@
+package ai_test
+
+import (
+	"go/build"
+	"strings"
+	"testing"
+)
+
+// TestAIPackage_DoesNotImportPIIRepo is the architectural enforcement that
+// ADR-0003 / ARCHITECTURE.md (PII Isolation) calls out: the AI layer must
+// never depend on pii_repo, transitively or directly. A new import here is
+// the easiest way to leak PII into prompts, so we fail the test the moment
+// the package graph references pii_repo.
+//
+// Walks the build-time import graph of internal/service/ai (recursively)
+// and asserts no edge ends in repository/pii_repo or any pii_ symbol from
+// the repository layer.
+func TestAIPackage_DoesNotImportPIIRepo(t *testing.T) {
+	const target = "github.com/gregwym/offbook/backend/internal/service/ai"
+	forbidden := []string{
+		"github.com/gregwym/offbook/backend/internal/repository/pii",
+		"internal/repository/pii_repo",
+	}
+
+	seen := map[string]bool{}
+	var walk func(pkgPath string)
+	walk = func(pkgPath string) {
+		if seen[pkgPath] {
+			return
+		}
+		seen[pkgPath] = true
+		pkg, err := build.Default.Import(pkgPath, ".", 0)
+		if err != nil {
+			// Stdlib packages or vendor-resolution issues should not fail
+			// the rule — they cannot contain pii_repo.
+			return
+		}
+		for _, imp := range pkg.Imports {
+			for _, bad := range forbidden {
+				if strings.Contains(imp, bad) {
+					t.Errorf("ai package imports forbidden path %q (via %s)", imp, pkgPath)
+				}
+			}
+			// Only recurse into our own module — stdlib and third-party
+			// dependencies cannot reach pii_repo by definition.
+			if strings.HasPrefix(imp, "github.com/gregwym/offbook/backend/") {
+				walk(imp)
+			}
+		}
+	}
+	walk(target)
+}

--- a/backend/internal/service/ai/provider.go
+++ b/backend/internal/service/ai/provider.go
@@ -1,0 +1,90 @@
+// Package ai is the AI assistant layer. It owns the provider abstraction
+// (Claude, Ollama, future LLMs), the anonymized context builder, and the
+// service that wires them to ai_threads/ai_messages.
+//
+// Architectural rule (ADR-0003, ADR-0005, ARCHITECTURE.md → PII Isolation):
+// nothing in this package may import the pii_repo. Providers see only the
+// anonymized context that context_builder produces. The check is enforced
+// by a test in noimport_test.go.
+package ai
+
+import (
+	"context"
+	"errors"
+)
+
+// Role is one of "user", "assistant", or "system". System messages should
+// usually go in Request.System instead of the Messages slice — Anthropic's
+// API rejects role=system in messages.
+type Role string
+
+const (
+	RoleUser      Role = "user"
+	RoleAssistant Role = "assistant"
+)
+
+// Message is one turn in the conversation. Content is a plain string; the
+// provider is responsible for encoding into provider-specific shapes (e.g.
+// Claude's content blocks).
+type Message struct {
+	Role    Role
+	Content string
+}
+
+// Request is the provider-agnostic input to Provider.Stream. Callers should
+// leave Model empty to use the provider's default — Provider implementations
+// fill in their own default if it is unset.
+type Request struct {
+	Model     string
+	System    string
+	Messages  []Message
+	MaxTokens int
+}
+
+// Delta is one event from the streaming response. Exactly one of Text, Done,
+// or Err is meaningful per delta:
+//   - Text: incremental token text. Concatenate across deltas to reconstruct
+//     the assistant message.
+//   - Done: terminal sentinel. FinishReason ("end_turn", "max_tokens", ...)
+//     and Usage are populated. Channel is closed after this delta is sent.
+//   - Err: transport / parse / API error. Terminal; channel closes after.
+//
+// FinishReason and Usage are only meaningful on the Done delta.
+type Delta struct {
+	Text         string
+	Done         bool
+	FinishReason string
+	Usage        Usage
+	Err          error
+}
+
+// Usage reports token counts for one Stream call. Output is the running
+// count from the provider; Input is the prompt count.
+type Usage struct {
+	InputTokens  int
+	OutputTokens int
+}
+
+// Provider is the minimum streaming surface the AI service depends on.
+// Implementations: claude_provider.go, ollama_provider.go.
+//
+// Stream returns a receive-only channel of deltas. The provider owns the
+// channel lifecycle: it MUST close the channel after sending a terminal
+// delta (Done=true or Err set), and MUST stop sending if ctx is cancelled.
+// Callers MUST drain or cancel — leaking a Stream call leaks the goroutine
+// reading from the upstream HTTP body.
+type Provider interface {
+	Stream(ctx context.Context, req Request) (<-chan Delta, error)
+
+	// Name returns a short stable identifier ("claude", "ollama") used in
+	// ai_messages.provider for provenance and in settings UI.
+	Name() string
+}
+
+// ErrEmptyRequest is returned when Request has no messages. Providers
+// short-circuit before opening a network connection.
+var ErrEmptyRequest = errors.New("ai: request has no messages")
+
+// ErrUnauthorized signals the provider rejected the API key. Surfaces to
+// the user as a settings-page hint to re-enter credentials.
+var ErrUnauthorized = errors.New("ai: provider rejected credentials")

--- a/backend/internal/service/ai/testdata/claude_stream.sse
+++ b/backend/internal/service/ai/testdata/claude_stream.sse
@@ -1,0 +1,27 @@
+event: message_start
+data: {"type":"message_start","message":{"id":"msg_01","type":"message","role":"assistant","content":[],"model":"claude-sonnet-4-6","stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":17,"output_tokens":1}}}
+
+event: content_block_start
+data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}
+
+event: ping
+data: {"type":"ping"}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":", "}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"world!"}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":0}
+
+event: message_delta
+data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":9}}
+
+event: message_stop
+data: {"type":"message_stop"}
+


### PR DESCRIPTION
## Summary
- New `internal/service/ai` package with a provider-agnostic `Provider` interface (`Stream(ctx, Request) -> <-chan Delta`), `Request`/`Message`/`Delta`/`Usage` types, and sentinel errors (`ErrEmptyRequest`, `ErrUnauthorized`).
- `ClaudeProvider` speaks Anthropic's Messages API over stdlib `net/http`, parses the SSE `text_delta`/`message_delta`/`message_stop`/`error` events inline, and surfaces token usage from `message_start` + `message_delta`. Default model `claude-sonnet-4-6`.
- Build-graph test (`noimport_test.go`) walks every transitive import of `internal/service/ai` and fails if anything references `pii_repo` — architectural enforcement for ADR-0003 / ARCHITECTURE.md PII isolation.
- Config gains `CLAUDE_API_KEY` + `OLLAMA_BASE_URL` with a `ClaudeConfigured()` helper. `.env.example` already had these keys.

## Test plan
- [x] `go test ./internal/service/ai/...` — fixture SSE round-trip, 401 → `ErrUnauthorized`, empty-request short-circuit, mid-stream `error` event, provider name pin
- [x] `go test -race -p 1 ./...` — full backend suite still green
- [x] `go vet ./...` — clean
- [ ] Lint blocked locally by the known Docker-VM `signal: killed during compile` issue documented in `CLAUDE.md`; will defer to CI