### PR TITLE
feat(ai): AI service orchestration + threads + SSE handler (#129)

### DIFF
--- a/backend/internal/handler/ai_handler.go
+++ b/backend/internal/handler/ai_handler.go
@@ -110,7 +110,7 @@ func (h *AIHandler) SendMessage(c *gin.Context) {
 		if !ok {
 			return false
 		}
-		fmt.Fprintf(w, "event: %s\ndata: %s\n\n", ev.Type, string(ev.Data))
+		_, _ = fmt.Fprintf(w, "event: %s\ndata: %s\n\n", ev.Type, string(ev.Data))
 		return ev.Type != ai.SSEDone && ev.Type != ai.SSEError
 	})
 }

--- a/backend/internal/handler/ai_handler.go
+++ b/backend/internal/handler/ai_handler.go
@@ -1,0 +1,129 @@
+package handler
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/gregwym/offbook/backend/internal/service/ai"
+	"github.com/gregwym/offbook/backend/internal/service/auth"
+)
+
+// AIHandler exposes the AI advisor surface. SendMessage holds open an SSE
+// stream — every other handler returns the standard `{"data": ...}`
+// envelope.
+type AIHandler struct {
+	svc *ai.Service
+}
+
+func NewAIHandler(s *ai.Service) *AIHandler {
+	return &AIHandler{svc: s}
+}
+
+func (h *AIHandler) Register(g *gin.RouterGroup) {
+	g.POST("/ai/threads", h.CreateThread)
+	g.GET("/ai/threads", h.ListThreads)
+	g.GET("/ai/threads/:id/messages", h.ListMessages)
+	g.POST("/ai/threads/:id/messages", h.SendMessage)
+}
+
+type createThreadRequest struct {
+	Title *string `json:"title"`
+}
+
+func (h *AIHandler) CreateThread(c *gin.Context) {
+	var req createThreadRequest
+	// Body is optional — a brand-new thread with no title is valid.
+	_ = c.ShouldBindJSON(&req)
+	t, err := h.svc.CreateThread(c.Request.Context(), auth.MustUserID(c.Request.Context()), req.Title)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error(), "code": "INTERNAL"})
+		return
+	}
+	c.JSON(http.StatusCreated, gin.H{"data": t})
+}
+
+func (h *AIHandler) ListThreads(c *gin.Context) {
+	threads, err := h.svc.ListThreads(c.Request.Context(), auth.MustUserID(c.Request.Context()))
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error(), "code": "INTERNAL"})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"data": threads, "total": int64(len(threads))})
+}
+
+func (h *AIHandler) ListMessages(c *gin.Context) {
+	id, ok := parseID(c)
+	if !ok {
+		return
+	}
+	msgs, err := h.svc.ListMessages(c.Request.Context(), auth.MustUserID(c.Request.Context()), id)
+	if err != nil {
+		h.writeServiceError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"data": msgs, "total": int64(len(msgs))})
+}
+
+type sendMessageRequest struct {
+	Content string `json:"content"`
+}
+
+// SendMessage holds an SSE stream open. Event format is:
+//
+//	event: delta
+//	data: {"text": "Hello"}
+//
+//	event: done
+//	data: {"finish_reason":"end_turn","input_tokens":17,"output_tokens":9,"message_id":42}
+//
+// Errors during the stream go on `event: error`. The connection closes
+// after a terminal `done` or `error`.
+func (h *AIHandler) SendMessage(c *gin.Context) {
+	id, ok := parseID(c)
+	if !ok {
+		return
+	}
+	var req sendMessageRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error(), "code": "INVALID_REQUEST"})
+		return
+	}
+
+	events, err := h.svc.SendMessage(c.Request.Context(), auth.MustUserID(c.Request.Context()), id, req.Content)
+	if err != nil {
+		h.writeServiceError(c, err)
+		return
+	}
+
+	c.Writer.Header().Set("Content-Type", "text/event-stream")
+	c.Writer.Header().Set("Cache-Control", "no-cache")
+	c.Writer.Header().Set("Connection", "keep-alive")
+	c.Writer.Header().Set("X-Accel-Buffering", "no") // disable nginx-style buffering
+	c.Writer.WriteHeader(http.StatusOK)
+
+	c.Stream(func(w io.Writer) bool {
+		ev, ok := <-events
+		if !ok {
+			return false
+		}
+		fmt.Fprintf(w, "event: %s\ndata: %s\n\n", ev.Type, string(ev.Data))
+		return ev.Type != ai.SSEDone && ev.Type != ai.SSEError
+	})
+}
+
+func (h *AIHandler) writeServiceError(c *gin.Context, err error) {
+	switch {
+	case errors.Is(err, ai.ErrThreadNotFound):
+		c.JSON(http.StatusNotFound, gin.H{"error": err.Error(), "code": "AI_THREAD_NOT_FOUND"})
+	case errors.Is(err, ai.ErrEmptyMessage):
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error(), "code": "EMPTY_MESSAGE"})
+	case errors.Is(err, ai.ErrNoProvider):
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": err.Error(), "code": "NO_AI_PROVIDER"})
+	default:
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error(), "code": "INTERNAL"})
+	}
+}

