### PR TITLE
feat(ai): per-user AI provider settings (#131)

### DIFF
--- a/backend/internal/handler/user_settings_handler.go
+++ b/backend/internal/handler/user_settings_handler.go
@@ -1,0 +1,77 @@
+package handler
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/gregwym/offbook/backend/internal/service"
+	"github.com/gregwym/offbook/backend/internal/service/auth"
+)
+
+// UserSettingsHandler exposes the per-user AI settings surface.
+type UserSettingsHandler struct {
+	svc *service.UserSettingsService
+}
+
+func NewUserSettingsHandler(s *service.UserSettingsService) *UserSettingsHandler {
+	return &UserSettingsHandler{svc: s}
+}
+
+func (h *UserSettingsHandler) Register(g *gin.RouterGroup) {
+	g.GET("/me/settings", h.Get)
+	g.PATCH("/me/settings", h.Update)
+}
+
+func (h *UserSettingsHandler) Get(c *gin.Context) {
+	v, err := h.svc.Get(c.Request.Context(), auth.MustUserID(c.Request.Context()))
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error(), "code": "INTERNAL"})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"data": v})
+}
+
+type updateUserSettingsRequest struct {
+	ClaudeAPIKey      *string `json:"claude_api_key"`
+	ClearClaudeAPIKey bool    `json:"clear_claude_api_key"`
+	OllamaBaseURL     *string `json:"ollama_base_url"`
+	ClearOllamaURL    bool    `json:"clear_ollama_url"`
+	PreferredProvider *string `json:"preferred_provider"`
+	PreferredModel    *string `json:"preferred_model"`
+	ClearModel        bool    `json:"clear_preferred_model"`
+}
+
+func (h *UserSettingsHandler) Update(c *gin.Context) {
+	var req updateUserSettingsRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error(), "code": "INVALID_REQUEST"})
+		return
+	}
+	v, err := h.svc.Update(c.Request.Context(), auth.MustUserID(c.Request.Context()), service.UpdateUserSettingsInput{
+		ClaudeAPIKey:      req.ClaudeAPIKey,
+		ClearClaudeAPIKey: req.ClearClaudeAPIKey,
+		OllamaBaseURL:     req.OllamaBaseURL,
+		ClearOllamaURL:    req.ClearOllamaURL,
+		PreferredProvider: req.PreferredProvider,
+		PreferredModel:    req.PreferredModel,
+		ClearModel:        req.ClearModel,
+	})
+	if err != nil {
+		switch {
+		case errors.Is(err, service.ErrInvalidProvider):
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error(), "code": "INVALID_PROVIDER"})
+		default:
+			// Empty-key-with-no-clear-flag and similar validation hits the
+			// generic 400 path; the message is human-readable.
+			if err.Error() == "claude_api_key must not be empty (use clear_claude_api_key to delete)" {
+				c.JSON(http.StatusBadRequest, gin.H{"error": err.Error(), "code": "INVALID_REQUEST"})
+				return
+			}
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error(), "code": "INTERNAL"})
+		}
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"data": v})
+}

--- a/backend/internal/model/user_settings.go
+++ b/backend/internal/model/user_settings.go
@@ -1,0 +1,19 @@
+package model
+
+import "time"
+
+// UserSettings is per-user configuration for the AI advisor (and the
+// scaffolding for any future per-user settings). One row per user; the
+// settings service auto-creates the row on first read so handlers can
+// treat absence as "all defaults" rather than handling a not-found path.
+type UserSettings struct {
+	UserID            int64     `gorm:"primaryKey" json:"user_id"`
+	ClaudeAPIKeyEnc   []byte    `gorm:"column:claude_api_key_enc" json:"-"`
+	OllamaBaseURL     *string   `gorm:"column:ollama_base_url" json:"ollama_base_url,omitempty"`
+	PreferredProvider string    `gorm:"column:preferred_provider;not null;default:claude" json:"preferred_provider"`
+	PreferredModel    *string   `gorm:"column:preferred_model" json:"preferred_model,omitempty"`
+	CreatedAt         time.Time `json:"created_at"`
+	UpdatedAt         time.Time `json:"updated_at"`
+}
+
+func (UserSettings) TableName() string { return "user_settings" }

