### PR TITLE
feat(ai): Ollama provider — local-first AI alternative (#127)

### DIFF
--- a/backend/internal/service/ai/ollama_provider.go
+++ b/backend/internal/service/ai/ollama_provider.go
@@ -1,0 +1,219 @@
+package ai
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+)
+
+// DefaultOllamaModel is the model used when Request.Model is empty. Picked
+// for being a sane "is this thing on" default — users override per-thread
+// from the Settings/model-switcher UI.
+const DefaultOllamaModel = "llama3:8b"
+
+// DefaultOllamaBaseURL is the conventional local Ollama bind address.
+const DefaultOllamaBaseURL = "http://localhost:11434"
+
+// OllamaProvider streams Ollama's /api/chat NDJSON responses through the
+// shared Delta channel. Because Ollama runs locally, there's no API key —
+// the only required config is the base URL.
+type OllamaProvider struct {
+	baseURL string
+	http    *http.Client
+}
+
+// OllamaConfig configures the provider. BaseURL defaults to
+// DefaultOllamaBaseURL when empty.
+type OllamaConfig struct {
+	BaseURL    string
+	HTTPClient *http.Client
+}
+
+// NewOllamaProvider returns a ready provider. It does NOT ping Ollama at
+// construction — the service layer probes /api/tags on a settings-page
+// "test connection" action so a missing daemon doesn't take the backend
+// down at boot.
+func NewOllamaProvider(cfg OllamaConfig) *OllamaProvider {
+	base := cfg.BaseURL
+	if base == "" {
+		base = DefaultOllamaBaseURL
+	}
+	base = strings.TrimRight(base, "/")
+	client := cfg.HTTPClient
+	if client == nil {
+		client = &http.Client{}
+	}
+	return &OllamaProvider{baseURL: base, http: client}
+}
+
+// Name is the stable identifier persisted in ai_messages.provider.
+func (p *OllamaProvider) Name() string { return "ollama" }
+
+// Stream POSTs to {baseURL}/api/chat with stream=true and surfaces each
+// NDJSON line as a Delta. The provider owns the channel: it closes after
+// the terminal Done delta (or an Err delta) and honors ctx cancellation.
+func (p *OllamaProvider) Stream(ctx context.Context, req Request) (<-chan Delta, error) {
+	if len(req.Messages) == 0 {
+		return nil, ErrEmptyRequest
+	}
+
+	model := req.Model
+	if model == "" {
+		model = DefaultOllamaModel
+	}
+
+	// Ollama's /api/chat takes the system prompt as a first system-role
+	// message, not a separate field. Stitch it in here so callers can use
+	// the same Request shape across providers.
+	msgs := make([]ollamaMessage, 0, len(req.Messages)+1)
+	if req.System != "" {
+		msgs = append(msgs, ollamaMessage{Role: "system", Content: req.System})
+	}
+	for _, m := range req.Messages {
+		msgs = append(msgs, ollamaMessage{Role: string(m.Role), Content: m.Content})
+	}
+
+	body := ollamaRequest{
+		Model:    model,
+		Messages: msgs,
+		Stream:   true,
+	}
+	// MaxTokens maps to Ollama's options.num_predict — left absent when 0
+	// so Ollama uses its server-side default.
+	if req.MaxTokens > 0 {
+		body.Options = &ollamaOptions{NumPredict: req.MaxTokens}
+	}
+
+	raw, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("ai: marshal ollama request: %w", err)
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, p.baseURL+"/api/chat", bytes.NewReader(raw))
+	if err != nil {
+		return nil, fmt.Errorf("ai: build ollama request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	resp, err := p.http.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("ai: ollama request failed: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		defer func() { _ = resp.Body.Close() }()
+		errBody, _ := io.ReadAll(io.LimitReader(resp.Body, 4*1024))
+		return nil, fmt.Errorf("ai: ollama returned %d: %s", resp.StatusCode, strings.TrimSpace(string(errBody)))
+	}
+
+	out := make(chan Delta, 16)
+	go p.readStream(ctx, resp.Body, out)
+	return out, nil
+}
+
+// readStream owns resp.Body and the out channel: both are closed before
+// return. NDJSON parsing is one JSON object per line; the terminal object
+// carries done=true plus prompt/eval token counts.
+func (p *OllamaProvider) readStream(ctx context.Context, body io.ReadCloser, out chan<- Delta) {
+	defer func() { _ = body.Close() }()
+	defer close(out)
+
+	scanner := bufio.NewScanner(body)
+	// A single Ollama "message" line can be long — bump the line cap so
+	// large content chunks don't error with bufio.ErrTooLong.
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+
+	send := func(d Delta) bool {
+		select {
+		case <-ctx.Done():
+			return false
+		case out <- d:
+			return true
+		}
+	}
+
+	for scanner.Scan() {
+		if ctx.Err() != nil {
+			return
+		}
+		line := bytes.TrimSpace(scanner.Bytes())
+		if len(line) == 0 {
+			continue
+		}
+		var ev ollamaStreamEvent
+		if err := json.Unmarshal(line, &ev); err != nil {
+			_ = send(Delta{Err: fmt.Errorf("ai: parse ollama line: %w", err)})
+			return
+		}
+		// Ollama also reports daemon-side errors mid-stream as a top-level
+		// "error" field. Surface as a terminal Err delta.
+		if ev.Error != "" {
+			_ = send(Delta{Err: fmt.Errorf("ai: ollama stream error: %s", ev.Error)})
+			return
+		}
+		if ev.Message.Content != "" {
+			if !send(Delta{Text: ev.Message.Content}) {
+				return
+			}
+		}
+		if ev.Done {
+			_ = send(Delta{
+				Done:         true,
+				FinishReason: ev.DoneReason,
+				Usage: Usage{
+					InputTokens:  ev.PromptEvalCount,
+					OutputTokens: ev.EvalCount,
+				},
+			})
+			return
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		if ctx.Err() != nil {
+			return
+		}
+		_ = send(Delta{Err: fmt.Errorf("ai: read ollama stream: %w", err)})
+		return
+	}
+
+	// Stream closed without a done=true line. Surface as error so the
+	// caller doesn't silently persist a half-message.
+	_ = send(Delta{Err: errors.New("ai: ollama stream ended without done=true")})
+}
+
+// ollamaRequest mirrors POST /api/chat body.
+type ollamaRequest struct {
+	Model    string          `json:"model"`
+	Messages []ollamaMessage `json:"messages"`
+	Stream   bool            `json:"stream"`
+	Options  *ollamaOptions  `json:"options,omitempty"`
+}
+
+type ollamaMessage struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+type ollamaOptions struct {
+	NumPredict int `json:"num_predict,omitempty"`
+}
+
+// ollamaStreamEvent is one NDJSON line. The done=true line carries
+// done_reason + eval counts; intermediate lines just carry message.content.
+type ollamaStreamEvent struct {
+	Message         ollamaMessage `json:"message"`
+	Done            bool          `json:"done"`
+	DoneReason      string        `json:"done_reason"`
+	PromptEvalCount int           `json:"prompt_eval_count"`
+	EvalCount       int           `json:"eval_count"`
+	Error           string        `json:"error"`
+}
+
+// Compile-time assertion that OllamaProvider satisfies Provider.
+var _ Provider = (*OllamaProvider)(nil)

--- a/backend/internal/service/ai/ollama_provider_test.go
+++ b/backend/internal/service/ai/ollama_provider_test.go
@@ -1,0 +1,157 @@
+package ai
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestOllamaProvider_Stream_FixtureRoundtrip pipes a recorded NDJSON
+// response through the provider and checks the Delta sequence. Locks down:
+// text concatenation order, system-prompt prepending, done_reason +
+// prompt/eval-count rollup, terminal Done sentinel, channel close.
+func TestOllamaProvider_Stream_FixtureRoundtrip(t *testing.T) {
+	fixture, err := os.ReadFile("testdata/ollama_stream.ndjson")
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+
+	var gotReq ollamaRequest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/chat" {
+			t.Errorf("path = %q, want /api/chat", r.URL.Path)
+		}
+		body, _ := io.ReadAll(r.Body)
+		if err := json.Unmarshal(body, &gotReq); err != nil {
+			t.Errorf("decode request: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/x-ndjson")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(fixture)
+	}))
+	defer srv.Close()
+
+	p := NewOllamaProvider(OllamaConfig{BaseURL: srv.URL})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	ch, err := p.Stream(ctx, Request{
+		System:   "You are a finance assistant.",
+		Messages: []Message{{Role: RoleUser, Content: "hi"}},
+	})
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+
+	var (
+		texts   []string
+		done    Delta
+		gotDone bool
+	)
+	for d := range ch {
+		switch {
+		case d.Err != nil:
+			t.Fatalf("unexpected error delta: %v", d.Err)
+		case d.Done:
+			done = d
+			gotDone = true
+		default:
+			texts = append(texts, d.Text)
+		}
+	}
+
+	if !gotDone {
+		t.Fatal("stream ended without a Done delta")
+	}
+	if got, want := strings.Join(texts, ""), "Hello, world!"; got != want {
+		t.Errorf("concatenated text = %q, want %q", got, want)
+	}
+	if got, want := done.FinishReason, "stop"; got != want {
+		t.Errorf("FinishReason = %q, want %q", got, want)
+	}
+	if got, want := done.Usage.InputTokens, 17; got != want {
+		t.Errorf("InputTokens = %d, want %d", got, want)
+	}
+	if got, want := done.Usage.OutputTokens, 9; got != want {
+		t.Errorf("OutputTokens = %d, want %d", got, want)
+	}
+
+	// Request payload sanity: default model, stream flag, system prepended.
+	if !gotReq.Stream {
+		t.Errorf("stream flag not set")
+	}
+	if gotReq.Model != DefaultOllamaModel {
+		t.Errorf("model = %q, want default %q", gotReq.Model, DefaultOllamaModel)
+	}
+	if len(gotReq.Messages) != 2 {
+		t.Fatalf("messages len = %d, want 2 (system + user)", len(gotReq.Messages))
+	}
+	if gotReq.Messages[0].Role != "system" || gotReq.Messages[0].Content != "You are a finance assistant." {
+		t.Errorf("first message = %+v, want system prompt", gotReq.Messages[0])
+	}
+	if gotReq.Messages[1].Role != "user" || gotReq.Messages[1].Content != "hi" {
+		t.Errorf("second message = %+v, want user 'hi'", gotReq.Messages[1])
+	}
+}
+
+// TestOllamaProvider_Stream_DaemonError surfaces a mid-stream {"error": ...}
+// line as a terminal Err delta.
+func TestOllamaProvider_Stream_DaemonError(t *testing.T) {
+	body := `{"error":"model 'bogus' not found, try pulling it first"}` + "\n"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	p := NewOllamaProvider(OllamaConfig{BaseURL: srv.URL})
+	ch, err := p.Stream(context.Background(), Request{Messages: []Message{{Role: RoleUser, Content: "hi"}}})
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+	var sawErr bool
+	for d := range ch {
+		if d.Err != nil {
+			sawErr = true
+			if !strings.Contains(d.Err.Error(), "not found") {
+				t.Errorf("err = %v, want it to mention not found", d.Err)
+			}
+		}
+	}
+	if !sawErr {
+		t.Fatal("expected Err delta for daemon-side error")
+	}
+}
+
+// TestOllamaProvider_Stream_EmptyRequest short-circuits before network IO.
+func TestOllamaProvider_Stream_EmptyRequest(t *testing.T) {
+	p := NewOllamaProvider(OllamaConfig{})
+	_, err := p.Stream(context.Background(), Request{})
+	if err != ErrEmptyRequest {
+		t.Fatalf("err = %v, want ErrEmptyRequest", err)
+	}
+}
+
+// TestOllamaProvider_Name pins the provenance string.
+func TestOllamaProvider_Name(t *testing.T) {
+	p := NewOllamaProvider(OllamaConfig{})
+	if got, want := p.Name(), "ollama"; got != want {
+		t.Errorf("Name() = %q, want %q", got, want)
+	}
+}
+
+// TestOllamaProvider_DefaultBaseURL ensures empty config uses the
+// conventional local bind.
+func TestOllamaProvider_DefaultBaseURL(t *testing.T) {
+	p := NewOllamaProvider(OllamaConfig{})
+	if p.baseURL != DefaultOllamaBaseURL {
+		t.Errorf("baseURL = %q, want %q", p.baseURL, DefaultOllamaBaseURL)
+	}
+}

