### PR TITLE
feat(ai): context_builder — anonymized financial context (#128)

### DIFF
--- a/backend/internal/service/ai/context_builder.go
+++ b/backend/internal/service/ai/context_builder.go
@@ -207,7 +207,7 @@ func (b *ContextBuilder) Build(ctx context.Context, userID int64) (*Context, err
 		for i := range gs {
 			v := service.View(&gs[i])
 			out.SavingsGoals = append(out.SavingsGoals, GoalSnapshot{
-				Label:       v.SavingsGoal.Name,
+				Label:       v.Name,
 				Target:      v.TargetAmount.String(),
 				Current:     v.CurrentAmount.String(),
 				ProgressPct: v.ProgressPct,

--- a/backend/internal/service/ai/context_builder.go
+++ b/backend/internal/service/ai/context_builder.go
@@ -1,0 +1,268 @@
+package ai
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/gregwym/offbook/backend/internal/service"
+)
+
+// Context is the anonymized financial snapshot embedded in the system
+// prompt before each user turn. Every field is an aggregate or a
+// user-chosen label (category, budget period, goal label). The struct
+// contains no holder names, account numbers, routing numbers, addresses,
+// or any other PII — enforced by TestContext_NoPIIFieldNames in
+// context_builder_test.go.
+//
+// Wire format is JSON. Decimals are stringified at the boundary so the
+// LLM sees stable "1234.56" representations rather than scientific
+// notation; the only float in the struct is ProgressPct (0.0–1.0+).
+type Context struct {
+	GeneratedAt     string           `json:"generated_at"`
+	Period          ContextPeriod    `json:"period"`
+	NetWorth        string           `json:"net_worth"`
+	SpendByCategory []SpendCategory  `json:"spend_by_category"`
+	Budgets         []BudgetSnapshot `json:"budgets"`
+	SavingsGoals    []GoalSnapshot   `json:"savings_goals"`
+	Holdings        HoldingsSummary  `json:"holdings"`
+}
+
+// ContextPeriod is the [from, to) window summarized by SpendByCategory.
+// RFC3339 dates so the LLM sees consistent timestamps.
+type ContextPeriod struct {
+	From string `json:"from"`
+	To   string `json:"to"`
+}
+
+// SpendCategory is one row of the spend rollup. "Category" is the
+// user-visible category label (e.g. "Groceries"), never PII.
+type SpendCategory struct {
+	Category string `json:"category"`
+	Amount   string `json:"amount"`
+}
+
+// BudgetSnapshot is one row of the budget envelope view. Pct is a
+// fraction in [0, 1+) — the assistant can multiply by 100 to display
+// as a percentage; we keep BudgetService's canonical 0..1 shape.
+type BudgetSnapshot struct {
+	Category string  `json:"category"`
+	Period   string  `json:"period"`
+	Limit    string  `json:"limit"`
+	Spent    string  `json:"spent"`
+	Pct      float64 `json:"pct"`
+}
+
+// GoalSnapshot is one row of the savings-goal view. The user-chosen
+// label sits in Label rather than Name so the privacy test's "name"
+// substring check stays strict.
+type GoalSnapshot struct {
+	Label       string  `json:"label"`
+	Target      string  `json:"target"`
+	Current     string  `json:"current"`
+	ProgressPct float64 `json:"progress_pct"`
+}
+
+// HoldingsSummary collapses the portfolio to totals + asset-class
+// allocation. Deliberately omits per-row tickers — the assistant gets the
+// shape of the portfolio, not the contents.
+type HoldingsSummary struct {
+	TotalMarketValue string             `json:"total_market_value"`
+	TotalCostBasis   string             `json:"total_cost_basis"`
+	HoldingsCount    int                `json:"holdings_count"`
+	ByAssetClass     []AssetClassWeight `json:"by_asset_class"`
+}
+
+// AssetClassWeight is one slice of the allocation donut. WeightPct is a
+// 0–100 percentage to match the API-side struct, not a fraction.
+type AssetClassWeight struct {
+	AssetClass  string `json:"asset_class"`
+	MarketValue string `json:"market_value"`
+	WeightPct   string `json:"weight_pct"`
+}
+
+// ContextBuilder assembles an anonymized context from existing aggregate
+// services. The set of injected dependencies is the architectural
+// guarantee: there is no pii_repo here, and there cannot be — pii_service
+// isn't on the dependency list either.
+//
+// All five services are required in production; nil values are accepted
+// to make targeted tests easier (a nil service is treated as "no data of
+// that kind" so a test focused on, say, budgets isn't forced to seed
+// investments).
+type ContextBuilder struct {
+	dashboard   *service.DashboardService
+	budgets     *service.BudgetService
+	goals       *service.SavingsGoalService
+	investments *service.InvestmentService
+	categories  *service.CategoryService
+	now         func() time.Time
+
+	// SpendMonths is the trailing window summed into SpendByCategory.
+	// Default 3 — enough to spot trend changes without overwhelming the
+	// prompt budget.
+	SpendMonths int
+}
+
+// NewContextBuilder wires the builder. Pass nil for any service you don't
+// have in a test; production callers pass all five.
+func NewContextBuilder(
+	dashboard *service.DashboardService,
+	budgets *service.BudgetService,
+	goals *service.SavingsGoalService,
+	investments *service.InvestmentService,
+	categories *service.CategoryService,
+) *ContextBuilder {
+	return &ContextBuilder{
+		dashboard:   dashboard,
+		budgets:     budgets,
+		goals:       goals,
+		investments: investments,
+		categories:  categories,
+		now:         time.Now,
+		SpendMonths: 3,
+	}
+}
+
+// WithNow overrides the clock for tests. Returns the receiver for chaining.
+func (b *ContextBuilder) WithNow(fn func() time.Time) *ContextBuilder {
+	b.now = fn
+	return b
+}
+
+// Build returns the anonymized context for the given user. Partial
+// failures are tolerated — a missing investment account, for example,
+// returns an empty HoldingsSummary rather than aborting the build.
+func (b *ContextBuilder) Build(ctx context.Context, userID int64) (*Context, error) {
+	now := b.now()
+	from, to := trailingMonthsWindow(now, b.SpendMonths)
+
+	out := &Context{
+		GeneratedAt:     now.UTC().Format(time.RFC3339),
+		Period:          ContextPeriod{From: from.UTC().Format(time.RFC3339), To: to.UTC().Format(time.RFC3339)},
+		NetWorth:        "0",
+		SpendByCategory: []SpendCategory{},
+		Budgets:         []BudgetSnapshot{},
+		SavingsGoals:    []GoalSnapshot{},
+		Holdings: HoldingsSummary{
+			TotalMarketValue: "0",
+			TotalCostBasis:   "0",
+			ByAssetClass:     []AssetClassWeight{},
+		},
+	}
+
+	if b.dashboard != nil {
+		// Net worth is point-in-time, so the dashboard's MTD period works
+		// fine — the NetWorth field on the summary ignores the period.
+		summary, err := b.dashboard.Summarize(ctx, userID, service.PeriodCurrentMonth)
+		if err != nil {
+			return nil, fmt.Errorf("ai: dashboard summarize: %w", err)
+		}
+		out.NetWorth = summary.NetWorth
+
+		rows, err := b.dashboard.SpendByCategory(ctx, userID, from, to)
+		if err != nil {
+			return nil, fmt.Errorf("ai: spend by category: %w", err)
+		}
+		for _, r := range rows {
+			out.SpendByCategory = append(out.SpendByCategory, SpendCategory{
+				Category: r.Name,
+				Amount:   r.Amount,
+			})
+		}
+	}
+
+	if b.budgets != nil {
+		list, err := b.budgets.List(ctx, userID)
+		if err != nil {
+			return nil, fmt.Errorf("ai: list budgets: %w", err)
+		}
+		labels := b.categoryLabels(ctx)
+		for _, bud := range list {
+			if !bud.IsActive {
+				continue
+			}
+			// One round trip per active budget. Acceptable: budgets are
+			// few (single-digit) and the context builder runs per-thread,
+			// not per-token.
+			spend, err := b.budgets.Spend(ctx, userID, bud.ID)
+			if err != nil {
+				return nil, fmt.Errorf("ai: budget spend %d: %w", bud.ID, err)
+			}
+			out.Budgets = append(out.Budgets, BudgetSnapshot{
+				Category: labels[bud.CategoryID],
+				Period:   bud.Period,
+				Limit:    spend.Limit.String(),
+				Spent:    spend.Spent.String(),
+				Pct:      spend.Pct,
+			})
+		}
+	}
+
+	if b.goals != nil {
+		gs, err := b.goals.List(ctx, userID)
+		if err != nil {
+			return nil, fmt.Errorf("ai: list goals: %w", err)
+		}
+		for i := range gs {
+			v := service.View(&gs[i])
+			out.SavingsGoals = append(out.SavingsGoals, GoalSnapshot{
+				Label:       v.SavingsGoal.Name,
+				Target:      v.TargetAmount.String(),
+				Current:     v.CurrentAmount.String(),
+				ProgressPct: v.ProgressPct,
+			})
+		}
+	}
+
+	if b.investments != nil {
+		pf, err := b.investments.PortfolioSummary(ctx, userID)
+		if err != nil {
+			return nil, fmt.Errorf("ai: portfolio summary: %w", err)
+		}
+		out.Holdings.TotalMarketValue = pf.TotalMarketValue.String()
+		out.Holdings.TotalCostBasis = pf.TotalCostBasis.String()
+		out.Holdings.HoldingsCount = pf.HoldingsCount
+		for _, ac := range pf.ByAssetClass {
+			out.Holdings.ByAssetClass = append(out.Holdings.ByAssetClass, AssetClassWeight{
+				AssetClass:  ac.AssetClass,
+				MarketValue: ac.MarketValue.String(),
+				WeightPct:   ac.WeightPct.String(),
+			})
+		}
+	}
+
+	return out, nil
+}
+
+// categoryLabels returns a category-id → label map for budget rendering.
+// Empty map (rather than error) when the category service is missing or
+// errors — labels are nice-to-have; budget data is the load-bearing
+// signal.
+func (b *ContextBuilder) categoryLabels(ctx context.Context) map[int64]string {
+	if b.categories == nil {
+		return map[int64]string{}
+	}
+	cats, err := b.categories.List(ctx)
+	if err != nil {
+		return map[int64]string{}
+	}
+	out := make(map[int64]string, len(cats))
+	for _, c := range cats {
+		out[c.ID] = c.Name
+	}
+	return out
+}
+
+// trailingMonthsWindow returns the [first-of-month-N-ago, today+1day)
+// window summed into SpendByCategory. End is exclusive to match the
+// dashboard repo's convention.
+func trailingMonthsWindow(now time.Time, months int) (time.Time, time.Time) {
+	if months <= 0 {
+		months = 1
+	}
+	today := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
+	from := time.Date(now.Year(), now.Month()-time.Month(months-1), 1, 0, 0, 0, 0, now.Location())
+	to := today.AddDate(0, 0, 1)
+	return from, to
+}

--- a/backend/internal/service/ai/context_builder_integration_test.go
+++ b/backend/internal/service/ai/context_builder_integration_test.go
@@ -1,0 +1,302 @@
+package ai_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/joho/godotenv"
+	"github.com/shopspring/decimal"
+	"gorm.io/gorm"
+
+	"github.com/gregwym/offbook/backend/internal/db"
+	"github.com/gregwym/offbook/backend/internal/model"
+	"github.com/gregwym/offbook/backend/internal/repository"
+	"github.com/gregwym/offbook/backend/internal/service"
+	"github.com/gregwym/offbook/backend/internal/service/ai"
+)
+
+// TestContextBuilder_Build_MixedFinancialData seeds a user with accounts,
+// transactions across categories, a budget, a savings goal, and an
+// investment snapshot, then asserts the built Context reflects each
+// signal accurately.
+//
+// Skips when no test DB is configured — mirrors the existing service
+// integration tests so `go test ./...` runs cleanly on a fresh checkout.
+func TestContextBuilder_Build_MixedFinancialData(t *testing.T) {
+	g := openTestDBForAI(t)
+	userID := seedUser(t, g)
+
+	// Seed: one checking account + one investment account, both owned by user.
+	suffix := time.Now().Format("150405.000000")
+	checking := &model.Account{
+		UserID: userID, Name: "CtxChk-" + suffix, InstitutionSlug: "fixture",
+		AccountType: "checking", Currency: "USD",
+		Balance: decimal.NewFromInt(5000), // counted toward net worth
+	}
+	invAcct := &model.Account{
+		UserID: userID, Name: "CtxInv-" + suffix, InstitutionSlug: "fixture",
+		AccountType: "investment", Currency: "USD",
+		Balance: decimal.Zero,
+	}
+	for _, a := range []*model.Account{checking, invAcct} {
+		if err := g.Create(a).Error; err != nil {
+			t.Fatalf("seed account: %v", err)
+		}
+	}
+
+	groceries := &model.Category{Name: "CtxGroc-" + suffix, Slug: "ctx-groc-" + suffix}
+	if err := g.Create(groceries).Error; err != nil {
+		t.Fatalf("seed category: %v", err)
+	}
+	// t.Cleanup runs LIFO. Register the category cleanup FIRST so it runs
+	// LAST — after the budget/etc. cleanup below has already cleared the
+	// FK-bearing rows.
+	t.Cleanup(func() { g.Unscoped().Delete(&model.Category{}, groceries.ID) })
+	t.Cleanup(func() {
+		g.Unscoped().Where("user_id = ?", userID).Delete(&model.Transaction{})
+		g.Unscoped().Where("user_id = ?", userID).Delete(&model.Investment{})
+		g.Unscoped().Where("user_id = ?", userID).Delete(&model.Budget{})
+		g.Unscoped().Where("user_id = ?", userID).Delete(&model.SavingsGoal{})
+		g.Unscoped().Delete(&model.Account{}, checking.ID)
+		g.Unscoped().Delete(&model.Account{}, invAcct.ID)
+	})
+
+	// Two grocery outflows in the current month — total $80 spent.
+	now := time.Date(2026, 5, 15, 12, 0, 0, 0, time.UTC)
+	mkTx := func(amt decimal.Decimal) {
+		t.Helper()
+		tx := &model.Transaction{
+			UserID: userID, AccountID: checking.ID, CategoryID: &groceries.ID,
+			Amount: amt, Currency: "USD",
+			TransactionDate: now.AddDate(0, 0, -5), Source: "manual",
+		}
+		if err := g.Create(tx).Error; err != nil {
+			t.Fatalf("seed txn: %v", err)
+		}
+	}
+	mkTx(decimal.NewFromInt(-50))
+	mkTx(decimal.NewFromInt(-30))
+
+	// Budget: $200 groceries, monthly. With $80 spent → 40% utilized.
+	budget := &model.Budget{
+		UserID: userID, CategoryID: groceries.ID, Period: "monthly",
+		Amount: decimal.NewFromInt(200), IsActive: true,
+	}
+	if err := g.Create(budget).Error; err != nil {
+		t.Fatalf("seed budget: %v", err)
+	}
+
+	// Savings goal: $1000 target, $250 saved → 25% progress.
+	goal := &model.SavingsGoal{
+		UserID: userID, Name: "Emergency Fund",
+		TargetAmount: decimal.NewFromInt(1000), CurrentAmount: decimal.NewFromInt(250),
+	}
+	if err := g.Create(goal).Error; err != nil {
+		t.Fatalf("seed goal: %v", err)
+	}
+
+	// Investment: 10 shares VTI @ $250 market = $2500 in Equity asset class.
+	ac := "Equity"
+	mv := decimal.NewFromInt(2500)
+	cb := decimal.NewFromInt(2000)
+	inv := &model.Investment{
+		UserID: userID, AccountID: invAcct.ID, Ticker: "VTI",
+		AssetClass:   &ac,
+		Quantity:     decimal.NewFromInt(10),
+		MarketValue:  &mv,
+		CostBasis:    &cb,
+		SnapshotDate: now.AddDate(0, 0, -1),
+		Source:       "manual",
+	}
+	if err := g.Create(inv).Error; err != nil {
+		t.Fatalf("seed inv: %v", err)
+	}
+
+	dashSvc := service.NewDashboardService(repository.NewDashboardRepository(g))
+	dashSvc.SetClock(func() time.Time { return now })
+	budSvc := service.NewBudgetService(
+		repository.NewBudgetRepository(g),
+		repository.NewCategoryRepository(g),
+	).WithNow(func() time.Time { return now })
+	goalSvc := service.NewSavingsGoalService(
+		repository.NewSavingsGoalRepository(g),
+		repository.NewAccountRepository(g),
+	)
+	invSvc := service.NewInvestmentService(
+		repository.NewInvestmentRepository(g),
+		repository.NewAccountRepository(g),
+	)
+	catSvc := service.NewCategoryService(repository.NewCategoryRepository(g))
+
+	cb_ := ai.NewContextBuilder(dashSvc, budSvc, goalSvc, invSvc, catSvc).WithNow(func() time.Time { return now })
+
+	ctx, err := cb_.Build(context.Background(), userID)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+
+	// NetWorth = checking balance (investment account holds $0 in
+	// accounts.balance; investment values aren't rolled into accounts).
+	if ctx.NetWorth != "5000" {
+		t.Errorf("NetWorth = %q, want 5000", ctx.NetWorth)
+	}
+
+	// Spend-by-category should include the grocery category at $80.
+	foundGroceries := false
+	for _, row := range ctx.SpendByCategory {
+		if row.Category == groceries.Name {
+			foundGroceries = true
+			if row.Amount != "80" {
+				t.Errorf("groceries spend = %q, want 80", row.Amount)
+			}
+		}
+	}
+	if !foundGroceries {
+		t.Errorf("groceries category missing from SpendByCategory: %+v", ctx.SpendByCategory)
+	}
+
+	// Budget should appear with 40% utilization.
+	if len(ctx.Budgets) != 1 {
+		t.Fatalf("budgets len = %d, want 1: %+v", len(ctx.Budgets), ctx.Budgets)
+	}
+	bSnap := ctx.Budgets[0]
+	if bSnap.Category != groceries.Name {
+		t.Errorf("budget category = %q, want %q", bSnap.Category, groceries.Name)
+	}
+	if bSnap.Limit != "200" || bSnap.Spent != "80" {
+		t.Errorf("budget limit/spent = %q/%q, want 200/80", bSnap.Limit, bSnap.Spent)
+	}
+	if bSnap.Pct < 0.39 || bSnap.Pct > 0.41 {
+		t.Errorf("budget pct = %v, want ~0.40", bSnap.Pct)
+	}
+
+	// Savings goal: 25% progress.
+	if len(ctx.SavingsGoals) != 1 {
+		t.Fatalf("savings goals len = %d, want 1", len(ctx.SavingsGoals))
+	}
+	gSnap := ctx.SavingsGoals[0]
+	if gSnap.Label != "Emergency Fund" {
+		t.Errorf("goal label = %q, want Emergency Fund", gSnap.Label)
+	}
+	if gSnap.Target != "1000" || gSnap.Current != "250" {
+		t.Errorf("goal target/current = %q/%q, want 1000/250", gSnap.Target, gSnap.Current)
+	}
+	if gSnap.ProgressPct < 0.24 || gSnap.ProgressPct > 0.26 {
+		t.Errorf("goal progress = %v, want ~0.25", gSnap.ProgressPct)
+	}
+
+	// Holdings: $2500 market value in Equity → 100% weight.
+	if ctx.Holdings.TotalMarketValue != "2500" {
+		t.Errorf("holdings total = %q, want 2500", ctx.Holdings.TotalMarketValue)
+	}
+	if ctx.Holdings.HoldingsCount != 1 {
+		t.Errorf("holdings count = %d, want 1", ctx.Holdings.HoldingsCount)
+	}
+	if len(ctx.Holdings.ByAssetClass) != 1 || ctx.Holdings.ByAssetClass[0].AssetClass != "Equity" {
+		t.Fatalf("by_asset_class = %+v, want one Equity slice", ctx.Holdings.ByAssetClass)
+	}
+	if ctx.Holdings.ByAssetClass[0].WeightPct != "100" {
+		t.Errorf("equity weight = %q, want 100", ctx.Holdings.ByAssetClass[0].WeightPct)
+	}
+}
+
+// TestContextBuilder_Build_DifferentUser asserts that the builder scopes
+// to the requested user — a second user's data must not leak into a
+// build for the first.
+func TestContextBuilder_Build_DifferentUser(t *testing.T) {
+	g := openTestDBForAI(t)
+	userA := seedUser(t, g)
+	userB := seedUser(t, g)
+
+	suffix := time.Now().Format("150405.000000")
+	accB := &model.Account{
+		UserID: userB, Name: "OtherCtx-" + suffix, InstitutionSlug: "fixture",
+		AccountType: "checking", Currency: "USD",
+		Balance: decimal.NewFromInt(9999),
+	}
+	if err := g.Create(accB).Error; err != nil {
+		t.Fatalf("seed other account: %v", err)
+	}
+	t.Cleanup(func() {
+		g.Unscoped().Where("user_id = ?", userB).Delete(&model.Transaction{})
+		g.Unscoped().Delete(&model.Account{}, accB.ID)
+	})
+
+	dashSvc := service.NewDashboardService(repository.NewDashboardRepository(g))
+	now := time.Date(2026, 5, 15, 12, 0, 0, 0, time.UTC)
+	dashSvc.SetClock(func() time.Time { return now })
+
+	cb := ai.NewContextBuilder(dashSvc, nil, nil, nil, nil).WithNow(func() time.Time { return now })
+	ctxA, err := cb.Build(context.Background(), userA)
+	if err != nil {
+		t.Fatalf("Build for userA: %v", err)
+	}
+	// Net worth for userA must be 0 — userB's $9999 must not leak in.
+	if ctxA.NetWorth != "0" {
+		t.Errorf("userA NetWorth = %q, want 0 (userB's data leaked?)", ctxA.NetWorth)
+	}
+}
+
+// --- helpers ---
+
+func openTestDBForAI(t *testing.T) *gorm.DB {
+	t.Helper()
+	loadRepoDotenvForAI()
+	url := os.Getenv("TEST_DATABASE_URL")
+	if url == "" {
+		url = os.Getenv("DATABASE_URL")
+	}
+	if url == "" {
+		t.Skip("no DATABASE_URL set; skipping integration test")
+	}
+	g, err := db.Open(url)
+	if err != nil {
+		t.Fatalf("db.Open: %v", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := db.Ping(ctx, g); err != nil {
+		t.Skipf("db.Ping: %v; skipping integration test", err)
+	}
+	return g
+}
+
+func loadRepoDotenvForAI() {
+	dir, err := os.Getwd()
+	if err != nil {
+		return
+	}
+	for i := 0; i < 8; i++ {
+		envPath := filepath.Join(dir, ".env")
+		if _, err := os.Stat(envPath); err == nil {
+			_ = godotenv.Load(envPath)
+			return
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return
+		}
+		dir = parent
+	}
+}
+
+func seedUser(t *testing.T, g *gorm.DB) int64 {
+	t.Helper()
+	u := &model.User{
+		Email:        fmt.Sprintf("ai-test-%d-%d@example.test", time.Now().UnixNano(), len(t.Name())),
+		PasswordHash: "x",
+		LastScope:    model.ScopePersonal,
+		DefaultScope: model.ScopePersonal,
+	}
+	if err := g.Create(u).Error; err != nil {
+		t.Fatalf("seed user: %v", err)
+	}
+	t.Cleanup(func() {
+		g.Unscoped().Delete(&model.User{}, u.ID)
+	})
+	return u.ID
+}

--- a/backend/internal/service/ai/context_builder_privacy_test.go
+++ b/backend/internal/service/ai/context_builder_privacy_test.go
@@ -1,0 +1,46 @@
+package ai_test
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/gregwym/offbook/backend/internal/service/ai"
+)
+
+// TestContext_NoPIIFieldNames walks the Context type tree and fails if any
+// field name (or JSON tag) carries a PII-indicator substring. This is a
+// tripwire for someone adding a future field like "AccountHolder" without
+// realizing the AI prompt is the wrong place for it.
+//
+// The list of forbidden tokens comes from issue #128's acceptance criteria
+// — "name", "holder", "account_number", "routing", "address". Note that
+// "name" is aggressive: it also fails on "category_name", "goal_name",
+// etc. The Context type therefore uses "Category" / "Label" instead of
+// "*_name" labels.
+func TestContext_NoPIIFieldNames(t *testing.T) {
+	forbidden := []string{"name", "holder", "account_number", "routing", "address"}
+
+	var walk func(t reflect.Type, path string)
+	walk = func(rt reflect.Type, path string) {
+		for rt.Kind() == reflect.Ptr || rt.Kind() == reflect.Slice || rt.Kind() == reflect.Array {
+			rt = rt.Elem()
+		}
+		if rt.Kind() != reflect.Struct {
+			return
+		}
+		for i := 0; i < rt.NumField(); i++ {
+			f := rt.Field(i)
+			fieldPath := path + "." + f.Name
+			lowered := strings.ToLower(f.Name)
+			tag := strings.ToLower(f.Tag.Get("json"))
+			for _, bad := range forbidden {
+				if strings.Contains(lowered, bad) || strings.Contains(tag, bad) {
+					t.Errorf("forbidden PII token %q in field %s (tag=%q)", bad, fieldPath, f.Tag.Get("json"))
+				}
+			}
+			walk(f.Type, fieldPath)
+		}
+	}
+	walk(reflect.TypeOf(ai.Context{}), "Context")
+}

--- a/backend/internal/service/ai/context_builder_privacy_test.go
+++ b/backend/internal/service/ai/context_builder_privacy_test.go
@@ -23,7 +23,7 @@ func TestContext_NoPIIFieldNames(t *testing.T) {
 
 	var walk func(t reflect.Type, path string)
 	walk = func(rt reflect.Type, path string) {
-		for rt.Kind() == reflect.Ptr || rt.Kind() == reflect.Slice || rt.Kind() == reflect.Array {
+		for rt.Kind() == reflect.Pointer || rt.Kind() == reflect.Slice || rt.Kind() == reflect.Array {
 			rt = rt.Elem()
 		}
 		if rt.Kind() != reflect.Struct {


### PR DESCRIPTION
## Summary
- `service/ai/context_builder.go` introduces `Context` (net worth, period spend-by-category, active budgets + utilization, savings goals + progress, holdings summary by asset class) and `ContextBuilder` that assembles it from the existing dashboard / budget / savings-goal / investment / category services.
- `ContextBuilder` is constructed with the **service** facades, never `pii_repo` or `pii_service` — the dependency surface is the architectural enforcement of PII isolation. Holdings deliberately omit per-row tickers (only asset-class allocation), and field names avoid PII tokens.
- `TestContext_NoPIIFieldNames` reflects over the whole `Context` tree and fails on any field name (or json tag) containing `name`, `holder`, `account_number`, `routing`, or `address` — tripwire for someone adding a future field like "AccountHolder".
- Integration test seeds a user with mixed accounts/txns/budget/goal/investment and asserts the builder produces correct numeric rollups (net worth $5000, $80 grocery spend, 40% budget utilization, 25% goal progress, $2500 Equity-class portfolio at 100% weight). Tenant-isolation test confirms a sibling user's data does not leak.

## Test plan
- [x] `go test ./internal/service/ai/...` — 14/14 pass including privacy-reflection, multi-tenant scope, and the new mixed-data integration
- [x] `go test -race -p 1 ./...` — full backend suite green
- [x] `go vet ./...` and `gofmt -l` — clean
- [ ] Lint via CI (local Docker VM still hits the documented `signal: killed during compile` ceiling)