--- a/backend/internal/repository/ai_repo.go
+++ b/backend/internal/repository/ai_repo.go
@@ -1,0 +1,103 @@
+package repository
+
+import (
+	"context"
+	"errors"
+
+	"gorm.io/gorm"
+
+	"github.com/gregwym/offbook/backend/internal/model"
+)
+
+// AIThreadRepository is the data-access contract for ai_threads.
+// Every read path is scoped by user_id — there is no "fetch by id"
+// without an owning user, so a sibling user passing a guessed id gets
+// ErrNotFound, not someone else's thread.
+type AIThreadRepository interface {
+	Create(ctx context.Context, t *model.AIThread) error
+	GetByID(ctx context.Context, userID, id int64) (*model.AIThread, error)
+	ListByUser(ctx context.Context, userID int64) ([]model.AIThread, error)
+	UpdateTitle(ctx context.Context, userID, id int64, title string) error
+}
+
+// AIMessageRepository is the data-access contract for ai_messages.
+// Messages are append-only — no soft delete (cascades on thread delete).
+// All reads go through a thread id that the service already
+// authorization-checked, so this repo doesn't take user_id.
+type AIMessageRepository interface {
+	Create(ctx context.Context, m *model.AIMessage) error
+	ListByThread(ctx context.Context, threadID int64) ([]model.AIMessage, error)
+}
+
+type aiThreadRepo struct {
+	db *gorm.DB
+}
+
+func NewAIThreadRepository(db *gorm.DB) AIThreadRepository {
+	return &aiThreadRepo{db: db}
+}
+
+func (r *aiThreadRepo) Create(ctx context.Context, t *model.AIThread) error {
+	return r.db.WithContext(ctx).Create(t).Error
+}
+
+func (r *aiThreadRepo) GetByID(ctx context.Context, userID, id int64) (*model.AIThread, error) {
+	var t model.AIThread
+	if err := r.db.WithContext(ctx).
+		Where("user_id = ?", userID).
+		First(&t, id).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, ErrNotFound
+		}
+		return nil, err
+	}
+	return &t, nil
+}
+
+func (r *aiThreadRepo) ListByUser(ctx context.Context, userID int64) ([]model.AIThread, error) {
+	var out []model.AIThread
+	if err := r.db.WithContext(ctx).
+		Where("user_id = ?", userID).
+		Order("updated_at DESC").
+		Find(&out).Error; err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (r *aiThreadRepo) UpdateTitle(ctx context.Context, userID, id int64, title string) error {
+	res := r.db.WithContext(ctx).
+		Model(&model.AIThread{}).
+		Where("user_id = ? AND id = ?", userID, id).
+		Update("title", title)
+	if res.Error != nil {
+		return res.Error
+	}
+	if res.RowsAffected == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+type aiMessageRepo struct {
+	db *gorm.DB
+}
+
+func NewAIMessageRepository(db *gorm.DB) AIMessageRepository {
+	return &aiMessageRepo{db: db}
+}
+
+func (r *aiMessageRepo) Create(ctx context.Context, m *model.AIMessage) error {
+	return r.db.WithContext(ctx).Create(m).Error
+}
+
+func (r *aiMessageRepo) ListByThread(ctx context.Context, threadID int64) ([]model.AIMessage, error) {
+	var out []model.AIMessage
+	if err := r.db.WithContext(ctx).
+		Where("thread_id = ?", threadID).
+		Order("created_at ASC, id ASC").
+		Find(&out).Error; err != nil {
+		return nil, err
+	}
+	return out, nil
+}

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -11,6 +11,7 @@ import (
 	"github.com/gregwym/offbook/backend/internal/handler"
 	"github.com/gregwym/offbook/backend/internal/repository"
 	"github.com/gregwym/offbook/backend/internal/service"
+	"github.com/gregwym/offbook/backend/internal/service/ai"
 	"github.com/gregwym/offbook/backend/internal/service/auth"
 	"github.com/gregwym/offbook/backend/internal/service/household"
 	plaidsvc "github.com/gregwym/offbook/backend/internal/service/plaid"
@@ -103,6 +104,18 @@ func New(cfg config.Config, gormDB *gorm.DB) *gin.Engine {
 	plaidSvc := newPlaidService(cfg, gormDB, plaidItemRepo, accountRepo, transactionRepo, plaidSyncErrRepo, piiSvc).WithRuleRepo(ruleRepo)
 	plaidHandler := handler.NewPlaidHandler(plaidSvc)
 
+	// AI advisor: provider is optional. Without CLAUDE_API_KEY the service
+	// still registers (so threads/list/history work for past conversations)
+	// but SendMessage returns ErrNoProvider until the user adds a key.
+	aiBuilder := ai.NewContextBuilder(dashboardSvc, budgetSvc, savingsGoalSvc, investmentSvc, categorySvc)
+	aiSvc := ai.NewService(
+		repository.NewAIThreadRepository(gormDB),
+		repository.NewAIMessageRepository(gormDB),
+		aiBuilder,
+		newAIProvider(cfg),
+	)
+	aiHandler := handler.NewAIHandler(aiSvc)
+
 	v1 := r.Group("/api/v1")
 	{
 		// Open routes — no session required.
@@ -126,6 +139,7 @@ func New(cfg config.Config, gormDB *gorm.DB) *gin.Engine {
 		aggregatorHandler.Register(secured)
 		scopeHandler.Register(secured)
 		plaidHandler.Register(secured)
+		aiHandler.Register(secured)
 	}
 
 	return r
@@ -178,6 +192,27 @@ func newPlaidService(
 		mapper,
 		gormDB,
 	)
+}
+
+// newAIProvider returns the configured Claude provider when
+// CLAUDE_API_KEY is set, otherwise nil. The AI service treats a nil
+// provider as "send disabled" — see ai.Service.ProviderConfigured.
+//
+// Ollama is also a valid choice but it isn't a startup-config flip: it's
+// a per-thread/per-user setting that ships with the settings UI in a
+// later issue. Until then, Claude is the only auto-wired provider.
+func newAIProvider(cfg config.Config) ai.Provider {
+	if !cfg.ClaudeConfigured() {
+		return nil
+	}
+	p, err := ai.NewClaudeProvider(ai.ClaudeConfig{APIKey: cfg.ClaudeAPIKey})
+	if err != nil {
+		// Misconfigured key (empty after validation). Fall through to
+		// "no provider" rather than panicking at boot — the operator can
+		// fix and reload without restarting if they need to.
+		return nil
+	}
+	return p
 }
 
 func corsMiddleware(origin string) gin.HandlerFunc {

--- a/backend/internal/service/ai/service.go
+++ b/backend/internal/service/ai/service.go
@@ -1,0 +1,317 @@
+package ai
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/gregwym/offbook/backend/internal/model"
+	"github.com/gregwym/offbook/backend/internal/repository"
+)
+
+// SystemPromptPrefix is prepended to every assistant turn ahead of the
+// serialized Context. Keeping the persona terse — providers see the
+// anonymized financial data immediately and the user message right after.
+const SystemPromptPrefix = `You are a privacy-first financial assistant. ` +
+	`You only see anonymized aggregate data — never names, account numbers, ` +
+	`or other PII. Answer concisely. When asked about specific accounts, ` +
+	`reason about the aggregates rather than guessing identifiers.`
+
+// Errors surfaced to the handler. The handler maps each to an HTTP code
+// and machine-readable code string.
+var (
+	ErrThreadNotFound = errors.New("ai thread not found")
+	ErrEmptyMessage   = errors.New("message content must not be empty")
+	ErrNoProvider     = errors.New("no AI provider configured")
+)
+
+// SSEEventType is the event-line value in the wire-format SSE stream.
+type SSEEventType string
+
+const (
+	// SSEDelta carries one chunk of assistant text.
+	SSEDelta SSEEventType = "delta"
+	// SSEDone is the terminal sentinel. Carries finish_reason + usage.
+	SSEDone SSEEventType = "done"
+	// SSEError is a terminal error event. The stream closes after it.
+	SSEError SSEEventType = "error"
+)
+
+// SSEEvent is what the service streams to the handler. The handler is
+// responsible for writing it out as `event: <type>\ndata: <json>\n\n`.
+type SSEEvent struct {
+	Type SSEEventType    `json:"-"`
+	Data json.RawMessage `json:"-"`
+}
+
+// DeltaPayload is the body of an SSEDelta event.
+type DeltaPayload struct {
+	Text string `json:"text"`
+}
+
+// DonePayload is the body of an SSEDone event.
+type DonePayload struct {
+	FinishReason string `json:"finish_reason,omitempty"`
+	InputTokens  int    `json:"input_tokens,omitempty"`
+	OutputTokens int    `json:"output_tokens,omitempty"`
+	MessageID    int64  `json:"message_id"`
+}
+
+// ErrorPayload is the body of an SSEError event.
+type ErrorPayload struct {
+	Message string `json:"message"`
+	Code    string `json:"code,omitempty"`
+}
+
+// Service is the orchestration layer: persistence + context build +
+// provider stream. Constructor signature is deliberately fixed — adding
+// `pii_repo` here would be the regression the noimport_test guards
+// against.
+type Service struct {
+	threads  repository.AIThreadRepository
+	messages repository.AIMessageRepository
+	builder  *ContextBuilder
+	provider Provider
+}
+
+// NewService wires the AI orchestration layer. The provider may be nil at
+// boot — callers that haven't configured CLAUDE_API_KEY pass nil and the
+// service rejects SendMessage with ErrNoProvider so the settings UI can
+// surface a useful error.
+func NewService(
+	threads repository.AIThreadRepository,
+	messages repository.AIMessageRepository,
+	builder *ContextBuilder,
+	provider Provider,
+) *Service {
+	return &Service{
+		threads:  threads,
+		messages: messages,
+		builder:  builder,
+		provider: provider,
+	}
+}
+
+// ProviderConfigured reports whether SendMessage will work. Handlers can
+// surface a 503-ish error before opening an SSE stream that's going to
+// immediately close.
+func (s *Service) ProviderConfigured() bool {
+	return s.provider != nil
+}
+
+// CreateThread starts a new conversation for the user. Title is optional
+// and may be filled in later — we deliberately don't auto-summarize from
+// the first message because that's a UI-affordance decision.
+func (s *Service) CreateThread(ctx context.Context, userID int64, title *string) (*model.AIThread, error) {
+	t := &model.AIThread{
+		UserID: userID,
+		Title:  title,
+	}
+	if err := s.threads.Create(ctx, t); err != nil {
+		return nil, fmt.Errorf("ai: create thread: %w", err)
+	}
+	return t, nil
+}
+
+// ListThreads returns the user's threads, newest activity first.
+func (s *Service) ListThreads(ctx context.Context, userID int64) ([]model.AIThread, error) {
+	return s.threads.ListByUser(ctx, userID)
+}
+
+// GetThread fetches a single thread, scoped to user. Returns
+// ErrThreadNotFound when the thread is missing or owned by a different
+// user — they look the same on the wire to prevent ID-enumeration.
+func (s *Service) GetThread(ctx context.Context, userID, id int64) (*model.AIThread, error) {
+	t, err := s.threads.GetByID(ctx, userID, id)
+	if err != nil {
+		if errors.Is(err, repository.ErrNotFound) {
+			return nil, ErrThreadNotFound
+		}
+		return nil, err
+	}
+	return t, nil
+}
+
+// ListMessages returns the turn history for a thread, oldest first. The
+// caller MUST have already authorization-checked the thread (use GetThread
+// first); ListByThread takes only thread_id.
+func (s *Service) ListMessages(ctx context.Context, userID, threadID int64) ([]model.AIMessage, error) {
+	if _, err := s.GetThread(ctx, userID, threadID); err != nil {
+		return nil, err
+	}
+	return s.messages.ListByThread(ctx, threadID)
+}
+
+// SendMessage is the streaming entry point. It:
+//  1. Authorization-checks the thread.
+//  2. Persists the user message immediately.
+//  3. Builds anonymized context.
+//  4. Streams the provider response, forwarding token deltas via SSEEvent.
+//  5. Persists the assistant message + context_snapshot on completion.
+//
+// The returned channel is closed after a terminal SSEDone or SSEError.
+// Callers must drain or cancel ctx — otherwise the provider goroutine
+// leaks. The handler's gin.Context cancellation handles this naturally
+// when the HTTP client disconnects.
+func (s *Service) SendMessage(ctx context.Context, userID, threadID int64, content string) (<-chan SSEEvent, error) {
+	if !s.ProviderConfigured() {
+		return nil, ErrNoProvider
+	}
+	content = strings.TrimSpace(content)
+	if content == "" {
+		return nil, ErrEmptyMessage
+	}
+	if _, err := s.GetThread(ctx, userID, threadID); err != nil {
+		return nil, err
+	}
+
+	// 1. Pull existing turns so the provider sees the conversation, then
+	//    persist the new user turn. Doing the read first means a write
+	//    error doesn't leave a hanging user message with no history
+	//    context.
+	prior, err := s.messages.ListByThread(ctx, threadID)
+	if err != nil {
+		return nil, fmt.Errorf("ai: list messages: %w", err)
+	}
+	userMsg := &model.AIMessage{
+		ThreadID: threadID,
+		Role:     string(RoleUser),
+		Content:  content,
+	}
+	if err := s.messages.Create(ctx, userMsg); err != nil {
+		return nil, fmt.Errorf("ai: persist user message: %w", err)
+	}
+
+	// 2. Build anonymized context. A nil builder is allowed for tests;
+	//    production wiring always passes one. On builder error we still
+	//    stream — the assistant just gets the user message without the
+	//    financial snapshot. Logging would help here, but the M7 service
+	//    layer doesn't have a logger plumbed yet.
+	var ctxSnapshotJSON json.RawMessage
+	var systemPrompt = SystemPromptPrefix
+	if s.builder != nil {
+		bctx, err := s.builder.Build(ctx, userID)
+		if err == nil && bctx != nil {
+			if raw, mErr := json.Marshal(bctx); mErr == nil {
+				ctxSnapshotJSON = raw
+				systemPrompt = SystemPromptPrefix + "\n\nFinancial context:\n" + string(raw)
+			}
+		}
+	}
+
+	// 3. Provider request: system + every prior turn + the just-persisted
+	//    user message. Order matches the on-disk creation order.
+	req := Request{
+		System: systemPrompt,
+		Messages: convertHistory(prior, Message{
+			Role:    RoleUser,
+			Content: content,
+		}),
+	}
+	deltas, err := s.provider.Stream(ctx, req)
+	if err != nil {
+		return nil, fmt.Errorf("ai: provider stream: %w", err)
+	}
+
+	out := make(chan SSEEvent, 16)
+	go s.relayProvider(ctx, threadID, ctxSnapshotJSON, deltas, out)
+	return out, nil
+}
+
+// relayProvider owns the deltas channel and closes out exactly once.
+// Concatenates streamed text into the persisted assistant message body.
+func (s *Service) relayProvider(
+	ctx context.Context,
+	threadID int64,
+	contextSnapshot json.RawMessage,
+	deltas <-chan Delta,
+	out chan<- SSEEvent,
+) {
+	defer close(out)
+
+	providerName := s.provider.Name()
+	var assembled strings.Builder
+	var finishReason string
+	var usage Usage
+
+	send := func(ev SSEEvent) bool {
+		select {
+		case <-ctx.Done():
+			return false
+		case out <- ev:
+			return true
+		}
+	}
+
+	for d := range deltas {
+		switch {
+		case d.Err != nil:
+			payload, _ := json.Marshal(ErrorPayload{Message: d.Err.Error(), Code: "PROVIDER_STREAM"})
+			_ = send(SSEEvent{Type: SSEError, Data: payload})
+			return
+		case d.Done:
+			finishReason = d.FinishReason
+			usage = d.Usage
+		default:
+			if d.Text == "" {
+				continue
+			}
+			assembled.WriteString(d.Text)
+			payload, _ := json.Marshal(DeltaPayload{Text: d.Text})
+			if !send(SSEEvent{Type: SSEDelta, Data: payload}) {
+				return
+			}
+		}
+	}
+
+	// 4. Persist assistant message + snapshot. Use a background context for
+	//    the write — the caller's ctx may have been cancelled at the moment
+	//    the provider finished its final delta, and we still want the
+	//    message saved if the model finished the response.
+	persistCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	asst := &model.AIMessage{
+		ThreadID:        threadID,
+		Role:            string(RoleAssistant),
+		Content:         assembled.String(),
+		ContextSnapshot: contextSnapshot,
+		Provider:        strPtr(providerName),
+	}
+	if err := s.messages.Create(persistCtx, asst); err != nil {
+		payload, _ := json.Marshal(ErrorPayload{
+			Message: "failed to persist assistant message: " + err.Error(),
+			Code:    "PERSIST_FAILED",
+		})
+		_ = send(SSEEvent{Type: SSEError, Data: payload})
+		return
+	}
+
+	donePayload, _ := json.Marshal(DonePayload{
+		FinishReason: finishReason,
+		InputTokens:  usage.InputTokens,
+		OutputTokens: usage.OutputTokens,
+		MessageID:    asst.ID,
+	})
+	_ = send(SSEEvent{Type: SSEDone, Data: donePayload})
+}
+
+// convertHistory turns persisted ai_messages rows into provider-format
+// turns, appending one extra Message at the end (typically the brand-new
+// user turn). Anything other than user/assistant roles is dropped — the
+// provider rejects unknown roles.
+func convertHistory(prior []model.AIMessage, extra ...Message) []Message {
+	out := make([]Message, 0, len(prior)+len(extra))
+	for _, m := range prior {
+		switch Role(m.Role) {
+		case RoleUser, RoleAssistant:
+			out = append(out, Message{Role: Role(m.Role), Content: m.Content})
+		}
+	}
+	out = append(out, extra...)
+	return out
+}
+
+func strPtr(s string) *string { return &s }

--- a/backend/internal/service/ai/service_test.go
+++ b/backend/internal/service/ai/service_test.go
@@ -1,0 +1,390 @@
+package ai_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gregwym/offbook/backend/internal/model"
+	"github.com/gregwym/offbook/backend/internal/repository"
+	"github.com/gregwym/offbook/backend/internal/service/ai"
+)
+
+// stubProvider emits a fixed delta sequence so the service test doesn't
+// need a real HTTP server. Records the request it received for sanity
+// assertions on system prompt + history forwarding.
+type stubProvider struct {
+	deltas    []ai.Delta
+	lastReq   ai.Request
+	streamErr error
+	mu        sync.Mutex
+}
+
+func (p *stubProvider) Name() string { return "stub" }
+
+func (p *stubProvider) Stream(_ context.Context, req ai.Request) (<-chan ai.Delta, error) {
+	p.mu.Lock()
+	p.lastReq = req
+	p.mu.Unlock()
+	if p.streamErr != nil {
+		return nil, p.streamErr
+	}
+	ch := make(chan ai.Delta, len(p.deltas))
+	for _, d := range p.deltas {
+		ch <- d
+	}
+	close(ch)
+	return ch, nil
+}
+
+// stubThreadRepo is an in-memory ai_threads store keyed by (userID, id).
+type stubThreadRepo struct {
+	mu      sync.Mutex
+	threads map[int64]*model.AIThread
+	nextID  int64
+}
+
+func newStubThreadRepo() *stubThreadRepo {
+	return &stubThreadRepo{threads: map[int64]*model.AIThread{}, nextID: 1}
+}
+
+func (r *stubThreadRepo) Create(_ context.Context, t *model.AIThread) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	t.ID = r.nextID
+	r.nextID++
+	t.CreatedAt = time.Now()
+	t.UpdatedAt = t.CreatedAt
+	r.threads[t.ID] = t
+	return nil
+}
+
+func (r *stubThreadRepo) GetByID(_ context.Context, userID, id int64) (*model.AIThread, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	t, ok := r.threads[id]
+	if !ok || t.UserID != userID {
+		return nil, repository.ErrNotFound
+	}
+	return t, nil
+}
+
+func (r *stubThreadRepo) ListByUser(_ context.Context, userID int64) ([]model.AIThread, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	var out []model.AIThread
+	for _, t := range r.threads {
+		if t.UserID == userID {
+			out = append(out, *t)
+		}
+	}
+	return out, nil
+}
+
+func (r *stubThreadRepo) UpdateTitle(_ context.Context, userID, id int64, title string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	t, ok := r.threads[id]
+	if !ok || t.UserID != userID {
+		return repository.ErrNotFound
+	}
+	t.Title = &title
+	return nil
+}
+
+// stubMessageRepo is an in-memory ai_messages store.
+type stubMessageRepo struct {
+	mu     sync.Mutex
+	msgs   []model.AIMessage
+	nextID int64
+}
+
+func newStubMessageRepo() *stubMessageRepo {
+	return &stubMessageRepo{nextID: 1}
+}
+
+func (r *stubMessageRepo) Create(_ context.Context, m *model.AIMessage) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	m.ID = r.nextID
+	r.nextID++
+	m.CreatedAt = time.Now()
+	r.msgs = append(r.msgs, *m)
+	return nil
+}
+
+func (r *stubMessageRepo) ListByThread(_ context.Context, threadID int64) ([]model.AIMessage, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	var out []model.AIMessage
+	for _, m := range r.msgs {
+		if m.ThreadID == threadID {
+			out = append(out, m)
+		}
+	}
+	return out, nil
+}
+
+// TestService_SendMessage_StubProvider exercises the happy path: provider
+// streams three deltas + a done; the service forwards them, then persists
+// the assembled assistant message with a non-empty context snapshot.
+func TestService_SendMessage_StubProvider(t *testing.T) {
+	threads := newStubThreadRepo()
+	msgs := newStubMessageRepo()
+
+	prov := &stubProvider{
+		deltas: []ai.Delta{
+			{Text: "Hello"},
+			{Text: ", "},
+			{Text: "world!"},
+			{Done: true, FinishReason: "end_turn", Usage: ai.Usage{InputTokens: 17, OutputTokens: 9}},
+		},
+	}
+
+	// Builder is nil — the service skips context build cleanly. The
+	// AC requires "non-empty context_snapshot" so we plumb a builder via
+	// a separate path below. For the first assertion we just want the
+	// delta-relay shape.
+	svc := ai.NewService(threads, msgs, nil, prov)
+
+	const userID int64 = 42
+	thr, err := svc.CreateThread(context.Background(), userID, nil)
+	if err != nil {
+		t.Fatalf("CreateThread: %v", err)
+	}
+
+	events, err := svc.SendMessage(context.Background(), userID, thr.ID, "hi there")
+	if err != nil {
+		t.Fatalf("SendMessage: %v", err)
+	}
+
+	var (
+		concatenated strings.Builder
+		gotDone      bool
+		doneEvent    ai.DonePayload
+	)
+	for ev := range events {
+		switch ev.Type {
+		case ai.SSEDelta:
+			var p ai.DeltaPayload
+			if err := json.Unmarshal(ev.Data, &p); err != nil {
+				t.Fatalf("delta unmarshal: %v", err)
+			}
+			concatenated.WriteString(p.Text)
+		case ai.SSEDone:
+			gotDone = true
+			if err := json.Unmarshal(ev.Data, &doneEvent); err != nil {
+				t.Fatalf("done unmarshal: %v", err)
+			}
+		case ai.SSEError:
+			t.Fatalf("unexpected error event: %s", string(ev.Data))
+		}
+	}
+
+	if !gotDone {
+		t.Fatal("stream ended without a Done event")
+	}
+	if got := concatenated.String(); got != "Hello, world!" {
+		t.Errorf("streamed text = %q, want %q", got, "Hello, world!")
+	}
+	if doneEvent.FinishReason != "end_turn" {
+		t.Errorf("finish_reason = %q, want end_turn", doneEvent.FinishReason)
+	}
+
+	// Persisted: user message + assistant message + correct concatenation.
+	persisted, _ := msgs.ListByThread(context.Background(), thr.ID)
+	if len(persisted) != 2 {
+		t.Fatalf("persisted len = %d, want 2 (user + assistant)", len(persisted))
+	}
+	if persisted[0].Role != string(ai.RoleUser) || persisted[0].Content != "hi there" {
+		t.Errorf("user message = %+v", persisted[0])
+	}
+	if persisted[1].Role != string(ai.RoleAssistant) || persisted[1].Content != "Hello, world!" {
+		t.Errorf("assistant message = %+v", persisted[1])
+	}
+	if doneEvent.MessageID != persisted[1].ID {
+		t.Errorf("done.message_id = %d, want %d", doneEvent.MessageID, persisted[1].ID)
+	}
+
+	// Request sanity: system prompt set, history forwarded ending with our user turn.
+	if prov.lastReq.System == "" {
+		t.Error("provider got empty system prompt")
+	}
+	if n := len(prov.lastReq.Messages); n != 1 {
+		t.Fatalf("provider got %d messages, want 1 (the new user turn)", n)
+	}
+	if got := prov.lastReq.Messages[0].Content; got != "hi there" {
+		t.Errorf("provider user message = %q, want %q", got, "hi there")
+	}
+}
+
+// TestService_SendMessage_PersistsContextSnapshot verifies the assistant
+// message's context_snapshot column is populated when a builder is wired.
+func TestService_SendMessage_PersistsContextSnapshot(t *testing.T) {
+	threads := newStubThreadRepo()
+	msgs := newStubMessageRepo()
+	prov := &stubProvider{
+		deltas: []ai.Delta{
+			{Text: "ok"},
+			{Done: true, FinishReason: "end_turn"},
+		},
+	}
+
+	// Pass a builder with all-nil sub-services. Build() returns an empty
+	// Context (no error), which JSON-marshals to a non-empty object — the
+	// AC's "context_snapshot is non-empty" check passes.
+	builder := ai.NewContextBuilder(nil, nil, nil, nil, nil)
+	svc := ai.NewService(threads, msgs, builder, prov)
+
+	const userID int64 = 7
+	thr, _ := svc.CreateThread(context.Background(), userID, nil)
+	events, err := svc.SendMessage(context.Background(), userID, thr.ID, "hi")
+	if err != nil {
+		t.Fatalf("SendMessage: %v", err)
+	}
+	for range events {
+		// drain
+	}
+
+	persisted, _ := msgs.ListByThread(context.Background(), thr.ID)
+	if len(persisted) != 2 {
+		t.Fatalf("len = %d, want 2", len(persisted))
+	}
+	snap := persisted[1].ContextSnapshot
+	if len(snap) == 0 {
+		t.Fatal("context_snapshot is empty on assistant message")
+	}
+	// Snapshot must be valid JSON and a non-empty object.
+	var parsed map[string]any
+	if err := json.Unmarshal(snap, &parsed); err != nil {
+		t.Fatalf("context_snapshot not JSON: %v (raw=%s)", err, string(snap))
+	}
+	if len(parsed) == 0 {
+		t.Fatalf("context_snapshot is an empty object: %s", string(snap))
+	}
+}
+
+// TestService_SendMessage_NoProvider returns ErrNoProvider before opening
+// a stream — so the handler can map to a 503 rather than holding an SSE
+// connection open just to immediately close it.
+func TestService_SendMessage_NoProvider(t *testing.T) {
+	svc := ai.NewService(newStubThreadRepo(), newStubMessageRepo(), nil, nil)
+	if svc.ProviderConfigured() {
+		t.Fatal("ProviderConfigured returned true with nil provider")
+	}
+	thr, _ := svc.CreateThread(context.Background(), 1, nil)
+	_, err := svc.SendMessage(context.Background(), 1, thr.ID, "hi")
+	if !errors.Is(err, ai.ErrNoProvider) {
+		t.Fatalf("err = %v, want ErrNoProvider", err)
+	}
+}
+
+// TestService_SendMessage_EmptyContent rejects whitespace-only messages
+// before persisting anything or invoking the provider.
+func TestService_SendMessage_EmptyContent(t *testing.T) {
+	threads := newStubThreadRepo()
+	msgs := newStubMessageRepo()
+	prov := &stubProvider{deltas: []ai.Delta{{Done: true}}}
+	svc := ai.NewService(threads, msgs, nil, prov)
+
+	thr, _ := svc.CreateThread(context.Background(), 1, nil)
+	_, err := svc.SendMessage(context.Background(), 1, thr.ID, "   \t  ")
+	if !errors.Is(err, ai.ErrEmptyMessage) {
+		t.Fatalf("err = %v, want ErrEmptyMessage", err)
+	}
+	if got, _ := msgs.ListByThread(context.Background(), thr.ID); len(got) != 0 {
+		t.Errorf("got %d persisted, want 0", len(got))
+	}
+}
+
+// TestService_CrossUserAccess — user B asking for user A's thread by ID
+// gets ErrThreadNotFound (not a 403 — same status as a missing thread,
+// to defeat enumeration). Applies to ListMessages, GetThread, SendMessage.
+func TestService_CrossUserAccess(t *testing.T) {
+	threads := newStubThreadRepo()
+	msgs := newStubMessageRepo()
+	prov := &stubProvider{deltas: []ai.Delta{{Done: true}}}
+	svc := ai.NewService(threads, msgs, nil, prov)
+
+	const userA, userB int64 = 1, 2
+	aThr, _ := svc.CreateThread(context.Background(), userA, nil)
+
+	cases := []struct {
+		name string
+		run  func() error
+	}{
+		{"GetThread", func() error {
+			_, err := svc.GetThread(context.Background(), userB, aThr.ID)
+			return err
+		}},
+		{"ListMessages", func() error {
+			_, err := svc.ListMessages(context.Background(), userB, aThr.ID)
+			return err
+		}},
+		{"SendMessage", func() error {
+			_, err := svc.SendMessage(context.Background(), userB, aThr.ID, "leak?")
+			return err
+		}},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.run()
+			if !errors.Is(err, ai.ErrThreadNotFound) {
+				t.Errorf("got %v, want ErrThreadNotFound", err)
+			}
+		})
+	}
+
+	// User B's ListThreads MUST NOT include user A's thread.
+	bThreads, err := svc.ListThreads(context.Background(), userB)
+	if err != nil {
+		t.Fatalf("ListThreads: %v", err)
+	}
+	for _, th := range bThreads {
+		if th.ID == aThr.ID {
+			t.Errorf("user B sees user A's thread %d in ListThreads", th.ID)
+		}
+	}
+}
+
+// TestService_SendMessage_ProviderError surfaces a mid-stream error as a
+// terminal SSEError event. No assistant message is persisted.
+func TestService_SendMessage_ProviderError(t *testing.T) {
+	threads := newStubThreadRepo()
+	msgs := newStubMessageRepo()
+	prov := &stubProvider{
+		deltas: []ai.Delta{
+			{Text: "partial"},
+			{Err: errors.New("upstream blew up")},
+		},
+	}
+	svc := ai.NewService(threads, msgs, nil, prov)
+
+	thr, _ := svc.CreateThread(context.Background(), 1, nil)
+	events, err := svc.SendMessage(context.Background(), 1, thr.ID, "hi")
+	if err != nil {
+		t.Fatalf("SendMessage: %v", err)
+	}
+	var sawError bool
+	for ev := range events {
+		if ev.Type == ai.SSEError {
+			sawError = true
+			if !strings.Contains(string(ev.Data), "upstream blew up") {
+				t.Errorf("error event = %s, want it to mention upstream", string(ev.Data))
+			}
+		}
+	}
+	if !sawError {
+		t.Fatal("expected SSEError event from mid-stream provider err")
+	}
+	// User message persisted; no assistant message.
+	persisted, _ := msgs.ListByThread(context.Background(), thr.ID)
+	if len(persisted) != 1 || persisted[0].Role != string(ai.RoleUser) {
+		t.Errorf("persisted = %+v, want just the user message", persisted)
+	}
+}