--- a/backend/internal/service/ai/testdata/ollama_stream.ndjson
+++ b/backend/internal/service/ai/testdata/ollama_stream.ndjson
@@ -1,0 +1,4 @@
+{"model":"llama3:8b","created_at":"2026-05-18T05:00:00Z","message":{"role":"assistant","content":"Hello"},"done":false}
+{"model":"llama3:8b","created_at":"2026-05-18T05:00:00Z","message":{"role":"assistant","content":", "},"done":false}
+{"model":"llama3:8b","created_at":"2026-05-18T05:00:00Z","message":{"role":"assistant","content":"world!"},"done":false}
+{"model":"llama3:8b","created_at":"2026-05-18T05:00:00Z","message":{"role":"assistant","content":""},"done":true,"done_reason":"stop","total_duration":1234567,"prompt_eval_count":17,"eval_count":9}


### PR DESCRIPTION
## Summary
- `OllamaProvider` implements `ai.Provider` against Ollama's `POST /api/chat` NDJSON streaming endpoint, reusing the same `Delta` channel shape as the Claude provider.
- Default base URL `http://localhost:11434`, default model `llama3:8b`, both overridable. `Request.System` is prepended as a `role: system` message (Ollama's convention).
- Recorded NDJSON fixture (`testdata/ollama_stream.ndjson`) plus tests for daemon-side errors, empty-request short-circuit, provider name, and base-URL defaulting.
- `service/ai/noimport_test.go` from #126 already covers the no-`pii_repo` rule for any new file in the package, so no new architectural test was needed.

## Test plan
- [x] `go test ./internal/service/ai/...` — fixture round-trip, daemon error, empty-request, name pin, default-URL pin
- [x] `go test -race -p 1 ./...` — full backend suite green
- [x] `go vet ./...` and `gofmt -l` — clean
- [ ] Lint via CI (local Docker VM hits the documented `signal: killed during compile` ceiling)