### PR TITLE
feat(ai): chat UI with thread list, streaming, context preview (#130)

### DIFF
--- a/frontend/src/api/ai.ts
+++ b/frontend/src/api/ai.ts
@@ -1,0 +1,110 @@
+import { apiClient, type ApiItem, type ApiList } from './client'
+import type {
+  AIDeltaPayload,
+  AIDonePayload,
+  AIErrorPayload,
+  AIMessage,
+  AIThread,
+} from '../types/ai'
+
+export async function listThreads(): Promise<AIThread[]> {
+  const res = await apiClient.get<ApiList<AIThread>>('/ai/threads')
+  return res.data.data
+}
+
+export async function createThread(title?: string): Promise<AIThread> {
+  const res = await apiClient.post<ApiItem<AIThread>>('/ai/threads', { title })
+  return res.data.data
+}
+
+export async function listMessages(threadID: number): Promise<AIMessage[]> {
+  const res = await apiClient.get<ApiList<AIMessage>>(`/ai/threads/${threadID}/messages`)
+  return res.data.data
+}
+
+// SSEHandlers receives parsed event payloads. The stream caller closes
+// after a terminal `done` or `error`; the caller can also abort via the
+// AbortController.
+export type SSEHandlers = {
+  onDelta?: (p: AIDeltaPayload) => void
+  onDone?: (p: AIDonePayload) => void
+  onError?: (p: AIErrorPayload) => void
+}
+
+// streamMessage opens the SSE stream backing `POST /ai/threads/:id/messages`.
+// We use fetch + ReadableStream (not EventSource) because the backend
+// gates the endpoint on the session cookie and EventSource doesn't carry
+// credentials by default. The signal lets the page abort if the user
+// navigates away mid-stream.
+export async function streamMessage(
+  threadID: number,
+  content: string,
+  handlers: SSEHandlers,
+  signal?: AbortSignal,
+): Promise<void> {
+  // Reuse the same base URL the rest of the client uses so dev (Vite
+  // proxy) and prod (VITE_API_BASE_URL) keep working without conditionals.
+  const baseURL = apiClient.defaults.baseURL ?? '/api/v1'
+  const res = await fetch(`${baseURL}/ai/threads/${threadID}/messages`, {
+    method: 'POST',
+    credentials: 'include',
+    headers: { 'Content-Type': 'application/json', Accept: 'text/event-stream' },
+    body: JSON.stringify({ content }),
+    signal,
+  })
+  if (!res.ok || !res.body) {
+    let detail = ''
+    try {
+      const j = await res.json()
+      detail = j?.error ?? ''
+    } catch {
+      // body wasn't JSON — fall through
+    }
+    handlers.onError?.({ message: detail || `HTTP ${res.status}` })
+    return
+  }
+
+  const reader = res.body.getReader()
+  const decoder = new TextDecoder()
+  let buf = ''
+
+  const flushEvent = (raw: string) => {
+    // Each event is "event: <type>\ndata: <json>\n\n"
+    let evType = ''
+    let data = ''
+    for (const line of raw.split('\n')) {
+      if (line.startsWith('event:')) evType = line.slice(6).trim()
+      else if (line.startsWith('data:')) data += line.slice(5).trim()
+    }
+    if (!evType || !data) return
+    try {
+      const parsed = JSON.parse(data)
+      if (evType === 'delta') handlers.onDelta?.(parsed as AIDeltaPayload)
+      else if (evType === 'done') handlers.onDone?.(parsed as AIDonePayload)
+      else if (evType === 'error') handlers.onError?.(parsed as AIErrorPayload)
+    } catch (err) {
+      handlers.onError?.({ message: `bad SSE payload: ${(err as Error).message}` })
+    }
+  }
+
+  try {
+    for (;;) {
+      const { value, done } = await reader.read()
+      if (done) break
+      buf += decoder.decode(value, { stream: true })
+      // SSE event boundary is a blank line — `\n\n`. Process every complete
+      // event, leave the trailing partial in buf for the next chunk.
+      let idx = buf.indexOf('\n\n')
+      while (idx !== -1) {
+        const eventStr = buf.slice(0, idx)
+        buf = buf.slice(idx + 2)
+        if (eventStr.trim() !== '') flushEvent(eventStr)
+        idx = buf.indexOf('\n\n')
+      }
+    }
+    if (buf.trim() !== '') flushEvent(buf)
+  } catch (err) {
+    if ((err as Error).name === 'AbortError') return
+    handlers.onError?.({ message: (err as Error).message })
+  }
+}

--- a/frontend/src/pages/AIPage.tsx
+++ b/frontend/src/pages/AIPage.tsx
@@ -1,5 +1,313 @@
-import { PageStub } from '../components/PageStub'
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { Plus, Send, Square, Sparkles } from 'lucide-react'
+import { useAIStore } from '../store/aiStore'
+import type { AIMessage, AIModel } from '../types/ai'
+
+// Starter prompts shown on empty threads. Picked to exercise the
+// aggregator surfaces in context_builder.go — net worth, spend, budgets,
+// goals, allocation — so users see the assistant pulling real data.
+const SUGGESTED_PROMPTS = [
+  'How am I doing against my budgets this month?',
+  'What was my biggest spending category last month?',
+  'Am I on track for my savings goals?',
+  'Is my asset allocation reasonable for my age?',
+]
 
 export function AIPage() {
-  return <PageStub title="AI Advisor" />
+  const {
+    threads,
+    activeThreadID,
+    messages,
+    loadingThreads,
+    loadingMessages,
+    streaming,
+    error,
+    model,
+    fetchThreads,
+    selectThread,
+    newThread,
+    sendMessage,
+    cancelStreaming,
+    setModel,
+    clearError,
+  } = useAIStore()
+  const [draft, setDraft] = useState('')
+  const messagesEnd = useRef<HTMLDivElement | null>(null)
+
+  useEffect(() => {
+    void fetchThreads()
+  }, [fetchThreads])
+
+  // Auto-scroll the chat to the latest message / streaming token.
+  useEffect(() => {
+    messagesEnd.current?.scrollIntoView({ behavior: 'smooth' })
+  }, [messages, streaming?.partialText])
+
+  const activeThread = useMemo(
+    () => threads.find((t) => t.id === activeThreadID) ?? null,
+    [threads, activeThreadID],
+  )
+
+  const lastContextSnapshot = useMemo(() => {
+    // Find the most recent assistant message in this thread that has a
+    // non-empty context_snapshot. That's the snapshot the model just used.
+    for (let i = messages.length - 1; i >= 0; i--) {
+      const m = messages[i]
+      if (m.role === 'assistant' && m.context_snapshot != null) {
+        return m.context_snapshot
+      }
+    }
+    return null
+  }, [messages])
+
+  const handleSend = async () => {
+    if (!draft.trim() || streaming) return
+    if (activeThreadID == null) {
+      // newThread() sets activeThreadID; sendMessage reads it via the store.
+      await newThread()
+    }
+    const content = draft
+    setDraft('')
+    await sendMessage(content)
+  }
+
+  const handleSuggested = async (prompt: string) => {
+    if (streaming) return
+    if (activeThreadID == null) {
+      await newThread()
+    }
+    await sendMessage(prompt)
+  }
+
+  return (
+    <div className="-mx-8 -my-8 grid grid-cols-[220px_1fr_280px] gap-0 h-[calc(100vh-0px)]">
+      {/* Thread list */}
+      <aside className="border-r border-gray-200 bg-white flex flex-col">
+        <div className="px-3 py-3 border-b border-gray-200 flex items-center justify-between">
+          <h2 className="text-sm font-semibold text-gray-900">Threads</h2>
+          <button
+            type="button"
+            onClick={() => void newThread()}
+            className="inline-flex items-center gap-1 rounded-md bg-indigo-600 px-2 py-1 text-xs font-medium text-white hover:bg-indigo-700"
+            title="New thread"
+          >
+            <Plus size={12} /> New
+          </button>
+        </div>
+        <div className="flex-1 overflow-auto">
+          {loadingThreads && threads.length === 0 && (
+            <div className="px-3 py-4 text-xs text-gray-400">Loading…</div>
+          )}
+          {!loadingThreads && threads.length === 0 && (
+            <div className="px-3 py-4 text-xs text-gray-400">
+              No threads yet. Start one to ask the AI a question.
+            </div>
+          )}
+          {threads.map((t) => (
+            <button
+              key={t.id}
+              type="button"
+              onClick={() => void selectThread(t.id)}
+              className={[
+                'block w-full text-left px-3 py-2 text-sm border-b border-gray-100',
+                t.id === activeThreadID ? 'bg-indigo-50 text-indigo-900' : 'hover:bg-gray-50 text-gray-700',
+              ].join(' ')}
+            >
+              <div className="truncate">{t.title || `Thread ${t.id}`}</div>
+              <div className="text-[11px] text-gray-400">
+                {new Date(t.updated_at).toLocaleString()}
+              </div>
+            </button>
+          ))}
+        </div>
+      </aside>
+
+      {/* Chat */}
+      <section className="flex flex-col bg-gray-50">
+        <header className="flex items-center justify-between border-b border-gray-200 bg-white px-4 py-3">
+          <div>
+            <h1 className="text-base font-semibold text-gray-900">AI Advisor</h1>
+            <p className="text-xs text-gray-500">
+              {activeThread
+                ? activeThread.title || `Thread ${activeThread.id}`
+                : 'Start a new thread or pick one from the left.'}
+            </p>
+          </div>
+          <ModelSwitcher value={model} onChange={setModel} />
+        </header>
+
+        {error && (
+          <div className="mx-4 mt-3 flex items-start justify-between rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
+            <span>{error}</span>
+            <button type="button" onClick={clearError} className="ml-3 text-red-600 hover:text-red-800">×</button>
+          </div>
+        )}
+
+        <div className="flex-1 overflow-auto px-4 py-4">
+          {loadingMessages && messages.length === 0 && (
+            <div className="text-center text-xs text-gray-400">Loading messages…</div>
+          )}
+          {!loadingMessages && messages.length === 0 && (
+            <EmptyState onSuggested={handleSuggested} disabled={!!streaming} />
+          )}
+          {messages.map((m) => (
+            <MessageBubble key={m.id} message={m} />
+          ))}
+          {streaming && streaming.partialText !== '' && (
+            <MessageBubble
+              message={{
+                id: -1,
+                thread_id: streaming.threadID,
+                role: 'assistant',
+                content: streaming.partialText,
+                created_at: new Date().toISOString(),
+              }}
+              streaming
+            />
+          )}
+          <div ref={messagesEnd} />
+        </div>
+
+        <footer className="border-t border-gray-200 bg-white p-3">
+          <div className="flex items-end gap-2">
+            <textarea
+              value={draft}
+              onChange={(e) => setDraft(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' && !e.shiftKey) {
+                  e.preventDefault()
+                  void handleSend()
+                }
+              }}
+              rows={2}
+              placeholder="Ask about your finances — e.g. can I afford a $2k flight in October?"
+              className="flex-1 resize-none rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-indigo-500 focus:outline-none"
+            />
+            {streaming ? (
+              <button
+                type="button"
+                onClick={cancelStreaming}
+                className="inline-flex items-center gap-1 rounded-md bg-gray-200 px-3 py-2 text-sm font-medium text-gray-700 hover:bg-gray-300"
+              >
+                <Square size={14} /> Stop
+              </button>
+            ) : (
+              <button
+                type="button"
+                onClick={() => void handleSend()}
+                disabled={!draft.trim()}
+                className="inline-flex items-center gap-1 rounded-md bg-indigo-600 px-3 py-2 text-sm font-medium text-white hover:bg-indigo-700 disabled:opacity-40"
+              >
+                <Send size={14} /> Send
+              </button>
+            )}
+          </div>
+        </footer>
+      </section>
+
+      {/* Context preview */}
+      <aside className="border-l border-gray-200 bg-white flex flex-col">
+        <div className="px-3 py-3 border-b border-gray-200">
+          <h2 className="text-sm font-semibold text-gray-900">Context sent</h2>
+          <p className="text-[11px] text-gray-500 leading-tight mt-1">
+            The exact aggregate snapshot the model received for the most recent turn.
+          </p>
+        </div>
+        <div className="flex-1 overflow-auto px-3 py-3 text-[11px]">
+          {lastContextSnapshot ? (
+            <pre className="whitespace-pre-wrap text-gray-700">
+              {JSON.stringify(lastContextSnapshot, null, 2)}
+            </pre>
+          ) : (
+            <p className="text-gray-400">
+              No context yet — send a message to see the snapshot the AI received.
+            </p>
+          )}
+        </div>
+        <div className="border-t border-gray-200 px-3 py-3 text-[11px]">
+          <div className="font-semibold text-red-700 mb-1">NOT sent:</div>
+          <ul className="space-y-0.5 text-gray-600">
+            <li className="line-through">account numbers</li>
+            <li className="line-through">holder names</li>
+            <li className="line-through">institutions</li>
+            <li className="line-through">per-transaction rows</li>
+          </ul>
+        </div>
+      </aside>
+    </div>
+  )
+}
+
+function ModelSwitcher({ value, onChange }: { value: AIModel; onChange: (m: AIModel) => void }) {
+  return (
+    <div className="inline-flex rounded-md border border-gray-200 bg-gray-50 p-0.5 text-xs">
+      {(['claude', 'ollama'] as const).map((m) => (
+        <button
+          key={m}
+          type="button"
+          onClick={() => onChange(m)}
+          className={[
+            'px-2 py-1 rounded',
+            value === m ? 'bg-white text-gray-900 shadow-sm' : 'text-gray-500 hover:text-gray-700',
+          ].join(' ')}
+        >
+          {m === 'claude' ? 'Claude' : 'Ollama'}
+        </button>
+      ))}
+    </div>
+  )
+}
+
+function EmptyState({
+  onSuggested,
+  disabled,
+}: {
+  onSuggested: (p: string) => void
+  disabled: boolean
+}) {
+  return (
+    <div className="mx-auto max-w-md text-center py-8">
+      <Sparkles size={28} className="mx-auto text-indigo-500 mb-2" />
+      <h3 className="text-base font-medium text-gray-900">Ask about your finances</h3>
+      <p className="text-xs text-gray-500 mt-1">
+        The assistant only sees anonymized aggregates from your data — no holder names, no
+        account numbers.
+      </p>
+      <div className="mt-4 grid gap-2">
+        {SUGGESTED_PROMPTS.map((p) => (
+          <button
+            key={p}
+            type="button"
+            disabled={disabled}
+            onClick={() => onSuggested(p)}
+            className="rounded-md border border-gray-200 bg-white px-3 py-2 text-left text-sm text-gray-700 hover:border-indigo-300 hover:bg-indigo-50 disabled:opacity-40"
+          >
+            {p}
+          </button>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function MessageBubble({ message, streaming }: { message: AIMessage; streaming?: boolean }) {
+  const isUser = message.role === 'user'
+  return (
+    <div className={['mb-3 flex', isUser ? 'justify-end' : 'justify-start'].join(' ')}>
+      <div
+        className={[
+          'max-w-[80%] rounded-lg px-3 py-2 text-sm whitespace-pre-wrap',
+          isUser
+            ? 'bg-indigo-600 text-white'
+            : 'bg-white border border-gray-200 text-gray-900',
+        ].join(' ')}
+      >
+        <div className={['text-[10px] uppercase tracking-wide mb-1', isUser ? 'text-indigo-200' : 'text-gray-400'].join(' ')}>
+          {isUser ? 'You' : message.provider || 'Assistant'}
+          {streaming && <span className="ml-1 animate-pulse">…</span>}
+        </div>
+        {message.content}
+      </div>
+    </div>
+  )
 }

--- a/frontend/src/store/aiStore.ts
+++ b/frontend/src/store/aiStore.ts
@@ -1,0 +1,176 @@
+import { create } from 'zustand'
+import {
+  createThread as apiCreate,
+  listMessages,
+  listThreads,
+  streamMessage,
+} from '../api/ai'
+import type { AIMessage, AIModel, AIThread } from '../types/ai'
+
+const MODEL_KEY = 'offbook.ai.model'
+
+function loadModel(): AIModel {
+  if (typeof window === 'undefined') return 'claude'
+  const v = window.localStorage.getItem(MODEL_KEY)
+  return v === 'ollama' ? 'ollama' : 'claude'
+}
+
+type StreamingState = {
+  threadID: number
+  partialText: string
+  abort: AbortController
+}
+
+type State = {
+  threads: AIThread[]
+  activeThreadID: number | null
+  messages: AIMessage[]
+  loadingThreads: boolean
+  loadingMessages: boolean
+  streaming: StreamingState | null
+  error: string | null
+  model: AIModel
+
+  fetchThreads: () => Promise<void>
+  selectThread: (id: number) => Promise<void>
+  newThread: () => Promise<AIThread>
+  sendMessage: (content: string) => Promise<void>
+  cancelStreaming: () => void
+  setModel: (m: AIModel) => void
+  clearError: () => void
+}
+
+export const useAIStore = create<State>((set, get) => ({
+  threads: [],
+  activeThreadID: null,
+  messages: [],
+  loadingThreads: false,
+  loadingMessages: false,
+  streaming: null,
+  error: null,
+  model: loadModel(),
+
+  fetchThreads: async () => {
+    set({ loadingThreads: true, error: null })
+    try {
+      const threads = await listThreads()
+      set({ threads, loadingThreads: false })
+    } catch (err) {
+      set({ loadingThreads: false, ...errInfo(err) })
+    }
+  },
+
+  selectThread: async (id) => {
+    set({ activeThreadID: id, messages: [], loadingMessages: true, error: null })
+    try {
+      const msgs = await listMessages(id)
+      set({ messages: msgs, loadingMessages: false })
+    } catch (err) {
+      set({ loadingMessages: false, ...errInfo(err) })
+    }
+  },
+
+  newThread: async () => {
+    set({ error: null })
+    try {
+      const t = await apiCreate()
+      set({
+        threads: [t, ...get().threads],
+        activeThreadID: t.id,
+        messages: [],
+      })
+      return t
+    } catch (err) {
+      set(errInfo(err))
+      throw err
+    }
+  },
+
+  sendMessage: async (content) => {
+    const { activeThreadID } = get()
+    if (!activeThreadID || !content.trim()) return
+    if (get().streaming) return // already streaming — caller shouldn't double-send
+
+    // Optimistically append the user message and an empty assistant
+    // placeholder. The placeholder accumulates streamed text in-place so
+    // the UI doesn't flash a "no messages" gap mid-stream.
+    const now = new Date().toISOString()
+    const userTurn: AIMessage = {
+      id: -Date.now(), // negative ID flags "optimistic"
+      thread_id: activeThreadID,
+      role: 'user',
+      content,
+      created_at: now,
+    }
+    set({
+      messages: [...get().messages, userTurn],
+      streaming: {
+        threadID: activeThreadID,
+        partialText: '',
+        abort: new AbortController(),
+      },
+      error: null,
+    })
+
+    await streamMessage(
+      activeThreadID,
+      content,
+      {
+        onDelta: (p) => {
+          const s = get().streaming
+          if (!s) return
+          const partial = s.partialText + p.text
+          set({ streaming: { ...s, partialText: partial } })
+        },
+        onDone: async () => {
+          // Reload messages so the server-canonical IDs + timestamps replace
+          // the optimistic rows. Also refresh thread list so updated_at order
+          // is correct.
+          set({ streaming: null })
+          try {
+            const [msgs, threads] = await Promise.all([
+              listMessages(activeThreadID),
+              listThreads(),
+            ])
+            set({ messages: msgs, threads })
+          } catch (err) {
+            set(errInfo(err))
+          }
+        },
+        onError: (p) => {
+          // Roll back the optimistic placeholder messages so the user can
+          // retry without two phantom turns hanging around.
+          set({
+            streaming: null,
+            messages: get().messages.filter((m) => m.id !== userTurn.id),
+            error: p.message,
+          })
+        },
+      },
+      get().streaming?.abort.signal,
+    )
+  },
+
+  cancelStreaming: () => {
+    const s = get().streaming
+    if (!s) return
+    s.abort.abort()
+    set({ streaming: null })
+  },
+
+  setModel: (m) => {
+    if (typeof window !== 'undefined') window.localStorage.setItem(MODEL_KEY, m)
+    set({ model: m })
+  },
+
+  clearError: () => set({ error: null }),
+}))
+
+function errInfo(err: unknown): { error: string } {
+  if (err && typeof err === 'object' && 'response' in err) {
+    const r = (err as { response?: { data?: { error?: string } } }).response
+    if (r?.data?.error) return { error: r.data.error }
+  }
+  if (err instanceof Error) return { error: err.message }
+  return { error: 'request failed' }
+}

--- a/frontend/src/types/ai.ts
+++ b/frontend/src/types/ai.ts
@@ -1,0 +1,42 @@
+// Mirror of backend model.AIThread / model.AIMessage. Keep in sync with
+// backend/internal/model/ai_thread.go and ai_message.go.
+
+export type AIThread = {
+  id: number
+  user_id: number
+  household_id?: number | null
+  shared_with_household: boolean
+  title?: string | null
+  created_at: string
+  updated_at: string
+}
+
+export type AIRole = 'user' | 'assistant' | 'system'
+
+export type AIMessage = {
+  id: number
+  thread_id: number
+  role: AIRole
+  content: string
+  context_snapshot?: unknown // JSONB on the server; opaque to the UI except for the preview panel
+  provider?: string | null
+  model_name?: string | null
+  created_at: string
+}
+
+// SSE event payloads mirror backend service/ai/service.go.
+export type AIDeltaPayload = { text: string }
+
+export type AIDonePayload = {
+  finish_reason?: string
+  input_tokens?: number
+  output_tokens?: number
+  message_id: number
+}
+
+export type AIErrorPayload = { message: string; code?: string }
+
+// AIModel is the user-facing choice in the model switcher. Settings page
+// (#131) will own real persistence; this page uses localStorage in the
+// meantime.
+export type AIModel = 'claude' | 'ollama'


### PR DESCRIPTION
## Summary
- Replaces `pages/AIPage.tsx`'s PageStub with the three-column AI Advisor layout from the wireframe: thread list (left) · chat (middle) · context-preview panel (right).
- `src/api/ai.ts` — thread CRUD + `streamMessage()` that consumes the backend SSE stream via `fetch` + `ReadableStream` (so the session cookie is sent — `EventSource` doesn't carry credentials and can't POST anyway).
- `src/store/aiStore.ts` — Zustand store with optimistic user-turn append, in-place token accumulation during streaming, rollback on error, and a localStorage-backed model toggle (Claude / Ollama) until Settings (#131) takes over persistence.
- `src/types/ai.ts` mirrors backend schemas.
- UI surfaces from the wireframe: thread list newest-first, model switcher in the header, suggested-prompts strip on empty threads, role-labeled bubbles, streaming "…" indicator, Stop button, error banner with retry-friendly state rollback, and the explicit "NOT sent: account numbers / holder names / institutions / per-transaction rows" callout under the context JSON.

## Test plan
- [x] `pnpm lint` — clean
- [x] `pnpm build` — type-checks and bundles
- [ ] Manual: open `/ai` against a backend with `CLAUDE_API_KEY` set, send a message, watch tokens stream and the context JSON appear in the right panel
- [ ] Manual: send a message with no `CLAUDE_API_KEY` and confirm the `NO_AI_PROVIDER` error shows in the banner
- [ ] Manual: stop mid-stream and confirm the assistant placeholder rolls back

Closes #130