### PR DESCRIPTION
## Summary
- `repository/ai_repo.go` — `AIThreadRepository` (user-scoped CRUD, soft-delete-aware) and `AIMessageRepository` (append-only).
- `service/ai/service.go` — `Service` with `CreateThread`, `ListThreads`, `ListMessages`, `SendMessage`. SendMessage authorization-checks the thread, persists the user turn, builds the anonymized `Context`, streams provider deltas, and persists the assistant turn with the `context_snapshot` JSONB on completion. Constructor takes `(threads, messages, builder, provider)` — explicitly no `pii_repo`, enforced by the existing noimport test.
- SSE event types are typed (`SSEDelta`, `SSEDone`, `SSEError`) with JSON payloads (`{text}`, `{finish_reason,input_tokens,output_tokens,message_id}`, `{message,code}`).
- `handler/ai_handler.go` — `POST/GET /api/v1/ai/threads`, `GET/POST /api/v1/ai/threads/:id/messages`. The POST messages route holds an SSE stream open via `c.Stream(...)`.
- `router/router.go` wires the AI service into the secured route group. `newAIProvider` returns a Claude provider when `CLAUDE_API_KEY` is set, otherwise nil — the service treats nil as "send disabled" and returns `ErrNoProvider` → 503 `NO_AI_PROVIDER`.

## Test plan
- [x] `go test -race ./internal/service/ai/...` — 19 tests pass including the new orchestration suite:
  - Stub-provider happy path: 3 deltas concat to `"Hello, world!"`, persisted assistant message matches, done payload carries the right `message_id` and `finish_reason`
  - `context_snapshot` is JSON, non-empty after a build (AC line)
  - `ErrNoProvider` returned without opening a stream when provider is nil
  - Empty content rejected with `ErrEmptyMessage` before persisting anything
  - Cross-user access: user B sees `ErrThreadNotFound` for user A's thread on `GetThread`, `ListMessages`, `SendMessage`; `ListThreads` excludes A's threads
  - Mid-stream provider error → terminal `SSEError` event; assistant message NOT persisted
- [x] `go test -race -p 1 ./...` — full backend suite green
- [x] `go vet ./...` and `gofmt -l` — clean
- [ ] Lint via CI

Closes #129