### PR TITLE
feat(accounts): household visibility chip column (#142)

### DIFF
--- a/frontend/src/api/accountShares.ts
+++ b/frontend/src/api/accountShares.ts
@@ -1,0 +1,34 @@
+import { apiClient, type ApiItem, type ApiList } from './client'
+
+// Visibility values mirror backend model.VisibilityPrivate etc. 'private'
+// is the API-only sentinel for "clear the row" — never stored.
+export type AccountShareVisibility = 'private' | 'balance_only' | 'balance_and_txns'
+
+export type AccountShare = {
+  id: number
+  account_id: number
+  household_id: number
+  visibility: AccountShareVisibility
+  created_at: string
+  updated_at: string
+}
+
+export async function listAccountShares(accountID: number): Promise<AccountShare[]> {
+  const res = await apiClient.get<ApiList<AccountShare>>(`/accounts/${accountID}/shares`)
+  return res.data.data
+}
+
+// setAccountShare returns null when visibility === 'private' (server clears
+// the row + responds 204). Otherwise the new share row.
+export async function setAccountShare(
+  accountID: number,
+  householdID: number,
+  visibility: AccountShareVisibility,
+): Promise<AccountShare | null> {
+  const res = await apiClient.put<ApiItem<AccountShare> | ''>(
+    `/accounts/${accountID}/shares/${householdID}`,
+    { visibility },
+  )
+  if (res.status === 204 || typeof res.data === 'string') return null
+  return res.data.data
+}

--- a/frontend/src/components/AccountVisibilityChip.tsx
+++ b/frontend/src/components/AccountVisibilityChip.tsx
@@ -1,0 +1,144 @@
+import { useEffect, useRef, useState } from 'react'
+import { ChevronDown, Eye, EyeOff, Lock } from 'lucide-react'
+import {
+  listAccountShares,
+  setAccountShare,
+  type AccountShare,
+  type AccountShareVisibility,
+} from '../api/accountShares'
+
+type Props = {
+  accountID: number
+  householdID: number
+}
+
+const OPTIONS: Array<{ value: AccountShareVisibility; label: string; description: string; icon: React.ComponentType<{ size?: number }> }> = [
+  {
+    value: 'private',
+    label: 'Private',
+    description: 'Hidden from the household. Default for new accounts.',
+    icon: Lock,
+  },
+  {
+    value: 'balance_only',
+    label: 'Balance-only',
+    description: "Household sees this account's balance in aggregates. Transactions stay private.",
+    icon: EyeOff,
+  },
+  {
+    value: 'balance_and_txns',
+    label: 'Balance + transactions',
+    description: 'Household sees the balance and every transaction in shared aggregates.',
+    icon: Eye,
+  },
+]
+
+const STYLES: Record<AccountShareVisibility, string> = {
+  private: 'bg-gray-100 text-gray-700',
+  balance_only: 'bg-amber-100 text-amber-800',
+  balance_and_txns: 'bg-emerald-100 text-emerald-800',
+}
+
+// AccountVisibilityChip renders the current visibility for an account-household
+// pair and lets the account owner change it via a click-to-open dropdown.
+// Read happens lazily on mount; PUT is optimistic with rollback on error.
+export function AccountVisibilityChip({ accountID, householdID }: Props) {
+  const [visibility, setVisibility] = useState<AccountShareVisibility>('private')
+  const [loading, setLoading] = useState(true)
+  const [saving, setSaving] = useState(false)
+  const [open, setOpen] = useState(false)
+  const rootRef = useRef<HTMLDivElement | null>(null)
+
+  useEffect(() => {
+    // The /accounts/:id/shares endpoint returns 0 or 1 share row per (account,
+    // household) — each user is in at most one household. Filter to our household.
+    listAccountShares(accountID)
+      .then((rows: AccountShare[]) => {
+        const mine = rows.find((r) => r.household_id === householdID)
+        setVisibility(mine?.visibility ?? 'private')
+      })
+      .catch(() => {
+        // Ignore — the chip falls back to 'private' (the absent-row default).
+      })
+      .finally(() => setLoading(false))
+  }, [accountID, householdID])
+
+  // Close the dropdown when the user clicks outside.
+  useEffect(() => {
+    if (!open) return
+    const handler = (e: MouseEvent) => {
+      if (rootRef.current && !rootRef.current.contains(e.target as Node)) setOpen(false)
+    }
+    document.addEventListener('mousedown', handler)
+    return () => document.removeEventListener('mousedown', handler)
+  }, [open])
+
+  const choose = async (next: AccountShareVisibility) => {
+    setOpen(false)
+    if (next === visibility) return
+    const prev = visibility
+    setVisibility(next)
+    setSaving(true)
+    try {
+      await setAccountShare(accountID, householdID, next)
+    } catch {
+      setVisibility(prev)
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const current = OPTIONS.find((o) => o.value === visibility) ?? OPTIONS[0]
+  const Icon = current.icon
+
+  return (
+    <div ref={rootRef} className="relative inline-block">
+      <button
+        type="button"
+        disabled={loading || saving}
+        onClick={() => setOpen((o) => !o)}
+        title={current.description}
+        className={[
+          'inline-flex items-center gap-1 rounded-full px-2.5 py-1 text-xs font-medium transition disabled:opacity-50',
+          STYLES[visibility],
+        ].join(' ')}
+        aria-haspopup="listbox"
+        aria-expanded={open}
+      >
+        <Icon size={12} />
+        {loading ? '…' : current.label}
+        <ChevronDown size={12} className="opacity-70" />
+      </button>
+      {open && (
+        <div
+          role="listbox"
+          className="absolute right-0 z-10 mt-1 w-64 rounded-md border border-gray-200 bg-white p-1 shadow-lg"
+        >
+          {OPTIONS.map((opt) => {
+            const Opt = opt.icon
+            const active = opt.value === visibility
+            return (
+              <button
+                key={opt.value}
+                type="button"
+                role="option"
+                aria-selected={active}
+                onClick={() => void choose(opt.value)}
+                className={[
+                  'flex w-full items-start gap-2 rounded px-2 py-2 text-left text-xs',
+                  active ? 'bg-indigo-50' : 'hover:bg-gray-50',
+                ].join(' ')}
+              >
+                <Opt size={14} />
+                <div className="min-w-0">
+                  <div className="font-medium text-gray-900">{opt.label}</div>
+                  <div className="text-[11px] text-gray-500">{opt.description}</div>
+                </div>
+              </button>
+            )
+          })}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/pages/AccountsPage.tsx
+++ b/frontend/src/pages/AccountsPage.tsx
@@ -1,9 +1,11 @@
 import { useEffect, useState, type ReactNode } from 'react'
 import { Pencil, Plus, Trash2 } from 'lucide-react'
+import { AccountVisibilityChip } from '../components/AccountVisibilityChip'
 import { AmountDisplay } from '../components/AmountDisplay'
 import { PIIPanel } from '../components/PIIPanel'
 import { SyncStatusPill } from '../components/SyncStatusPill'
 import { useAccountsStore } from '../store/accountsStore'
+import { useScopeStore } from '../store/scopeStore'
 import {
   ACCOUNT_TYPES,
   type Account,
@@ -14,6 +16,11 @@ import {
 
 export function AccountsPage() {
   const { accounts, loading, error, fetch, create, update, remove } = useAccountsStore()
+  // householdId is null when the user belongs to no household — the
+  // visibility column is omitted entirely in that case (private-only
+  // mode), matching the rule in `.claude/rules/frontend.md`: don't
+  // surface a column the user can't act on.
+  const householdId = useScopeStore((s) => s.householdId)
   const [adding, setAdding] = useState(false)
   const [editing, setEditing] = useState<Account | null>(null)
 
@@ -54,15 +61,16 @@ export function AccountsPage() {
               <th className="px-4 py-2 text-right">Balance</th>
               <th className="px-4 py-2 text-center">Active</th>
               <th className="px-4 py-2 text-left">Sync</th>
+              {householdId != null && <th className="px-4 py-2 text-left">Household visibility</th>}
               <th className="px-4 py-2"></th>
             </tr>
           </thead>
           <tbody className="divide-y divide-gray-100">
             {loading && accounts.length === 0 && (
-              <tr><td colSpan={8} className="px-4 py-6 text-center text-gray-400">Loading…</td></tr>
+              <tr><td colSpan={householdId != null ? 9 : 8} className="px-4 py-6 text-center text-gray-400">Loading…</td></tr>
             )}
             {!loading && accounts.length === 0 && (
-              <tr><td colSpan={8} className="px-4 py-6 text-center text-gray-400">No accounts yet.</td></tr>
+              <tr><td colSpan={householdId != null ? 9 : 8} className="px-4 py-6 text-center text-gray-400">No accounts yet.</td></tr>
             )}
             {accounts.map((a) => (
               <tr key={a.id} className="hover:bg-gray-50">
@@ -81,6 +89,11 @@ export function AccountsPage() {
                 <td className="px-4 py-2">
                   <SyncStatusPill account={a} />
                 </td>
+                {householdId != null && (
+                  <td className="px-4 py-2">
+                    <AccountVisibilityChip accountID={a.id} householdID={householdId} />
+                  </td>
+                )}
                 <td className="px-4 py-2 text-right">
                   <button
                     type="button"


### PR DESCRIPTION
## Summary
Adds a per-account household visibility chip on `/accounts`. Each row now shows the account's current sharing level with the active household (private / balance-only / balance-and-txns); clicking the chip opens a dropdown that PUTs the new visibility to `/accounts/:id/shares/:householdID`.

- `src/api/accountShares.ts` — typed client for `GET /accounts/:id/shares` and `PUT /accounts/:id/shares/:householdID`. Handles the 204 response when visibility goes to `private` (server clears the row).
- `src/components/AccountVisibilityChip.tsx` — color-coded chip (private=gray, balance-only=amber, balance-and-txns=emerald), click-to-open dropdown with description per level, click-outside close, optimistic save with rollback on error.
- `AccountsPage.tsx` — extra column rendered only when `scopeStore.householdId` is non-null (no household → no chip, no column).

## Test plan
- [x] `pnpm lint` — clean
- [x] `pnpm build` — type-checks and bundles
- [ ] Manual: in a household, visit `/accounts`, see each row's visibility, change one to `balance_only`, see it persist after reload
- [ ] Manual: change back to `private`, confirm the account drops out of the household dashboard's aggregates
- [ ] Manual: user with no household sees no chip column

Closes #142