### PR TITLE
feat(auth): setup-admin / signin / signup pages + auth guard (#139)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,8 @@
-import { Navigate, Route, Routes } from 'react-router-dom'
+import { useEffect } from 'react'
+import { Navigate, Outlet, Route, Routes, useNavigate } from 'react-router-dom'
 import { AppShell } from './components/AppShell'
+import { setUnauthorizedHandler } from './api/client'
+import { useAuthStore } from './store/authStore'
 import { AccountsPage } from './pages/AccountsPage'
 import { AIPage } from './pages/AIPage'
 import { BudgetsPage } from './pages/BudgetsPage'
@@ -16,32 +19,81 @@ import { PlaidConnectPage } from './pages/PlaidConnectPage'
 import { RulesPage } from './pages/RulesPage'
 import { SavingsGoalsPage } from './pages/SavingsGoalsPage'
 import { SettingsPage } from './pages/SettingsPage'
+import { SetupAdminPage } from './pages/SetupAdminPage'
+import { SigninPage } from './pages/SigninPage'
+import { SignupPage } from './pages/SignupPage'
 import { TransactionsPage } from './pages/TransactionsPage'
 
 export default function App() {
+  const { hydrated, hydrate, signout } = useAuthStore()
+  const navigate = useNavigate()
+
+  // Register the global 401 handler once. When any authenticated API call
+  // returns 401, drop the in-memory user and bounce to /signin — covers
+  // the "session expired in another tab" case without a page reload.
+  useEffect(() => {
+    setUnauthorizedHandler(() => {
+      void signout()
+      navigate('/signin', { replace: true })
+    })
+  }, [navigate, signout])
+
+  useEffect(() => {
+    if (!hydrated) void hydrate()
+  }, [hydrated, hydrate])
+
   return (
     <Routes>
-      <Route element={<AppShell />}>
-        <Route index element={<Navigate to="/dashboard" replace />} />
-        <Route path="/dashboard" element={<DashboardPage />} />
-        <Route path="/accounts" element={<AccountsPage />} />
-        <Route path="/connect" element={<PlaidConnectPage />} />
-        <Route path="/transactions" element={<TransactionsPage />} />
-        <Route path="/rules" element={<RulesPage />} />
-        <Route path="/budgets" element={<BudgetsPage />} />
-        <Route path="/savings-goals" element={<SavingsGoalsPage />} />
-        <Route path="/investments" element={<InvestmentsPage />} />
-        <Route path="/import" element={<ImportPage />} />
-        <Route path="/ai" element={<AIPage />} />
-        <Route path="/settings" element={<SettingsPage />} />
+      {/* Unauthenticated routes — no AppShell, no auth required. */}
+      <Route path="/setup/admin" element={<SetupAdminPage />} />
+      <Route path="/signin" element={<SigninPage />} />
+      <Route path="/signup" element={<SignupPage />} />
 
-        <Route path="/h/dashboard" element={<HouseholdDashboardPage />} />
-        <Route path="/h/budgets"   element={<HouseholdBudgetsPage />} />
-        <Route path="/h/goals"     element={<HouseholdGoalsPage />} />
-        <Route path="/h/members"   element={<HouseholdMembersPage />} />
-        <Route path="/h/ai"        element={<HouseholdAIPage />} />
-        <Route path="/h/settings"  element={<HouseholdSettingsPage />} />
+      {/* Authenticated routes — RequireAuth wraps the AppShell. */}
+      <Route element={<RequireAuth />}>
+        <Route element={<AppShell />}>
+          <Route index element={<Navigate to="/dashboard" replace />} />
+          <Route path="/dashboard" element={<DashboardPage />} />
+          <Route path="/accounts" element={<AccountsPage />} />
+          <Route path="/connect" element={<PlaidConnectPage />} />
+          <Route path="/transactions" element={<TransactionsPage />} />
+          <Route path="/rules" element={<RulesPage />} />
+          <Route path="/budgets" element={<BudgetsPage />} />
+          <Route path="/savings-goals" element={<SavingsGoalsPage />} />
+          <Route path="/investments" element={<InvestmentsPage />} />
+          <Route path="/import" element={<ImportPage />} />
+          <Route path="/ai" element={<AIPage />} />
+          <Route path="/settings" element={<SettingsPage />} />
+
+          <Route path="/h/dashboard" element={<HouseholdDashboardPage />} />
+          <Route path="/h/budgets"   element={<HouseholdBudgetsPage />} />
+          <Route path="/h/goals"     element={<HouseholdGoalsPage />} />
+          <Route path="/h/members"   element={<HouseholdMembersPage />} />
+          <Route path="/h/ai"        element={<HouseholdAIPage />} />
+          <Route path="/h/settings"  element={<HouseholdSettingsPage />} />
+        </Route>
       </Route>
     </Routes>
   )
+}
+
+// RequireAuth gates everything under the AppShell. Three states:
+//   - not hydrated → render nothing (avoids an auth flicker)
+//   - bootstrapped=false → redirect to /setup/admin
+//   - no user → redirect to /signin
+//   - user present → render the protected tree via <Outlet/> (AppShell wraps it)
+function RequireAuth() {
+  const { hydrated, setup, user } = useAuthStore()
+
+  if (!hydrated) {
+    return (
+      <div className="flex h-screen w-screen items-center justify-center bg-gray-50 text-sm text-gray-400">
+        Loading…
+      </div>
+    )
+  }
+  if (setup && !setup.bootstrapped) return <Navigate to="/setup/admin" replace />
+  if (!user) return <Navigate to="/signin" replace />
+  // <Outlet/> renders the nested AppShell + child route.
+  return <Outlet />
 }

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -1,0 +1,35 @@
+import { apiClient, type ApiItem } from './client'
+import type { AuthUser, CurrentUser, SetupStatus, SignupMode } from '../types/auth'
+
+export async function getSetupStatus(): Promise<SetupStatus> {
+  const res = await apiClient.get<ApiItem<SetupStatus>>('/setup/status')
+  return res.data.data
+}
+
+export async function setupAdmin(input: {
+  email: string
+  password: string
+  signup_mode: SignupMode
+}): Promise<AuthUser> {
+  const res = await apiClient.post<ApiItem<AuthUser>>('/setup/admin', input)
+  return res.data.data
+}
+
+export async function signin(email: string, password: string): Promise<AuthUser> {
+  const res = await apiClient.post<ApiItem<AuthUser>>('/auth/signin', { email, password })
+  return res.data.data
+}
+
+export async function signup(email: string, password: string): Promise<AuthUser> {
+  const res = await apiClient.post<ApiItem<AuthUser>>('/auth/signup', { email, password })
+  return res.data.data
+}
+
+export async function signout(): Promise<void> {
+  await apiClient.post('/auth/signout')
+}
+
+export async function getMe(): Promise<CurrentUser> {
+  const res = await apiClient.get<ApiItem<CurrentUser>>('/me')
+  return res.data.data
+}

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -13,6 +13,35 @@ export const apiClient = axios.create({
   withCredentials: true,
 })
 
+// onUnauthorized is called when any API request returns 401. The auth
+// store registers a handler at boot to clear the user + redirect to
+// /signin. Module-level rather than a direct store import to avoid the
+// circular dep (client → store → api/auth → client).
+let onUnauthorized: (() => void) | null = null
+export function setUnauthorizedHandler(fn: () => void) {
+  onUnauthorized = fn
+}
+
+apiClient.interceptors.response.use(
+  (res) => res,
+  (err) => {
+    const url: string = err?.config?.url ?? ''
+    const status: number | undefined = err?.response?.status
+    if (
+      status === 401 &&
+      // Auth-probe and signin endpoints expect 401s — handling them here
+      // would loop the user back to signin from inside signin.
+      !url.includes('/auth/signin') &&
+      !url.includes('/auth/signup') &&
+      !url.includes('/setup/') &&
+      !url.includes('/me') // hydrate() probes /me and handles 401 itself
+    ) {
+      onUnauthorized?.()
+    }
+    return Promise.reject(err)
+  },
+)
+
 // Standard backend envelope shapes (mirror backend handler conventions).
 export type ApiList<T> = { data: T[]; total: number }
 export type ApiItem<T> = { data: T }

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -3,6 +3,7 @@ import {
   Bot,
   Landmark,
   LayoutDashboard,
+  LogOut,
   PiggyBank,
   Receipt,
   Settings,
@@ -13,7 +14,8 @@ import {
   Wallet,
 } from 'lucide-react'
 import { useEffect } from 'react'
-import { NavLink, Outlet } from 'react-router-dom'
+import { NavLink, Outlet, useNavigate } from 'react-router-dom'
+import { useAuthStore } from '../store/authStore'
 import { useScopeStore } from '../store/scopeStore'
 import { SCOPE_HOUSEHOLD, SCOPE_PERSONAL, type Scope } from '../types/scope'
 
@@ -48,6 +50,8 @@ const HOUSEHOLD_NAV: NavItem[] = [
 
 export function AppShell() {
   const { active, available, hydrated, hydrate, setScope } = useScopeStore()
+  const signout = useAuthStore((s) => s.signout)
+  const navigate = useNavigate()
 
   useEffect(() => {
     if (!hydrated) {
@@ -58,12 +62,17 @@ export function AppShell() {
   const items = active === SCOPE_HOUSEHOLD ? HOUSEHOLD_NAV : PERSONAL_NAV
   const canSwitch = available.includes(SCOPE_HOUSEHOLD)
 
+  const handleSignout = async () => {
+    await signout()
+    navigate('/signin', { replace: true })
+  }
+
   return (
     <div className="flex h-screen w-screen bg-gray-50">
       <aside className="flex w-60 flex-col border-r border-gray-200 bg-white">
         <div className="px-6 py-5 text-lg font-semibold text-gray-900">offbook</div>
         {canSwitch && <ScopePicker active={active} onChange={setScope} />}
-        <nav className="flex-1 space-y-1 px-3 pb-4">
+        <nav className="flex-1 space-y-1 px-3 pb-4 overflow-y-auto">
           {items.map(({ to, label, icon: Icon }) => (
             <NavLink
               key={to}
@@ -82,6 +91,16 @@ export function AppShell() {
             </NavLink>
           ))}
         </nav>
+        <div className="border-t border-gray-200 p-3">
+          <button
+            type="button"
+            onClick={() => void handleSignout()}
+            className="flex w-full items-center gap-2 rounded-md px-3 py-2 text-sm font-medium text-gray-600 hover:bg-gray-100 hover:text-gray-900"
+          >
+            <LogOut size={16} />
+            Sign out
+          </button>
+        </div>
       </aside>
       <main className="flex-1 overflow-auto">
         <div className="mx-auto max-w-6xl px-8 py-8">

--- a/frontend/src/pages/SetupAdminPage.tsx
+++ b/frontend/src/pages/SetupAdminPage.tsx
@@ -1,0 +1,142 @@
+import { useState } from 'react'
+import { Navigate } from 'react-router-dom'
+import { Sparkles } from 'lucide-react'
+import { useAuthStore } from '../store/authStore'
+import type { SignupMode } from '../types/auth'
+
+export function SetupAdminPage() {
+  const { setup, hydrated, user, setupAdmin, error, clearError } = useAuthStore()
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [mode, setMode] = useState<SignupMode>('invite_only')
+  const [submitting, setSubmitting] = useState(false)
+
+  // Once setup-status reports bootstrapped, this page is no longer reachable.
+  if (hydrated && setup?.bootstrapped) {
+    return <Navigate to={user ? '/dashboard' : '/signin'} replace />
+  }
+
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    clearError()
+    setSubmitting(true)
+    try {
+      await setupAdmin(email, password, mode)
+      // hydrate-fired Navigate above will move us to /dashboard.
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <AuthShell>
+      <h1 className="text-xl font-semibold text-gray-900 flex items-center gap-2">
+        <Sparkles size={18} className="text-indigo-600" />
+        Welcome to Offbook
+      </h1>
+      <p className="mt-2 text-sm text-gray-600">
+        This instance hasn't been set up yet. Create the admin account and pick how new users
+        can sign up. You can change the signup mode later.
+      </p>
+
+      <form onSubmit={submit} className="mt-6 space-y-4">
+        <Field label="Admin email">
+          <input
+            type="email"
+            required
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-indigo-500 focus:outline-none"
+            autoFocus
+          />
+        </Field>
+        <Field label="Password (min 8 characters)">
+          <input
+            type="password"
+            required
+            minLength={8}
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-indigo-500 focus:outline-none"
+          />
+        </Field>
+        <Field label="Signup mode">
+          <div className="space-y-2 text-sm">
+            <ModeOption
+              checked={mode === 'invite_only'}
+              onChange={() => setMode('invite_only')}
+              label="Invite-only (recommended)"
+              description="Only the admin can mint invite tokens. Other users sign up by accepting an invite."
+            />
+            <ModeOption
+              checked={mode === 'local_multi_tenant'}
+              onChange={() => setMode('local_multi_tenant')}
+              label="Local multi-tenant"
+              description="Anyone who can reach the instance can create an account. Use only on trusted networks."
+            />
+          </div>
+        </Field>
+
+        {error && (
+          <div className="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
+            {error}
+          </div>
+        )}
+
+        <button
+          type="submit"
+          disabled={submitting || !email || !password}
+          className="w-full rounded-md bg-indigo-600 px-3 py-2 text-sm font-medium text-white hover:bg-indigo-700 disabled:opacity-40"
+        >
+          {submitting ? 'Creating admin…' : 'Create admin account'}
+        </button>
+      </form>
+    </AuthShell>
+  )
+}
+
+export function AuthShell({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-gray-50 px-4 py-12">
+      <div className="w-full max-w-md rounded-lg border border-gray-200 bg-white p-8 shadow-sm">
+        {children}
+      </div>
+    </div>
+  )
+}
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <label className="block">
+      <div className="text-sm font-medium text-gray-700 mb-1">{label}</div>
+      {children}
+    </label>
+  )
+}
+
+function ModeOption({
+  checked,
+  onChange,
+  label,
+  description,
+}: {
+  checked: boolean
+  onChange: () => void
+  label: string
+  description: string
+}) {
+  return (
+    <label
+      className={[
+        'flex cursor-pointer items-start gap-2 rounded-md border p-3',
+        checked ? 'border-indigo-500 bg-indigo-50' : 'border-gray-200 hover:bg-gray-50',
+      ].join(' ')}
+    >
+      <input type="radio" checked={checked} onChange={onChange} className="mt-0.5" />
+      <div>
+        <div className="font-medium text-gray-900">{label}</div>
+        <div className="text-xs text-gray-500">{description}</div>
+      </div>
+    </label>
+  )
+}

--- a/frontend/src/pages/SigninPage.tsx
+++ b/frontend/src/pages/SigninPage.tsx
@@ -1,0 +1,90 @@
+import { useState } from 'react'
+import { Link, Navigate } from 'react-router-dom'
+import { useAuthStore } from '../store/authStore'
+import { AuthShell } from './SetupAdminPage'
+
+export function SigninPage() {
+  const { setup, hydrated, user, signin, error, clearError } = useAuthStore()
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+
+  // Auth-state-driven redirects: not bootstrapped → setup, already signed-in → dashboard.
+  if (hydrated && setup && !setup.bootstrapped) {
+    return <Navigate to="/setup/admin" replace />
+  }
+  if (user) {
+    return <Navigate to="/dashboard" replace />
+  }
+
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    clearError()
+    setSubmitting(true)
+    try {
+      await signin(email, password)
+    } catch {
+      // error surfaces via store; nothing to do.
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  const canSignup = setup?.signup_mode === 'local_multi_tenant'
+
+  return (
+    <AuthShell>
+      <h1 className="text-xl font-semibold text-gray-900">Sign in to Offbook</h1>
+      <p className="mt-1 text-sm text-gray-500">Your data stays on this instance.</p>
+
+      <form onSubmit={submit} className="mt-6 space-y-4">
+        <label className="block">
+          <div className="text-sm font-medium text-gray-700 mb-1">Email</div>
+          <input
+            type="email"
+            required
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            autoFocus
+            className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-indigo-500 focus:outline-none"
+          />
+        </label>
+        <label className="block">
+          <div className="text-sm font-medium text-gray-700 mb-1">Password</div>
+          <input
+            type="password"
+            required
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-indigo-500 focus:outline-none"
+          />
+        </label>
+
+        {error && (
+          <div className="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
+            {error}
+          </div>
+        )}
+
+        <button
+          type="submit"
+          disabled={submitting || !email || !password}
+          className="w-full rounded-md bg-indigo-600 px-3 py-2 text-sm font-medium text-white hover:bg-indigo-700 disabled:opacity-40"
+        >
+          {submitting ? 'Signing in…' : 'Sign in'}
+        </button>
+      </form>
+
+      <div className="mt-4 text-center text-xs text-gray-500">
+        {canSignup ? (
+          <>
+            Don't have an account?{' '}
+            <Link to="/signup" className="text-indigo-600 hover:text-indigo-700">Sign up</Link>
+          </>
+        ) : (
+          'Signups are invite-only on this instance.'
+        )}
+      </div>
+    </AuthShell>
+  )
+}

--- a/frontend/src/pages/SignupPage.tsx
+++ b/frontend/src/pages/SignupPage.tsx
@@ -1,0 +1,111 @@
+import { useState } from 'react'
+import { Link, Navigate } from 'react-router-dom'
+import { Lock } from 'lucide-react'
+import { useAuthStore } from '../store/authStore'
+import { AuthShell } from './SetupAdminPage'
+
+export function SignupPage() {
+  const { setup, hydrated, user, signup, error, clearError } = useAuthStore()
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+
+  if (hydrated && setup && !setup.bootstrapped) {
+    return <Navigate to="/setup/admin" replace />
+  }
+  if (user) {
+    return <Navigate to="/dashboard" replace />
+  }
+
+  // invite_only mode: signup endpoint is closed for new users. Backend
+  // support for signup-with-invite is tracked in #145. Until then, show
+  // a friendly "ask your admin" page.
+  if (hydrated && setup?.signup_mode === 'invite_only') {
+    return (
+      <AuthShell>
+        <h1 className="text-xl font-semibold text-gray-900 flex items-center gap-2">
+          <Lock size={18} className="text-gray-500" />
+          Signups are invite-only
+        </h1>
+        <p className="mt-2 text-sm text-gray-600">
+          This instance only lets admins add new users. Ask your admin to send you an invite, then
+          sign in with the credentials they share.
+        </p>
+        <div className="mt-6">
+          <Link
+            to="/signin"
+            className="inline-flex items-center justify-center w-full rounded-md bg-indigo-600 px-3 py-2 text-sm font-medium text-white hover:bg-indigo-700"
+          >
+            Back to sign in
+          </Link>
+        </div>
+      </AuthShell>
+    )
+  }
+
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    clearError()
+    setSubmitting(true)
+    try {
+      await signup(email, password)
+    } catch {
+      // error surfaces via store.
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <AuthShell>
+      <h1 className="text-xl font-semibold text-gray-900">Create your account</h1>
+      <p className="mt-1 text-sm text-gray-500">
+        Each user gets their own private book. Households are joined by invite later.
+      </p>
+
+      <form onSubmit={submit} className="mt-6 space-y-4">
+        <label className="block">
+          <div className="text-sm font-medium text-gray-700 mb-1">Email</div>
+          <input
+            type="email"
+            required
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            autoFocus
+            className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-indigo-500 focus:outline-none"
+          />
+        </label>
+        <label className="block">
+          <div className="text-sm font-medium text-gray-700 mb-1">Password (min 8 characters)</div>
+          <input
+            type="password"
+            required
+            minLength={8}
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-indigo-500 focus:outline-none"
+          />
+        </label>
+
+        {error && (
+          <div className="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
+            {error}
+          </div>
+        )}
+
+        <button
+          type="submit"
+          disabled={submitting || !email || !password}
+          className="w-full rounded-md bg-indigo-600 px-3 py-2 text-sm font-medium text-white hover:bg-indigo-700 disabled:opacity-40"
+        >
+          {submitting ? 'Creating account…' : 'Sign up'}
+        </button>
+      </form>
+
+      <div className="mt-4 text-center text-xs text-gray-500">
+        Already have an account?{' '}
+        <Link to="/signin" className="text-indigo-600 hover:text-indigo-700">Sign in</Link>
+      </div>
+    </AuthShell>
+  )
+}

--- a/frontend/src/store/authStore.ts
+++ b/frontend/src/store/authStore.ts
@@ -1,0 +1,129 @@
+import { create } from 'zustand'
+import {
+  getMe,
+  getSetupStatus,
+  setupAdmin as apiSetupAdmin,
+  signin as apiSignin,
+  signout as apiSignout,
+  signup as apiSignup,
+} from '../api/auth'
+import type { AuthUser, SetupStatus, SignupMode } from '../types/auth'
+
+// AuthState is the canonical "who am I, can I sign in here" client store.
+// AppShell consults it before rendering protected routes; the auth pages
+// consume it to trigger the actual signin/signup/setup calls.
+type AuthState = {
+  // Setup probe — null until hydrated; afterward the shape from the backend.
+  setup: SetupStatus | null
+  // Current user — null when unauthenticated. Distinct from setup so we can
+  // render `/setup/admin` when bootstrapped=false even without a session.
+  user: AuthUser | null
+  // hydrated flips true on the first round-trip so the app can stop
+  // showing "Loading…" the moment we know the auth state.
+  hydrated: boolean
+  error: string | null
+
+  hydrate: () => Promise<void>
+  setupAdmin: (email: string, password: string, mode: SignupMode) => Promise<void>
+  signin: (email: string, password: string) => Promise<void>
+  signup: (email: string, password: string) => Promise<void>
+  signout: () => Promise<void>
+  clearError: () => void
+}
+
+export const useAuthStore = create<AuthState>((set) => ({
+  setup: null,
+  user: null,
+  hydrated: false,
+  error: null,
+
+  hydrate: async () => {
+    // Resolve setup status first so we can decide where to send the user
+    // when /me is also unauthenticated. Both probes are unauthenticated
+    // (setup) or 401-tolerant (me).
+    let status: SetupStatus
+    try {
+      status = await getSetupStatus()
+    } catch (err) {
+      // /setup/status failing means the server's unreachable. The auth
+      // pages render a friendly "server unavailable" state via `error`.
+      set({
+        setup: null,
+        user: null,
+        hydrated: true,
+        error: err instanceof Error ? err.message : 'auth probe failed',
+      })
+      return
+    }
+
+    let user: AuthUser | null = null
+    if (status.bootstrapped) {
+      try {
+        const me = await getMe()
+        user = { id: me.id }
+      } catch {
+        // 401 / 403 — unauthenticated. Not an error condition, just means
+        // we need the user to sign in.
+        user = null
+      }
+    }
+
+    set({ setup: status, user, hydrated: true, error: null })
+  },
+
+  setupAdmin: async (email, password, mode) => {
+    set({ error: null })
+    try {
+      const u = await apiSetupAdmin({ email, password, signup_mode: mode })
+      set({
+        user: u,
+        setup: { bootstrapped: true, signup_mode: mode },
+      })
+    } catch (err) {
+      set({ error: errMsg(err) })
+      throw err
+    }
+  },
+
+  signin: async (email, password) => {
+    set({ error: null })
+    try {
+      const u = await apiSignin(email, password)
+      set({ user: u })
+    } catch (err) {
+      set({ error: errMsg(err) })
+      throw err
+    }
+  },
+
+  signup: async (email, password) => {
+    set({ error: null })
+    try {
+      const u = await apiSignup(email, password)
+      set({ user: u })
+    } catch (err) {
+      set({ error: errMsg(err) })
+      throw err
+    }
+  },
+
+  signout: async () => {
+    try {
+      await apiSignout()
+    } catch {
+      // Best-effort — server might already have deleted the session.
+    }
+    set({ user: null })
+  },
+
+  clearError: () => set({ error: null }),
+}))
+
+function errMsg(err: unknown): string {
+  if (err && typeof err === 'object' && 'response' in err) {
+    const r = (err as { response?: { data?: { error?: string } } }).response
+    if (r?.data?.error) return r.data.error
+  }
+  if (err instanceof Error) return err.message
+  return 'request failed'
+}

--- a/frontend/src/types/auth.ts
+++ b/frontend/src/types/auth.ts
@@ -1,0 +1,22 @@
+// Mirror of backend auth response shapes. See backend/internal/handler/auth_handler.go.
+
+export type SignupMode = 'invite_only' | 'local_multi_tenant'
+
+export type SetupStatus = {
+  bootstrapped: boolean
+  signup_mode: SignupMode | null
+}
+
+export type AuthUser = {
+  id: number
+  email?: string
+  is_admin?: boolean
+}
+
+// CurrentUser is what `GET /me` returns. The backend currently returns
+// `{id, user_id}` — both alias the session user. Extend as backend
+// surfaces more.
+export type CurrentUser = {
+  id: number
+  user_id: number
+}


### PR DESCRIPTION
## Summary
Replaces the curl-only auth surface with real UI plus an app-level auth guard.

- `src/api/auth.ts` + `src/types/auth.ts` — typed client for `/setup/status`, `/setup/admin`, `/auth/signup`, `/auth/signin`, `/auth/signout`, `/me`.
- `src/store/authStore.ts` — single hydrate that resolves setup-status first, then `/me` (401-tolerant) to decide who you are.
- Pages: `SetupAdminPage.tsx` (email + password + invite-only/local-multi-tenant picker), `SigninPage.tsx`, `SignupPage.tsx`. Signup in `invite_only` mode shows a friendly "ask your admin" page — backend signup-with-invite is tracked in #145.
- `App.tsx` adds `<RequireAuth/>` layout: unhydrated → "Loading…", `bootstrapped=false` → redirect to `/setup/admin`, no user → redirect to `/signin`, else render the AppShell + protected route.
- `api/client.ts` adds a 401 interceptor that runs a registered handler (App wires it to `signout()` + navigate-to-`/signin`) so a session-expired-in-another-tab case bounces the user gracefully instead of leaving them on a 500-banner page.
- `AppShell` gains a Sign out button in the footer.

## Test plan
- [x] `pnpm lint` — clean
- [x] `pnpm build` — type-checks and bundles
- [ ] Manual: fresh DB → `/setup/admin` form appears, submitting creates admin + lands on `/dashboard`
- [ ] Manual: subsequent visits → `/signin`; `/signup` form when mode is `local_multi_tenant`, "invite-only" message otherwise
- [ ] Manual: sign out from the sidebar → lands on `/signin`; protected URLs redirect there too
- [ ] Manual: kill the session in another tab → next API call bounces to `/signin`

Closes #139