--- a/backend/internal/repository/user_settings_repo.go
+++ b/backend/internal/repository/user_settings_repo.go
@@ -1,0 +1,47 @@
+package repository
+
+import (
+	"context"
+	"errors"
+
+	"gorm.io/gorm"
+
+	"github.com/gregwym/offbook/backend/internal/model"
+)
+
+// UserSettingsRepository is the data-access contract for user_settings.
+// One row per user; Get auto-returns ErrNotFound so the service can
+// upsert defaults on first read.
+type UserSettingsRepository interface {
+	Get(ctx context.Context, userID int64) (*model.UserSettings, error)
+	Upsert(ctx context.Context, s *model.UserSettings) error
+}
+
+type userSettingsRepo struct {
+	db *gorm.DB
+}
+
+func NewUserSettingsRepository(db *gorm.DB) UserSettingsRepository {
+	return &userSettingsRepo{db: db}
+}
+
+func (r *userSettingsRepo) Get(ctx context.Context, userID int64) (*model.UserSettings, error) {
+	var s model.UserSettings
+	if err := r.db.WithContext(ctx).First(&s, "user_id = ?", userID).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, ErrNotFound
+		}
+		return nil, err
+	}
+	return &s, nil
+}
+
+// Upsert writes the row, inserting on first call and updating on
+// subsequent ones. The conflict target is the PK (user_id) so the upsert
+// is collision-safe under concurrent writes from multiple sessions.
+func (r *userSettingsRepo) Upsert(ctx context.Context, s *model.UserSettings) error {
+	// Plain Save() works here: gorm will INSERT if no row exists and UPDATE
+	// otherwise. Race condition is benign — both writes carry the same
+	// user's settings.
+	return r.db.WithContext(ctx).Save(s).Error
+}

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -2,6 +2,7 @@ package router
 
 import (
 	"context"
+	"crypto/sha256"
 
 	"github.com/gin-gonic/gin"
 	"gorm.io/gorm"
@@ -104,15 +105,23 @@ func New(cfg config.Config, gormDB *gorm.DB) *gin.Engine {
 	plaidSvc := newPlaidService(cfg, gormDB, plaidItemRepo, accountRepo, transactionRepo, plaidSyncErrRepo, piiSvc).WithRuleRepo(ruleRepo)
 	plaidHandler := handler.NewPlaidHandler(plaidSvc)
 
-	// AI advisor: provider is optional. Without CLAUDE_API_KEY the service
-	// still registers (so threads/list/history work for past conversations)
-	// but SendMessage returns ErrNoProvider until the user adds a key.
+	// User settings: per-user AI provider config (Claude key, Ollama URL,
+	// preferred provider). The Claude key is encrypted with a SecretBox
+	// derived from SESSION_SECRET — no new operator secret.
+	userSettingsSvc := newUserSettingsService(cfg, gormDB)
+	userSettingsHandler := handler.NewUserSettingsHandler(userSettingsSvc)
+
+	// AI advisor: per-user provider resolution. The resolver reads user
+	// settings; missing settings fall back to env-configured Claude. The
+	// service still registers when nothing is configured (threads/list/
+	// history work for past conversations) and SendMessage returns
+	// ErrNoProvider until the user adds a key.
 	aiBuilder := ai.NewContextBuilder(dashboardSvc, budgetSvc, savingsGoalSvc, investmentSvc, categorySvc)
 	aiSvc := ai.NewService(
 		repository.NewAIThreadRepository(gormDB),
 		repository.NewAIMessageRepository(gormDB),
 		aiBuilder,
-		newAIProvider(cfg),
+		&aiProviderResolver{settings: userSettingsSvc, envFallback: newAIProvider(cfg)},
 	)
 	aiHandler := handler.NewAIHandler(aiSvc)
 
@@ -140,6 +149,7 @@ func New(cfg config.Config, gormDB *gorm.DB) *gin.Engine {
 		scopeHandler.Register(secured)
 		plaidHandler.Register(secured)
 		aiHandler.Register(secured)
+		userSettingsHandler.Register(secured)
 	}
 
 	return r
@@ -194,13 +204,13 @@ func newPlaidService(
 	)
 }
 
-// newAIProvider returns the configured Claude provider when
+// newAIProvider returns the env-configured Claude provider when
 // CLAUDE_API_KEY is set, otherwise nil. The AI service treats a nil
-// provider as "send disabled" — see ai.Service.ProviderConfigured.
+// provider as "send disabled" and returns ErrNoProvider.
 //
-// Ollama is also a valid choice but it isn't a startup-config flip: it's
-// a per-thread/per-user setting that ships with the settings UI in a
-// later issue. Until then, Claude is the only auto-wired provider.
+// This is the fallback path: per-user settings take precedence (see
+// aiProviderResolver below). The env default keeps the single-tenant
+// local-deploy story working without anyone visiting Settings.
 func newAIProvider(cfg config.Config) ai.Provider {
 	if !cfg.ClaudeConfigured() {
 		return nil
@@ -213,6 +223,60 @@ func newAIProvider(cfg config.Config) ai.Provider {
 		return nil
 	}
 	return p
+}
+
+// newUserSettingsService derives a SecretBox key from SESSION_SECRET via
+// SHA-256 (SESSION_SECRET is hex-encoded in operator config but the
+// existing auth code treats it as raw bytes — hashing normalizes either
+// shape to 32 bytes for AES-256). One SecretBox per process; the cipher
+// is concurrent-safe.
+func newUserSettingsService(cfg config.Config, gormDB *gorm.DB) *service.UserSettingsService {
+	sum := sha256.Sum256([]byte(cfg.SessionSecret))
+	box, err := crypto.NewSecretBox(sum[:])
+	if err != nil {
+		// SESSION_SECRET is required from M2.5+; the only way NewSecretBox
+		// fails here is a panic-worthy bug (it accepts 32 bytes and we
+		// just gave it exactly that).
+		panic("user_settings: secretbox: " + err.Error())
+	}
+	return service.NewUserSettingsService(repository.NewUserSettingsRepository(gormDB), box)
+}
+
+// aiProviderResolver maps a userID to the right Provider for SendMessage.
+// Looks up per-user settings first; falls back to the env-configured
+// provider when nothing user-specific is set.
+type aiProviderResolver struct {
+	settings    *service.UserSettingsService
+	envFallback ai.Provider
+}
+
+func (r *aiProviderResolver) For(ctx context.Context, userID int64) (ai.Provider, error) {
+	resolved, err := r.settings.Resolve(ctx, userID)
+	if err != nil {
+		return nil, err
+	}
+	switch resolved.Provider {
+	case "ollama":
+		base := resolved.OllamaBaseURL
+		if base == "" {
+			// No user URL → env default. Ollama works without an API key,
+			// so there's nothing further to gate on.
+			return ai.NewOllamaProvider(ai.OllamaConfig{}), nil
+		}
+		return ai.NewOllamaProvider(ai.OllamaConfig{BaseURL: base}), nil
+	case "claude":
+		fallthrough
+	default:
+		key := resolved.ClaudeKey
+		if key == "" {
+			return r.envFallback, nil
+		}
+		p, err := ai.NewClaudeProvider(ai.ClaudeConfig{APIKey: key})
+		if err != nil {
+			return r.envFallback, nil
+		}
+		return p, nil
+	}
 }
 
 func corsMiddleware(origin string) gin.HandlerFunc {

--- a/backend/internal/service/ai/service.go
+++ b/backend/internal/service/ai/service.go
@@ -66,6 +66,31 @@ type ErrorPayload struct {
 	Code    string `json:"code,omitempty"`
 }
 
+// ProviderResolver maps a user to the Provider that should handle their
+// SendMessage calls. The router-side implementation looks up per-user
+// settings (Claude key, Ollama URL, preferred provider) and falls back
+// to env-configured defaults when settings are unset.
+//
+// Returning (nil, nil) is the explicit "no provider configured for this
+// user" signal — Service.SendMessage maps it to ErrNoProvider so the
+// frontend can prompt the user to add a Claude key.
+type ProviderResolver interface {
+	For(ctx context.Context, userID int64) (Provider, error)
+}
+
+// staticResolver wraps a single Provider so tests don't need to define a
+// fresh resolver type for each suite. Production wiring uses a real
+// resolver that reads user settings.
+type staticResolver struct{ p Provider }
+
+func (r staticResolver) For(_ context.Context, _ int64) (Provider, error) {
+	return r.p, nil
+}
+
+// StaticResolver builds a ProviderResolver that always returns p. Useful
+// in tests and for single-user instances where everyone shares one key.
+func StaticResolver(p Provider) ProviderResolver { return staticResolver{p: p} }
+
 // Service is the orchestration layer: persistence + context build +
 // provider stream. Constructor signature is deliberately fixed — adding
 // `pii_repo` here would be the regression the noimport_test guards
@@ -74,32 +99,35 @@ type Service struct {
 	threads  repository.AIThreadRepository
 	messages repository.AIMessageRepository
 	builder  *ContextBuilder
-	provider Provider
+	resolver ProviderResolver
 }
 
-// NewService wires the AI orchestration layer. The provider may be nil at
-// boot — callers that haven't configured CLAUDE_API_KEY pass nil and the
-// service rejects SendMessage with ErrNoProvider so the settings UI can
-// surface a useful error.
+// NewService wires the AI orchestration layer. Resolver may be nil at
+// boot — when nil, every SendMessage returns ErrNoProvider, so the
+// settings UI can surface a useful error rather than the request hanging
+// on an SSE stream that immediately closes.
 func NewService(
 	threads repository.AIThreadRepository,
 	messages repository.AIMessageRepository,
 	builder *ContextBuilder,
-	provider Provider,
+	resolver ProviderResolver,
 ) *Service {
 	return &Service{
 		threads:  threads,
 		messages: messages,
 		builder:  builder,
-		provider: provider,
+		resolver: resolver,
 	}
 }
 
-// ProviderConfigured reports whether SendMessage will work. Handlers can
-// surface a 503-ish error before opening an SSE stream that's going to
-// immediately close.
-func (s *Service) ProviderConfigured() bool {
-	return s.provider != nil
+// providerFor delegates to the resolver. Returns nil when the user has
+// no provider configured (the resolver is allowed to return nil), or an
+// error when the resolver itself fails (DB read, decryption).
+func (s *Service) providerFor(ctx context.Context, userID int64) (Provider, error) {
+	if s.resolver == nil {
+		return nil, nil
+	}
+	return s.resolver.For(ctx, userID)
 }
 
 // CreateThread starts a new conversation for the user. Title is optional
@@ -157,7 +185,11 @@ func (s *Service) ListMessages(ctx context.Context, userID, threadID int64) ([]m
 // leaks. The handler's gin.Context cancellation handles this naturally
 // when the HTTP client disconnects.
 func (s *Service) SendMessage(ctx context.Context, userID, threadID int64, content string) (<-chan SSEEvent, error) {
-	if !s.ProviderConfigured() {
+	provider, err := s.providerFor(ctx, userID)
+	if err != nil {
+		return nil, fmt.Errorf("ai: resolve provider: %w", err)
+	}
+	if provider == nil {
 		return nil, ErrNoProvider
 	}
 	content = strings.TrimSpace(content)
@@ -211,13 +243,13 @@ func (s *Service) SendMessage(ctx context.Context, userID, threadID int64, conte
 			Content: content,
 		}),
 	}
-	deltas, err := s.provider.Stream(ctx, req)
+	deltas, err := provider.Stream(ctx, req)
 	if err != nil {
 		return nil, fmt.Errorf("ai: provider stream: %w", err)
 	}
 
 	out := make(chan SSEEvent, 16)
-	go s.relayProvider(ctx, threadID, ctxSnapshotJSON, deltas, out)
+	go s.relayProvider(ctx, threadID, provider, ctxSnapshotJSON, deltas, out)
 	return out, nil
 }
 
@@ -226,13 +258,14 @@ func (s *Service) SendMessage(ctx context.Context, userID, threadID int64, conte
 func (s *Service) relayProvider(
 	ctx context.Context,
 	threadID int64,
+	provider Provider,
 	contextSnapshot json.RawMessage,
 	deltas <-chan Delta,
 	out chan<- SSEEvent,
 ) {
 	defer close(out)
 
-	providerName := s.provider.Name()
+	providerName := provider.Name()
 	var assembled strings.Builder
 	var finishReason string
 	var usage Usage

--- a/backend/internal/service/ai/service_test.go
+++ b/backend/internal/service/ai/service_test.go
@@ -149,7 +149,7 @@ func TestService_SendMessage_StubProvider(t *testing.T) {
 	// AC requires "non-empty context_snapshot" so we plumb a builder via
 	// a separate path below. For the first assertion we just want the
 	// delta-relay shape.
-	svc := ai.NewService(threads, msgs, nil, prov)
+	svc := ai.NewService(threads, msgs, nil, ai.StaticResolver(prov))
 
 	const userID int64 = 42
 	thr, err := svc.CreateThread(context.Background(), userID, nil)
@@ -238,7 +238,7 @@ func TestService_SendMessage_PersistsContextSnapshot(t *testing.T) {
 	// Context (no error), which JSON-marshals to a non-empty object — the
 	// AC's "context_snapshot is non-empty" check passes.
 	builder := ai.NewContextBuilder(nil, nil, nil, nil, nil)
-	svc := ai.NewService(threads, msgs, builder, prov)
+	svc := ai.NewService(threads, msgs, builder, ai.StaticResolver(prov))
 
 	const userID int64 = 7
 	thr, _ := svc.CreateThread(context.Background(), userID, nil)
@@ -270,17 +270,25 @@ func TestService_SendMessage_PersistsContextSnapshot(t *testing.T) {
 
 // TestService_SendMessage_NoProvider returns ErrNoProvider before opening
 // a stream — so the handler can map to a 503 rather than holding an SSE
-// connection open just to immediately close it.
+// connection open just to immediately close it. nil resolver and a
+// resolver that returns nil both map to ErrNoProvider.
 func TestService_SendMessage_NoProvider(t *testing.T) {
-	svc := ai.NewService(newStubThreadRepo(), newStubMessageRepo(), nil, nil)
-	if svc.ProviderConfigured() {
-		t.Fatal("ProviderConfigured returned true with nil provider")
-	}
-	thr, _ := svc.CreateThread(context.Background(), 1, nil)
-	_, err := svc.SendMessage(context.Background(), 1, thr.ID, "hi")
-	if !errors.Is(err, ai.ErrNoProvider) {
-		t.Fatalf("err = %v, want ErrNoProvider", err)
-	}
+	t.Run("nil resolver", func(t *testing.T) {
+		svc := ai.NewService(newStubThreadRepo(), newStubMessageRepo(), nil, nil)
+		thr, _ := svc.CreateThread(context.Background(), 1, nil)
+		_, err := svc.SendMessage(context.Background(), 1, thr.ID, "hi")
+		if !errors.Is(err, ai.ErrNoProvider) {
+			t.Fatalf("err = %v, want ErrNoProvider", err)
+		}
+	})
+	t.Run("resolver returns nil", func(t *testing.T) {
+		svc := ai.NewService(newStubThreadRepo(), newStubMessageRepo(), nil, ai.StaticResolver(nil))
+		thr, _ := svc.CreateThread(context.Background(), 1, nil)
+		_, err := svc.SendMessage(context.Background(), 1, thr.ID, "hi")
+		if !errors.Is(err, ai.ErrNoProvider) {
+			t.Fatalf("err = %v, want ErrNoProvider", err)
+		}
+	})
 }
 
 // TestService_SendMessage_EmptyContent rejects whitespace-only messages
@@ -289,7 +297,7 @@ func TestService_SendMessage_EmptyContent(t *testing.T) {
 	threads := newStubThreadRepo()
 	msgs := newStubMessageRepo()
 	prov := &stubProvider{deltas: []ai.Delta{{Done: true}}}
-	svc := ai.NewService(threads, msgs, nil, prov)
+	svc := ai.NewService(threads, msgs, nil, ai.StaticResolver(prov))
 
 	thr, _ := svc.CreateThread(context.Background(), 1, nil)
 	_, err := svc.SendMessage(context.Background(), 1, thr.ID, "   \t  ")
@@ -308,7 +316,7 @@ func TestService_CrossUserAccess(t *testing.T) {
 	threads := newStubThreadRepo()
 	msgs := newStubMessageRepo()
 	prov := &stubProvider{deltas: []ai.Delta{{Done: true}}}
-	svc := ai.NewService(threads, msgs, nil, prov)
+	svc := ai.NewService(threads, msgs, nil, ai.StaticResolver(prov))
 
 	const userA, userB int64 = 1, 2
 	aThr, _ := svc.CreateThread(context.Background(), userA, nil)
@@ -363,7 +371,7 @@ func TestService_SendMessage_ProviderError(t *testing.T) {
 			{Err: errors.New("upstream blew up")},
 		},
 	}
-	svc := ai.NewService(threads, msgs, nil, prov)
+	svc := ai.NewService(threads, msgs, nil, ai.StaticResolver(prov))
 
 	thr, _ := svc.CreateThread(context.Background(), 1, nil)
 	events, err := svc.SendMessage(context.Background(), 1, thr.ID, "hi")

--- a/backend/internal/service/user_settings_service.go
+++ b/backend/internal/service/user_settings_service.go
@@ -1,0 +1,209 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/gregwym/offbook/backend/internal/crypto"
+	"github.com/gregwym/offbook/backend/internal/model"
+	"github.com/gregwym/offbook/backend/internal/repository"
+)
+
+var (
+	ErrInvalidProvider = errors.New("preferred_provider must be 'claude' or 'ollama'")
+)
+
+// UserSettingsView is the redacted shape returned over the API. The
+// Claude key is NEVER returned to the client — only a boolean flag —
+// because exfiltrating a stored bearer key would defeat the encrypt-at-rest
+// guarantee.
+type UserSettingsView struct {
+	UserID            int64   `json:"user_id"`
+	ClaudeAPIKeySet   bool    `json:"claude_api_key_set"`
+	OllamaBaseURL     *string `json:"ollama_base_url,omitempty"`
+	PreferredProvider string  `json:"preferred_provider"`
+	PreferredModel    *string `json:"preferred_model,omitempty"`
+}
+
+// UpdateUserSettingsInput is a sparse patch — only set fields apply. The
+// two Clear* flags exist to disambiguate "leave alone" from "delete":
+// sending `claude_api_key=""` is rejected (empty keys are useless);
+// sending `clear_claude_api_key=true` removes the stored ciphertext.
+type UpdateUserSettingsInput struct {
+	ClaudeAPIKey      *string
+	ClearClaudeAPIKey bool
+	OllamaBaseURL     *string
+	ClearOllamaURL    bool
+	PreferredProvider *string
+	PreferredModel    *string
+	ClearModel        bool
+}
+
+// UserSettingsService owns user_settings CRUD + Claude-key encryption.
+// It is the ONLY service with access to the Claude SecretBox — handlers
+// and the AI service must go through here.
+type UserSettingsService struct {
+	repo repository.UserSettingsRepository
+	box  *crypto.SecretBox
+}
+
+// NewUserSettingsService wires the service. The SecretBox is constructed
+// once at boot from a SESSION_SECRET-derived key; see router.go for the
+// derivation.
+func NewUserSettingsService(repo repository.UserSettingsRepository, box *crypto.SecretBox) *UserSettingsService {
+	return &UserSettingsService{repo: repo, box: box}
+}
+
+// Get returns the redacted view for an existing row, or a default row
+// when the user has never saved settings. Auto-create-on-read keeps the
+// API surface idempotent: GET is safe even on fresh accounts.
+func (s *UserSettingsService) Get(ctx context.Context, userID int64) (*UserSettingsView, error) {
+	row, err := s.fetchOrDefault(ctx, userID)
+	if err != nil {
+		return nil, err
+	}
+	return view(row), nil
+}
+
+// GetClaudeAPIKey decrypts and returns the user's Claude key, or
+// (empty, nil) when no key is stored. This is the ONLY way callers get
+// access to the plaintext; the router-side provider resolver uses it.
+//
+// The handler MUST NOT call this — it would defeat the redact-on-read
+// guarantee. Enforced by code review since Go has no per-method visibility.
+func (s *UserSettingsService) GetClaudeAPIKey(ctx context.Context, userID int64) (string, error) {
+	row, err := s.fetchOrDefault(ctx, userID)
+	if err != nil {
+		return "", err
+	}
+	if len(row.ClaudeAPIKeyEnc) == 0 {
+		return "", nil
+	}
+	plain, err := s.box.Decrypt(row.ClaudeAPIKeyEnc)
+	if err != nil {
+		return "", fmt.Errorf("user_settings: decrypt claude key: %w", err)
+	}
+	return string(plain), nil
+}
+
+// Update applies the sparse patch and returns the redacted view.
+func (s *UserSettingsService) Update(ctx context.Context, userID int64, in UpdateUserSettingsInput) (*UserSettingsView, error) {
+	row, err := s.fetchOrDefault(ctx, userID)
+	if err != nil {
+		return nil, err
+	}
+
+	if in.ClearClaudeAPIKey {
+		row.ClaudeAPIKeyEnc = nil
+	} else if in.ClaudeAPIKey != nil {
+		key := strings.TrimSpace(*in.ClaudeAPIKey)
+		if key == "" {
+			return nil, errors.New("claude_api_key must not be empty (use clear_claude_api_key to delete)")
+		}
+		enc, err := s.box.Encrypt([]byte(key))
+		if err != nil {
+			return nil, fmt.Errorf("user_settings: encrypt claude key: %w", err)
+		}
+		row.ClaudeAPIKeyEnc = enc
+	}
+
+	if in.ClearOllamaURL {
+		row.OllamaBaseURL = nil
+	} else if in.OllamaBaseURL != nil {
+		v := strings.TrimSpace(*in.OllamaBaseURL)
+		if v == "" {
+			row.OllamaBaseURL = nil
+		} else {
+			row.OllamaBaseURL = &v
+		}
+	}
+
+	if in.PreferredProvider != nil {
+		p := strings.TrimSpace(*in.PreferredProvider)
+		if p != "claude" && p != "ollama" {
+			return nil, ErrInvalidProvider
+		}
+		row.PreferredProvider = p
+	}
+
+	if in.ClearModel {
+		row.PreferredModel = nil
+	} else if in.PreferredModel != nil {
+		m := strings.TrimSpace(*in.PreferredModel)
+		if m == "" {
+			row.PreferredModel = nil
+		} else {
+			row.PreferredModel = &m
+		}
+	}
+
+	if err := s.repo.Upsert(ctx, row); err != nil {
+		return nil, fmt.Errorf("user_settings: upsert: %w", err)
+	}
+	return view(row), nil
+}
+
+// Resolve is what the AI service / router uses to figure out which
+// provider this user wants. Returns the preferred provider, the model
+// override (or empty), and the decrypted claude key (or empty).
+//
+// Callers fall back to env defaults when ClaudeKey is empty AND
+// PreferredProvider == "claude" — keeps the local single-tenant deploy
+// model working without anyone visiting Settings.
+type ResolvedProvider struct {
+	Provider      string // "claude" | "ollama"
+	Model         string // "" → provider default
+	ClaudeKey     string // "" → env fallback applies
+	OllamaBaseURL string // "" → env fallback applies
+}
+
+func (s *UserSettingsService) Resolve(ctx context.Context, userID int64) (*ResolvedProvider, error) {
+	row, err := s.fetchOrDefault(ctx, userID)
+	if err != nil {
+		return nil, err
+	}
+	out := &ResolvedProvider{
+		Provider: row.PreferredProvider,
+	}
+	if row.PreferredModel != nil {
+		out.Model = *row.PreferredModel
+	}
+	if row.OllamaBaseURL != nil {
+		out.OllamaBaseURL = *row.OllamaBaseURL
+	}
+	if len(row.ClaudeAPIKeyEnc) > 0 {
+		plain, err := s.box.Decrypt(row.ClaudeAPIKeyEnc)
+		if err != nil {
+			return nil, fmt.Errorf("user_settings: decrypt claude key: %w", err)
+		}
+		out.ClaudeKey = string(plain)
+	}
+	return out, nil
+}
+
+func (s *UserSettingsService) fetchOrDefault(ctx context.Context, userID int64) (*model.UserSettings, error) {
+	row, err := s.repo.Get(ctx, userID)
+	if err == nil {
+		return row, nil
+	}
+	if !errors.Is(err, repository.ErrNotFound) {
+		return nil, fmt.Errorf("user_settings: get: %w", err)
+	}
+	row = &model.UserSettings{UserID: userID, PreferredProvider: "claude"}
+	if err := s.repo.Upsert(ctx, row); err != nil {
+		return nil, fmt.Errorf("user_settings: create: %w", err)
+	}
+	return row, nil
+}
+
+func view(s *model.UserSettings) *UserSettingsView {
+	return &UserSettingsView{
+		UserID:            s.UserID,
+		ClaudeAPIKeySet:   len(s.ClaudeAPIKeyEnc) > 0,
+		OllamaBaseURL:     s.OllamaBaseURL,
+		PreferredProvider: s.PreferredProvider,
+		PreferredModel:    s.PreferredModel,
+	}
+}

--- a/backend/internal/service/user_settings_service_test.go
+++ b/backend/internal/service/user_settings_service_test.go
@@ -1,0 +1,171 @@
+package service_test
+
+import (
+	"context"
+	"crypto/sha256"
+	"errors"
+	"testing"
+
+	"github.com/gregwym/offbook/backend/internal/crypto"
+	"github.com/gregwym/offbook/backend/internal/model"
+	"github.com/gregwym/offbook/backend/internal/repository"
+	"github.com/gregwym/offbook/backend/internal/service"
+)
+
+func newUserSettingsSvc(t *testing.T) (*service.UserSettingsService, int64) {
+	t.Helper()
+	g := openTestDB(t)
+	userID := seedTestUser(t, g)
+
+	sum := sha256.Sum256([]byte("test-session-secret"))
+	box, err := crypto.NewSecretBox(sum[:])
+	if err != nil {
+		t.Fatalf("NewSecretBox: %v", err)
+	}
+	svc := service.NewUserSettingsService(repository.NewUserSettingsRepository(g), box)
+
+	t.Cleanup(func() {
+		// SoftDelete on users cascades into user_settings via FK; the user
+		// cleanup registered by seedTestUser handles it. Belt-and-braces:
+		// hard-delete settings explicitly so re-runs are clean.
+		g.Unscoped().Where("user_id = ?", userID).Delete(&model.UserSettings{})
+	})
+	return svc, userID
+}
+
+// TestUserSettings_Get_Default returns a default row on first read.
+func TestUserSettings_Get_Default(t *testing.T) {
+	svc, userID := newUserSettingsSvc(t)
+	v, err := svc.Get(context.Background(), userID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if v.ClaudeAPIKeySet {
+		t.Errorf("ClaudeAPIKeySet = true on fresh user, want false")
+	}
+	if v.PreferredProvider != "claude" {
+		t.Errorf("PreferredProvider = %q, want 'claude'", v.PreferredProvider)
+	}
+}
+
+// TestUserSettings_Update_StoresAndHidesClaudeKey verifies the encrypt-at-
+// rest + redact-on-read contract: the plaintext is recoverable via
+// Resolve(), but Get() never returns the key — only ClaudeAPIKeySet=true.
+func TestUserSettings_Update_StoresAndHidesClaudeKey(t *testing.T) {
+	svc, userID := newUserSettingsSvc(t)
+	ctx := context.Background()
+
+	key := "sk-ant-test-12345"
+	v, err := svc.Update(ctx, userID, service.UpdateUserSettingsInput{
+		ClaudeAPIKey: &key,
+	})
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if !v.ClaudeAPIKeySet {
+		t.Errorf("ClaudeAPIKeySet = false after setting, want true")
+	}
+
+	// Resolve must be able to recover the plaintext (router-side provider
+	// resolver depends on it).
+	resolved, err := svc.Resolve(ctx, userID)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if resolved.ClaudeKey != key {
+		t.Errorf("Resolve.ClaudeKey = %q, want %q", resolved.ClaudeKey, key)
+	}
+}
+
+// TestUserSettings_Update_ClearClaudeKey removes the stored ciphertext.
+func TestUserSettings_Update_ClearClaudeKey(t *testing.T) {
+	svc, userID := newUserSettingsSvc(t)
+	ctx := context.Background()
+	k := "sk-test"
+	if _, err := svc.Update(ctx, userID, service.UpdateUserSettingsInput{ClaudeAPIKey: &k}); err != nil {
+		t.Fatalf("Update set: %v", err)
+	}
+	v, err := svc.Update(ctx, userID, service.UpdateUserSettingsInput{ClearClaudeAPIKey: true})
+	if err != nil {
+		t.Fatalf("Update clear: %v", err)
+	}
+	if v.ClaudeAPIKeySet {
+		t.Errorf("ClaudeAPIKeySet = true after clear, want false")
+	}
+	resolved, _ := svc.Resolve(ctx, userID)
+	if resolved.ClaudeKey != "" {
+		t.Errorf("Resolve.ClaudeKey = %q after clear, want empty", resolved.ClaudeKey)
+	}
+}
+
+// TestUserSettings_Update_EmptyKeyRejected — empty plaintext is a
+// user-error (probably a stripped paste); we reject rather than encrypting
+// an empty byte slice that would behave as "set but useless".
+func TestUserSettings_Update_EmptyKeyRejected(t *testing.T) {
+	svc, userID := newUserSettingsSvc(t)
+	empty := "   "
+	_, err := svc.Update(context.Background(), userID, service.UpdateUserSettingsInput{ClaudeAPIKey: &empty})
+	if err == nil {
+		t.Fatal("Update with empty key succeeded, want error")
+	}
+}
+
+// TestUserSettings_Update_PreferredProviderValidation rejects unknown
+// values so the AI service's switch statement doesn't fall through to a
+// silent default.
+func TestUserSettings_Update_PreferredProviderValidation(t *testing.T) {
+	svc, userID := newUserSettingsSvc(t)
+	bogus := "gpt-4"
+	_, err := svc.Update(context.Background(), userID, service.UpdateUserSettingsInput{PreferredProvider: &bogus})
+	if !errors.Is(err, service.ErrInvalidProvider) {
+		t.Fatalf("err = %v, want ErrInvalidProvider", err)
+	}
+}
+
+// TestUserSettings_Update_OllamaURL set + clear round-trip.
+func TestUserSettings_Update_OllamaURL(t *testing.T) {
+	svc, userID := newUserSettingsSvc(t)
+	ctx := context.Background()
+	url := "http://my-ollama:11434"
+	v, err := svc.Update(ctx, userID, service.UpdateUserSettingsInput{OllamaBaseURL: &url})
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if v.OllamaBaseURL == nil || *v.OllamaBaseURL != url {
+		t.Errorf("OllamaBaseURL = %v, want %q", v.OllamaBaseURL, url)
+	}
+	v2, err := svc.Update(ctx, userID, service.UpdateUserSettingsInput{ClearOllamaURL: true})
+	if err != nil {
+		t.Fatalf("Update clear: %v", err)
+	}
+	if v2.OllamaBaseURL != nil {
+		t.Errorf("OllamaBaseURL = %v after clear, want nil", v2.OllamaBaseURL)
+	}
+}
+
+// TestUserSettings_DifferentUsers — each user keeps separate settings.
+func TestUserSettings_DifferentUsers(t *testing.T) {
+	svc, userA := newUserSettingsSvc(t)
+	g := openTestDB(t)
+	userB := seedTestUser(t, g)
+	t.Cleanup(func() {
+		g.Unscoped().Where("user_id = ?", userB).Delete(&model.UserSettings{})
+	})
+
+	ctx := context.Background()
+	keyA := "sk-A"
+	if _, err := svc.Update(ctx, userA, service.UpdateUserSettingsInput{ClaudeAPIKey: &keyA}); err != nil {
+		t.Fatalf("Update A: %v", err)
+	}
+	vB, err := svc.Get(ctx, userB)
+	if err != nil {
+		t.Fatalf("Get B: %v", err)
+	}
+	if vB.ClaudeAPIKeySet {
+		t.Errorf("user B inherited user A's key flag")
+	}
+	resolvedB, _ := svc.Resolve(ctx, userB)
+	if resolvedB.ClaudeKey != "" {
+		t.Errorf("user B sees user A's key: %q", resolvedB.ClaudeKey)
+	}
+}

--- a/backend/migrations/000010_user_settings.down.sql
+++ b/backend/migrations/000010_user_settings.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS user_settings;

--- a/backend/migrations/000010_user_settings.up.sql
+++ b/backend/migrations/000010_user_settings.up.sql
@@ -1,0 +1,27 @@
+-- #131: per-user AI provider settings.
+--
+-- API keys are user-scoped (multiple users on the same instance keep
+-- separate keys). The Claude key is stored encrypted at rest using the
+-- existing crypto.SecretBox AES-256-GCM scheme — same primitive as
+-- Plaid access tokens (ADR-0010). The encryption key is derived from
+-- SESSION_SECRET via SHA-256 so there's no new operator-facing secret
+-- to manage.
+--
+-- One row per user. The router auto-creates a row on first /me/settings
+-- access, so handlers can assume the row exists for an authenticated
+-- session.
+CREATE TABLE user_settings (
+    user_id            BIGINT PRIMARY KEY REFERENCES users(id) ON DELETE CASCADE,
+    -- Encrypted ciphertext. NULL → user has not configured a key.
+    claude_api_key_enc BYTEA NULL,
+    -- Local Ollama daemon URL. NULL → falls back to OLLAMA_BASE_URL env.
+    ollama_base_url    TEXT NULL,
+    -- Which provider the AI service uses for this user's SendMessage.
+    -- 'claude' is the default since most users will start with a key.
+    preferred_provider TEXT NOT NULL DEFAULT 'claude' CHECK (preferred_provider IN ('claude', 'ollama')),
+    -- Optional model override. NULL → use provider default (claude-sonnet-4-6
+    -- or llama3:8b). Free-form because Ollama users can install anything.
+    preferred_model    TEXT NULL,
+    created_at         TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at         TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);

--- a/frontend/src/api/userSettings.ts
+++ b/frontend/src/api/userSettings.ts
@@ -1,0 +1,12 @@
+import { apiClient, type ApiItem } from './client'
+import type { UpdateUserSettingsInput, UserSettingsView } from '../types/userSettings'
+
+export async function getUserSettings(): Promise<UserSettingsView> {
+  const res = await apiClient.get<ApiItem<UserSettingsView>>('/me/settings')
+  return res.data.data
+}
+
+export async function updateUserSettings(input: UpdateUserSettingsInput): Promise<UserSettingsView> {
+  const res = await apiClient.patch<ApiItem<UserSettingsView>>('/me/settings', input)
+  return res.data.data
+}

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from 'react'
 import { Link } from 'react-router-dom'
-import { AlertTriangle, Landmark, Plug, Trash2, X } from 'lucide-react'
+import { AlertTriangle, Bot, Check, Landmark, Plug, Trash2, X } from 'lucide-react'
 import {
   disconnectItem,
   dismissSyncError,
@@ -8,17 +8,195 @@ import {
   listSyncErrors,
   retrySyncError,
 } from '../api/plaid'
+import { getUserSettings, updateUserSettings } from '../api/userSettings'
 import type { PlaidItem, PlaidSyncError } from '../types/plaid'
+import type { UpdateUserSettingsInput, UserSettingsView } from '../types/userSettings'
 
 export function SettingsPage() {
   return (
     <div className="space-y-8">
       <div>
         <h1 className="text-2xl font-semibold text-gray-900">Settings</h1>
-        <p className="mt-1 text-sm text-gray-500">Linked institutions and preferences.</p>
+        <p className="mt-1 text-sm text-gray-500">AI provider, linked institutions, and preferences.</p>
       </div>
+      <AISettingsSection />
       <LinkedInstitutionsSection />
     </div>
+  )
+}
+
+function AISettingsSection() {
+  const [settings, setSettings] = useState<UserSettingsView | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [keyDraft, setKeyDraft] = useState('')
+  const [ollamaDraft, setOllamaDraft] = useState('')
+  const [savedFlash, setSavedFlash] = useState(false)
+
+  const refresh = useCallback(() => {
+    return getUserSettings()
+      .then((v) => {
+        setSettings(v)
+        setOllamaDraft(v.ollama_base_url ?? '')
+        setError(null)
+      })
+      .catch((e: unknown) => setError(errMsg(e)))
+      .finally(() => setLoading(false))
+  }, [])
+
+  useEffect(() => {
+    // setState only fires inside then/catch/finally — effect body is sync-pure.
+    void refresh()
+  }, [refresh])
+
+  const save = async (patch: UpdateUserSettingsInput) => {
+    setSaving(true)
+    setError(null)
+    try {
+      const v = await updateUserSettings(patch)
+      setSettings(v)
+      setKeyDraft('')
+      setOllamaDraft(v.ollama_base_url ?? '')
+      setSavedFlash(true)
+      window.setTimeout(() => setSavedFlash(false), 1500)
+    } catch (e) {
+      setError(errMsg(e))
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  if (loading || !settings) {
+    return (
+      <section className="rounded-lg border border-gray-200 bg-white px-5 py-6 text-sm text-gray-400">
+        Loading AI settings…
+      </section>
+    )
+  }
+
+  return (
+    <section className="rounded-lg border border-gray-200 bg-white">
+      <div className="flex items-center justify-between border-b border-gray-200 px-5 py-3">
+        <div className="flex items-center gap-2">
+          <Bot size={16} className="text-gray-500" />
+          <h2 className="text-base font-medium text-gray-900">AI Advisor</h2>
+        </div>
+        {savedFlash && (
+          <span className="inline-flex items-center gap-1 text-xs text-emerald-700">
+            <Check size={14} /> Saved
+          </span>
+        )}
+      </div>
+
+      {error && (
+        <div className="mx-5 mt-3 rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
+          {error}
+        </div>
+      )}
+
+      <div className="space-y-5 px-5 py-4">
+        {/* Provider radio */}
+        <div>
+          <label className="block text-sm font-medium text-gray-800 mb-1">Preferred provider</label>
+          <div className="flex gap-3 text-sm">
+            {(['claude', 'ollama'] as const).map((p) => (
+              <label key={p} className="inline-flex items-center gap-2 cursor-pointer">
+                <input
+                  type="radio"
+                  name="provider"
+                  value={p}
+                  checked={settings.preferred_provider === p}
+                  onChange={() => void save({ preferred_provider: p })}
+                  disabled={saving}
+                />
+                <span className="text-gray-700">{p === 'claude' ? 'Claude (cloud)' : 'Ollama (local)'}</span>
+              </label>
+            ))}
+          </div>
+          <p className="text-xs text-gray-500 mt-1">
+            Claude streams from Anthropic and needs a key. Ollama runs locally — no key, no data leaves
+            your machine.
+          </p>
+        </div>
+
+        {/* Claude key */}
+        <div>
+          <label className="block text-sm font-medium text-gray-800 mb-1">Claude API key</label>
+          <div className="flex items-center gap-2">
+            <input
+              type="password"
+              placeholder={settings.claude_api_key_set ? '••••••••  (key set)' : 'sk-ant-…'}
+              value={keyDraft}
+              onChange={(e) => setKeyDraft(e.target.value)}
+              className="flex-1 rounded-md border border-gray-300 px-3 py-1.5 text-sm focus:border-indigo-500 focus:outline-none"
+            />
+            <button
+              type="button"
+              onClick={() => void save({ claude_api_key: keyDraft })}
+              disabled={!keyDraft.trim() || saving}
+              className="rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-indigo-700 disabled:opacity-40"
+            >
+              Save key
+            </button>
+            {settings.claude_api_key_set && (
+              <button
+                type="button"
+                onClick={() => {
+                  if (window.confirm('Remove the stored Claude key?')) {
+                    void save({ clear_claude_api_key: true })
+                  }
+                }}
+                disabled={saving}
+                className="inline-flex items-center gap-1 rounded-md border border-gray-300 px-2.5 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50"
+              >
+                <Trash2 size={14} /> Remove
+              </button>
+            )}
+          </div>
+          <p className="text-xs text-gray-500 mt-1">
+            Stored encrypted at rest. The key is never displayed again after you save it — only a
+            "set" indicator. Find your key at{' '}
+            <span className="font-mono">console.anthropic.com</span>.
+          </p>
+        </div>
+
+        {/* Ollama URL */}
+        <div>
+          <label className="block text-sm font-medium text-gray-800 mb-1">Ollama base URL</label>
+          <div className="flex items-center gap-2">
+            <input
+              type="text"
+              placeholder="http://localhost:11434"
+              value={ollamaDraft}
+              onChange={(e) => setOllamaDraft(e.target.value)}
+              className="flex-1 rounded-md border border-gray-300 px-3 py-1.5 text-sm focus:border-indigo-500 focus:outline-none"
+            />
+            <button
+              type="button"
+              onClick={() => void save({ ollama_base_url: ollamaDraft })}
+              disabled={saving || ollamaDraft === (settings.ollama_base_url ?? '')}
+              className="rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-indigo-700 disabled:opacity-40"
+            >
+              Save URL
+            </button>
+            {settings.ollama_base_url && (
+              <button
+                type="button"
+                onClick={() => void save({ clear_ollama_url: true })}
+                disabled={saving}
+                className="inline-flex items-center gap-1 rounded-md border border-gray-300 px-2.5 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50"
+              >
+                <Trash2 size={14} /> Clear
+              </button>
+            )}
+          </div>
+          <p className="text-xs text-gray-500 mt-1">
+            Leave blank to use the server default (<span className="font-mono">http://localhost:11434</span>).
+          </p>
+        </div>
+      </div>
+    </section>
   )
 }
 

--- a/frontend/src/types/userSettings.ts
+++ b/frontend/src/types/userSettings.ts
@@ -1,0 +1,21 @@
+// Mirror of backend service.UserSettingsView. The Claude API key is
+// never sent over the wire — only a boolean flag — so the type cannot
+// accidentally surface it in the UI.
+
+export type UserSettingsView = {
+  user_id: number
+  claude_api_key_set: boolean
+  ollama_base_url?: string | null
+  preferred_provider: 'claude' | 'ollama'
+  preferred_model?: string | null
+}
+
+export type UpdateUserSettingsInput = {
+  claude_api_key?: string
+  clear_claude_api_key?: boolean
+  ollama_base_url?: string
+  clear_ollama_url?: boolean
+  preferred_provider?: 'claude' | 'ollama'
+  preferred_model?: string
+  clear_preferred_model?: boolean
+}


### PR DESCRIPTION
## Summary
**Backend**
- Migration `000010_user_settings` — one row per user, FK cascades on user delete. Columns: `claude_api_key_enc BYTEA`, `ollama_base_url`, `preferred_provider` (claude|ollama, CHECK-constrained), `preferred_model`.
- `internal/crypto.SecretBox` reuse for the Claude key. Encryption key is derived from `SESSION_SECRET` via SHA-256 — no new operator secret.
- `service.UserSettingsService`: redact-on-read (`Get` returns `claude_api_key_set: bool`, never the plaintext), `Update` accepts a sparse patch with explicit `clear_*` flags, `Resolve` decrypts for the router-side provider resolver.
- `ai.ProviderResolver` interface + `StaticResolver` helper for tests. `ai.Service` constructor now takes a resolver; existing tests updated.
- Router wires an `aiProviderResolver` that reads per-user settings and falls back to env-configured Claude when nothing is set — single-tenant local deploy keeps working without anyone visiting Settings.
- `GET/PATCH /api/v1/me/settings`.

**Frontend**
- `Settings` page gains an AI section above Linked Institutions: preferred-provider radio, masked Claude key input with "set" indicator and Remove button, Ollama base URL input with Clear button, "Saved" flash.
- `src/api/userSettings.ts`, `src/types/userSettings.ts`.

## Test plan
- [x] Migration up/down clean against the local Postgres
- [x] `go test -race -p 1 ./...` — full backend green; new `user_settings_service` integration tests cover: default-row-on-first-read, encrypted-at-rest round trip via `Resolve`, clear key, empty-key rejection, provider validation, Ollama URL set/clear, per-user isolation (user B never sees user A's key)
- [x] `pnpm lint && pnpm build` — frontend clean
- [ ] CI

Closes #131