### PR TITLE
feat(auth): /auth/signup-with-invite — onboard new users in invite_only mode (#145)

### DIFF
--- a/backend/internal/handler/auth_handler.go
+++ b/backend/internal/handler/auth_handler.go
@@ -7,6 +7,7 @@ import (
 	"github.com/gin-gonic/gin"
 
 	"github.com/gregwym/offbook/backend/internal/service/auth"
+	"github.com/gregwym/offbook/backend/internal/service/household"
 )
 
 // AuthHandler exposes /setup/admin, /auth/*, and /me. These are the only
@@ -25,6 +26,7 @@ func (h *AuthHandler) RegisterPublic(g *gin.RouterGroup) {
 	g.POST("/setup/admin", h.SetupAdmin)
 	g.GET("/setup/status", h.SetupStatus)
 	g.POST("/auth/signup", h.Signup)
+	g.POST("/auth/signup-with-invite", h.SignupWithInvite)
 	g.POST("/auth/signin", h.Signin)
 	g.POST("/auth/signout", h.Signout)
 }
@@ -105,6 +107,36 @@ func (h *AuthHandler) Signup(c *gin.Context) {
 	}})
 }
 
+type signupWithInviteRequest struct {
+	Email       string `json:"email"`
+	Password    string `json:"password"`
+	InviteToken string `json:"invite_token"`
+}
+
+// SignupWithInvite is the only onboarding path that works in invite_only
+// mode for brand-new users — the valid invite is the gate, not signup_mode.
+func (h *AuthHandler) SignupWithInvite(c *gin.Context) {
+	var req signupWithInviteRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error(), "code": "INVALID_REQUEST"})
+		return
+	}
+	res, err := h.svc.SignupWithInvite(c.Request.Context(), auth.SignupWithInviteInput{
+		Email:       req.Email,
+		Password:    req.Password,
+		InviteToken: req.InviteToken,
+	})
+	if err != nil {
+		h.writeAuthError(c, err)
+		return
+	}
+	h.setSessionCookie(c, res)
+	c.JSON(http.StatusCreated, gin.H{"data": gin.H{
+		"id":    res.User.ID,
+		"email": res.User.Email,
+	}})
+}
+
 func (h *AuthHandler) Signin(c *gin.Context) {
 	var req credentialsRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
@@ -161,6 +193,16 @@ func (h *AuthHandler) writeAuthError(c *gin.Context, err error) {
 		c.JSON(http.StatusForbidden, gin.H{"error": err.Error(), "code": "SIGNUP_CLOSED"})
 	case errors.Is(err, auth.ErrInvalidCredentials):
 		c.JSON(http.StatusUnauthorized, gin.H{"error": err.Error(), "code": "INVALID_CREDENTIALS"})
+	case errors.Is(err, auth.ErrInviteUnavailable):
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": err.Error(), "code": "INVITE_UNAVAILABLE"})
+	case errors.Is(err, auth.ErrInviteRequired):
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error(), "code": "INVALID_REQUEST"})
+	case errors.Is(err, household.ErrInviteNotFound):
+		c.JSON(http.StatusNotFound, gin.H{"error": err.Error(), "code": "INVITE_NOT_FOUND"})
+	case errors.Is(err, household.ErrInviteExpired):
+		c.JSON(http.StatusGone, gin.H{"error": err.Error(), "code": "INVITE_EXPIRED"})
+	case errors.Is(err, household.ErrInviteAlreadyAccepted):
+		c.JSON(http.StatusConflict, gin.H{"error": err.Error(), "code": "INVITE_ACCEPTED"})
 	case errors.Is(err, auth.ErrEmailRequired),
 		errors.Is(err, auth.ErrInvalidEmail),
 		errors.Is(err, auth.ErrPasswordTooShort),

--- a/backend/internal/repository/user_repo.go
+++ b/backend/internal/repository/user_repo.go
@@ -16,6 +16,11 @@ type UserRepository interface {
 	GetByEmail(ctx context.Context, email string) (*model.User, error)
 	UpdateLastScope(ctx context.Context, id int64, scope string) error
 	Count(ctx context.Context) (int64, error)
+	// HardDelete removes the user row outright. Used only by the
+	// signup-with-invite cleanup path when invite acceptance fails
+	// post-create; never expose to handlers — deleting users is destructive
+	// and the proper user-facing path is leave-household + admin tooling.
+	HardDelete(ctx context.Context, id int64) error
 }
 
 type userRepo struct{ db *gorm.DB }
@@ -71,4 +76,15 @@ func (r *userRepo) Count(ctx context.Context) (int64, error) {
 		return 0, err
 	}
 	return n, nil
+}
+
+func (r *userRepo) HardDelete(ctx context.Context, id int64) error {
+	res := r.db.WithContext(ctx).Unscoped().Delete(&model.User{}, id)
+	if res.Error != nil {
+		return res.Error
+	}
+	if res.RowsAffected == 0 {
+		return ErrNotFound
+	}
+	return nil
 }

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -88,6 +88,12 @@ func New(cfg config.Config, gormDB *gorm.DB) *gin.Engine {
 	)
 	householdHandler := handler.NewHouseholdHandler(householdSvc)
 
+	// Now that the household service exists, wire it into auth so the
+	// /auth/signup-with-invite flow can consume tokens during signup
+	// (see #145). authSvc is already constructed at the top of the func —
+	// this just upgrades it with the invite acceptor.
+	authSvc.WithInviteAcceptor(householdSvc)
+
 	aggregator := household.NewAggregator(
 		repository.NewHouseholdAggregatorRepository(gormDB),
 		householdRepo,

--- a/backend/internal/service/auth/service.go
+++ b/backend/internal/service/auth/service.go
@@ -22,6 +22,8 @@ var (
 	ErrInstanceConfigured = errors.New("instance already configured")
 	ErrInvalidCredentials = errors.New("invalid credentials")
 	ErrInvalidScope       = errors.New("invalid scope")
+	ErrInviteRequired     = errors.New("invite_token is required")
+	ErrInviteUnavailable  = errors.New("invite acceptance not configured on this instance")
 )
 
 // MinPasswordLen is intentionally modest — Offbook is a local-first app and
@@ -31,6 +33,30 @@ const MinPasswordLen = 8
 type SignupInput struct {
 	Email    string
 	Password string
+}
+
+// SignupWithInviteInput is the body for POST /auth/signup-with-invite.
+// Works regardless of instance signup_mode — the invite token is the gate.
+type SignupWithInviteInput struct {
+	Email       string
+	Password    string
+	InviteToken string
+}
+
+// InviteAcceptor is the slice of household.Service the auth service needs
+// to consume invites during signup. Defining it here (vs importing
+// household directly) keeps the dependency arrow one-directional and lets
+// tests stub the acceptor without spinning up a real household stack.
+//
+// Method names mirror household.Service so the production wiring can pass
+// `*household.Service` directly without an adapter.
+type InviteAcceptor interface {
+	// ValidateInvite returns nil if the token would be acceptable for a
+	// new user. Returns the same error sentinels household.AcceptInvite
+	// would (ErrInviteNotFound / ErrInviteExpired / ErrInviteAlreadyAccepted).
+	ValidateInvite(ctx context.Context, rawToken string) error
+	// AcceptInviteForUser consumes the token on the new user's behalf.
+	AcceptInviteForUser(ctx context.Context, userID int64, rawToken string) error
 }
 
 // SetupAdminInput is accepted by /setup/admin. It both creates the first
@@ -54,6 +80,7 @@ type Service struct {
 	users    repository.UserRepository
 	sessions repository.SessionRepository
 	config   repository.InstanceConfigRepository
+	invites  InviteAcceptor // optional — nil disables SignupWithInvite
 	secret   string
 	now      func() time.Time
 }
@@ -71,6 +98,14 @@ func NewService(
 		secret:   secret,
 		now:      time.Now,
 	}
+}
+
+// WithInviteAcceptor wires the household-side invite acceptor for the
+// SignupWithInvite path. Router-level wiring uses this; tests that don't
+// exercise invite-signup leave it nil.
+func (s *Service) WithInviteAcceptor(a InviteAcceptor) *Service {
+	s.invites = a
+	return s
 }
 
 // SetClock lets tests freeze time for session-expiry assertions.
@@ -145,6 +180,57 @@ func (s *Service) Signup(ctx context.Context, in SignupInput) (*SigninResult, er
 	}
 	if err := s.users.Create(ctx, u); err != nil {
 		return nil, fmt.Errorf("create user: %w", err)
+	}
+	return s.issueSession(ctx, u)
+}
+
+// SignupWithInvite creates a non-admin user and consumes the supplied
+// household invite token in one flow. Works regardless of the instance's
+// signup_mode — the valid invite IS the gate, so this is the canonical
+// onboarding path in invite_only mode.
+//
+// Sequencing: validate token (peek-only) → validate credentials → create
+// user → accept invite for new user. If acceptance races and fails
+// post-create, we delete the freshly-created user so the operator doesn't
+// see an orphan account.
+func (s *Service) SignupWithInvite(ctx context.Context, in SignupWithInviteInput) (*SigninResult, error) {
+	if s.invites == nil {
+		return nil, ErrInviteUnavailable
+	}
+	if strings.TrimSpace(in.InviteToken) == "" {
+		return nil, ErrInviteRequired
+	}
+	// Confirm /setup/admin has run — otherwise there can't be any invites.
+	if _, err := s.config.Get(ctx); err != nil {
+		if errors.Is(err, repository.ErrNotFound) {
+			return nil, ErrInstanceConfigured
+		}
+		return nil, fmt.Errorf("get instance_config: %w", err)
+	}
+	if err := s.invites.ValidateInvite(ctx, in.InviteToken); err != nil {
+		return nil, err
+	}
+	if err := validateCredentials(in.Email, in.Password); err != nil {
+		return nil, err
+	}
+	hash, err := HashPassword(in.Password)
+	if err != nil {
+		return nil, fmt.Errorf("hash password: %w", err)
+	}
+	u := &model.User{
+		Email:        normalizeEmail(in.Email),
+		PasswordHash: hash,
+		LastScope:    model.ScopePersonal,
+		DefaultScope: model.ScopePersonal,
+	}
+	if err := s.users.Create(ctx, u); err != nil {
+		return nil, fmt.Errorf("create user: %w", err)
+	}
+	if err := s.invites.AcceptInviteForUser(ctx, u.ID, in.InviteToken); err != nil {
+		// Race / rejection between probe and accept. Clean up the orphan
+		// user so retries with a fresh token work without an email collision.
+		_ = s.users.HardDelete(ctx, u.ID)
+		return nil, err
 	}
 	return s.issueSession(ctx, u)
 }

--- a/backend/internal/service/auth/signup_with_invite_test.go
+++ b/backend/internal/service/auth/signup_with_invite_test.go
@@ -1,0 +1,231 @@
+package auth_test
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/gregwym/offbook/backend/internal/model"
+	"github.com/gregwym/offbook/backend/internal/service/auth"
+	"github.com/gregwym/offbook/backend/internal/service/household"
+)
+
+// stubInviteAcceptor records ValidateInvite and AcceptInviteForUser calls
+// without needing the full household service stack. Tests configure the
+// errors each method should return so the auth service's sequencing is
+// observable from outside.
+type stubInviteAcceptor struct {
+	mu             sync.Mutex
+	validateErr    error
+	acceptErr      error
+	validateCalls  int
+	acceptCalls    int
+	acceptedFor    int64
+	acceptedToken  string
+	validatedToken string
+}
+
+func (s *stubInviteAcceptor) ValidateInvite(_ context.Context, rawToken string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.validateCalls++
+	s.validatedToken = rawToken
+	return s.validateErr
+}
+
+func (s *stubInviteAcceptor) AcceptInviteForUser(_ context.Context, userID int64, rawToken string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.acceptCalls++
+	s.acceptedFor = userID
+	s.acceptedToken = rawToken
+	return s.acceptErr
+}
+
+// TestSignupWithInvite_HappyPath: valid token + valid credentials + admin
+// already set up → new user is created, invite is consumed, session is
+// returned. Works in invite_only mode (the canonical case).
+func TestSignupWithInvite_HappyPath(t *testing.T) {
+	svc, g := newTestService(t)
+	truncateAuthState(t, g)
+	ctx := context.Background()
+
+	if _, err := svc.SetupAdmin(ctx, auth.SetupAdminInput{
+		Email:      uniqueEmail("admin"),
+		Password:   "a-strong-password",
+		SignupMode: model.SignupModeInviteOnly,
+	}); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	stub := &stubInviteAcceptor{}
+	svc.WithInviteAcceptor(stub)
+
+	res, err := svc.SignupWithInvite(ctx, auth.SignupWithInviteInput{
+		Email:       uniqueEmail("invitee"),
+		Password:    "guest-password",
+		InviteToken: "raw-token-abc",
+	})
+	if err != nil {
+		t.Fatalf("SignupWithInvite: %v", err)
+	}
+	if res.User.ID == 0 {
+		t.Errorf("user ID = 0, want > 0")
+	}
+	if res.Token == "" {
+		t.Errorf("session token empty")
+	}
+	if stub.validateCalls != 1 {
+		t.Errorf("validate calls = %d, want 1", stub.validateCalls)
+	}
+	if stub.acceptCalls != 1 {
+		t.Errorf("accept calls = %d, want 1", stub.acceptCalls)
+	}
+	if stub.acceptedFor != res.User.ID {
+		t.Errorf("accept user_id = %d, want %d", stub.acceptedFor, res.User.ID)
+	}
+	if stub.acceptedToken != "raw-token-abc" {
+		t.Errorf("accept token = %q, want raw-token-abc", stub.acceptedToken)
+	}
+}
+
+// TestSignupWithInvite_InvalidToken: validate fails → user never created.
+func TestSignupWithInvite_InvalidToken(t *testing.T) {
+	svc, g := newTestService(t)
+	truncateAuthState(t, g)
+	ctx := context.Background()
+
+	if _, err := svc.SetupAdmin(ctx, auth.SetupAdminInput{
+		Email:      uniqueEmail("admin"),
+		Password:   "a-strong-password",
+		SignupMode: model.SignupModeInviteOnly,
+	}); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	stub := &stubInviteAcceptor{validateErr: household.ErrInviteNotFound}
+	svc.WithInviteAcceptor(stub)
+
+	email := uniqueEmail("invitee")
+	_, err := svc.SignupWithInvite(ctx, auth.SignupWithInviteInput{
+		Email:       email,
+		Password:    "guest-password",
+		InviteToken: "bad-token",
+	})
+	if !errors.Is(err, household.ErrInviteNotFound) {
+		t.Fatalf("err = %v, want ErrInviteNotFound", err)
+	}
+	if stub.acceptCalls != 0 {
+		t.Errorf("acceptCalls = %d, want 0 (must not consume on invalid token)", stub.acceptCalls)
+	}
+	// Verify no user was created.
+	if _, signinErr := svc.Signin(ctx, email, "guest-password"); !errors.Is(signinErr, auth.ErrInvalidCredentials) {
+		t.Errorf("Signin after failed invite-signup err = %v, want ErrInvalidCredentials (no user)", signinErr)
+	}
+}
+
+// TestSignupWithInvite_AcceptRace: validate passes but the accept call
+// fails (race with another acceptor consuming the token). The user row
+// must be deleted so retries with a fresh token don't hit a unique-email
+// collision.
+func TestSignupWithInvite_AcceptRace(t *testing.T) {
+	svc, g := newTestService(t)
+	truncateAuthState(t, g)
+	ctx := context.Background()
+
+	if _, err := svc.SetupAdmin(ctx, auth.SetupAdminInput{
+		Email:      uniqueEmail("admin"),
+		Password:   "a-strong-password",
+		SignupMode: model.SignupModeInviteOnly,
+	}); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	stub := &stubInviteAcceptor{acceptErr: household.ErrInviteAlreadyAccepted}
+	svc.WithInviteAcceptor(stub)
+
+	email := uniqueEmail("invitee")
+	_, err := svc.SignupWithInvite(ctx, auth.SignupWithInviteInput{
+		Email:       email,
+		Password:    "guest-password",
+		InviteToken: "raced-token",
+	})
+	if !errors.Is(err, household.ErrInviteAlreadyAccepted) {
+		t.Fatalf("err = %v, want ErrInviteAlreadyAccepted", err)
+	}
+	// User must be cleaned up so a retry with the SAME email + a fresh
+	// token doesn't fail on the unique constraint.
+	if _, signinErr := svc.Signin(ctx, email, "guest-password"); !errors.Is(signinErr, auth.ErrInvalidCredentials) {
+		t.Errorf("user not cleaned up — Signin err = %v, want ErrInvalidCredentials", signinErr)
+	}
+}
+
+// TestSignupWithInvite_RejectsEmptyToken: the gate fails before any DB call.
+func TestSignupWithInvite_RejectsEmptyToken(t *testing.T) {
+	svc, g := newTestService(t)
+	truncateAuthState(t, g)
+	stub := &stubInviteAcceptor{}
+	svc.WithInviteAcceptor(stub)
+
+	_, err := svc.SignupWithInvite(context.Background(), auth.SignupWithInviteInput{
+		Email:       uniqueEmail("invitee"),
+		Password:    "password",
+		InviteToken: "  ",
+	})
+	if !errors.Is(err, auth.ErrInviteRequired) {
+		t.Fatalf("err = %v, want ErrInviteRequired", err)
+	}
+	if stub.validateCalls != 0 {
+		t.Errorf("validate called %d times on empty token; should short-circuit", stub.validateCalls)
+	}
+}
+
+// TestSignupWithInvite_RejectsBadCredentials: validate passes, but
+// credentials fail validation → user never created and accept never called.
+func TestSignupWithInvite_RejectsBadCredentials(t *testing.T) {
+	svc, g := newTestService(t)
+	truncateAuthState(t, g)
+	ctx := context.Background()
+
+	if _, err := svc.SetupAdmin(ctx, auth.SetupAdminInput{
+		Email:      uniqueEmail("admin"),
+		Password:   "a-strong-password",
+		SignupMode: model.SignupModeInviteOnly,
+	}); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	stub := &stubInviteAcceptor{}
+	svc.WithInviteAcceptor(stub)
+
+	_, err := svc.SignupWithInvite(ctx, auth.SignupWithInviteInput{
+		Email:       "not-an-email",
+		Password:    "short", // < MinPasswordLen
+		InviteToken: "raw-token",
+	})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if stub.acceptCalls != 0 {
+		t.Errorf("accept called %d times despite bad credentials", stub.acceptCalls)
+	}
+}
+
+// TestSignupWithInvite_UnconfiguredService: ErrInviteUnavailable when the
+// acceptor was never wired (defensive — keeps a misconfigured router
+// from silently creating users).
+func TestSignupWithInvite_UnconfiguredService(t *testing.T) {
+	svc, g := newTestService(t)
+	truncateAuthState(t, g)
+	// Deliberately don't WithInviteAcceptor.
+
+	_, err := svc.SignupWithInvite(context.Background(), auth.SignupWithInviteInput{
+		Email:       uniqueEmail("invitee"),
+		Password:    "guest-password",
+		InviteToken: "raw-token",
+	})
+	if !errors.Is(err, auth.ErrInviteUnavailable) {
+		t.Fatalf("err = %v, want ErrInviteUnavailable", err)
+	}
+}

--- a/backend/internal/service/household/service.go
+++ b/backend/internal/service/household/service.go
@@ -250,6 +250,43 @@ func (s *Service) CreateInvite(ctx context.Context, userID, householdID int64, i
 	return &CreateInviteResult{Invite: inv, Token: token}, nil
 }
 
+// ValidateInvite is a non-consuming check that a token is acceptable for
+// a new user. Mirrors the early validation gates of AcceptInvite but
+// performs no writes — used by `auth.SignupWithInvite` to fail-fast on a
+// bad token before creating the user. Returns ErrInviteNotFound /
+// ErrInviteExpired / ErrInviteAlreadyAccepted as appropriate.
+func (s *Service) ValidateInvite(ctx context.Context, rawToken string) error {
+	if rawToken == "" {
+		return ErrInviteNotFound
+	}
+	inv, err := s.invites.GetByTokenHash(ctx, auth.HashToken(rawToken, s.secret))
+	if err != nil {
+		if errors.Is(err, repository.ErrNotFound) {
+			return ErrInviteNotFound
+		}
+		return err
+	}
+	if !inv.ExpiresAt.After(s.now()) {
+		return ErrInviteExpired
+	}
+	if inv.AcceptedAt != nil {
+		// A consumed token is unusable for a brand-new user. (The
+		// auto-resume path in AcceptInvite is only valid for the original
+		// invitee re-accepting their own token — not relevant during
+		// initial signup since the user doesn't exist yet.)
+		return ErrInviteAlreadyAccepted
+	}
+	return nil
+}
+
+// AcceptInviteForUser is a thin wrapper around AcceptInvite exposed via
+// the auth.InviteAcceptor interface — keeps the auth package decoupled
+// from household.Service's full API surface.
+func (s *Service) AcceptInviteForUser(ctx context.Context, userID int64, rawToken string) error {
+	_, err := s.AcceptInvite(ctx, userID, rawToken)
+	return err
+}
+
 // AcceptInvite consumes a raw invite token for the calling user.
 // Auto-resume per ADR-0007: if the user has a not-yet-purged left_at row in
 // the same household, we clear left_at and return resumed=true. Otherwise we

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -25,6 +25,21 @@ export async function signup(email: string, password: string): Promise<AuthUser>
   return res.data.data
 }
 
+// signupWithInvite is the canonical onboarding path in invite_only mode.
+// The valid invite is the gate — signup_mode doesn't matter.
+export async function signupWithInvite(
+  email: string,
+  password: string,
+  invite_token: string,
+): Promise<AuthUser> {
+  const res = await apiClient.post<ApiItem<AuthUser>>('/auth/signup-with-invite', {
+    email,
+    password,
+    invite_token,
+  })
+  return res.data.data
+}
+
 export async function signout(): Promise<void> {
   await apiClient.post('/auth/signout')
 }

--- a/frontend/src/pages/SigninPage.tsx
+++ b/frontend/src/pages/SigninPage.tsx
@@ -30,7 +30,9 @@ export function SigninPage() {
     }
   }
 
-  const canSignup = setup?.signup_mode === 'local_multi_tenant'
+  // Both modes have a self-service signup path now — local_multi_tenant
+  // takes plain email+password, invite_only takes an invite token too.
+  const canSignup = setup?.signup_mode === 'local_multi_tenant' || setup?.signup_mode === 'invite_only'
 
   return (
     <AuthShell>
@@ -76,13 +78,13 @@ export function SigninPage() {
       </form>
 
       <div className="mt-4 text-center text-xs text-gray-500">
-        {canSignup ? (
+        {canSignup && (
           <>
-            Don't have an account?{' '}
-            <Link to="/signup" className="text-indigo-600 hover:text-indigo-700">Sign up</Link>
+            {setup?.signup_mode === 'invite_only' ? 'Have an invite?' : "Don't have an account?"}{' '}
+            <Link to="/signup" className="text-indigo-600 hover:text-indigo-700">
+              {setup?.signup_mode === 'invite_only' ? 'Accept invite' : 'Sign up'}
+            </Link>
           </>
-        ) : (
-          'Signups are invite-only on this instance.'
         )}
       </div>
     </AuthShell>

--- a/frontend/src/pages/SignupPage.tsx
+++ b/frontend/src/pages/SignupPage.tsx
@@ -1,13 +1,13 @@
 import { useState } from 'react'
 import { Link, Navigate } from 'react-router-dom'
-import { Lock } from 'lucide-react'
 import { useAuthStore } from '../store/authStore'
 import { AuthShell } from './SetupAdminPage'
 
 export function SignupPage() {
-  const { setup, hydrated, user, signup, error, clearError } = useAuthStore()
+  const { setup, hydrated, user, signup, signupWithInvite, error, clearError } = useAuthStore()
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
+  const [inviteToken, setInviteToken] = useState('')
   const [submitting, setSubmitting] = useState(false)
 
   if (hydrated && setup && !setup.bootstrapped) {
@@ -17,38 +17,19 @@ export function SignupPage() {
     return <Navigate to="/dashboard" replace />
   }
 
-  // invite_only mode: signup endpoint is closed for new users. Backend
-  // support for signup-with-invite is tracked in #145. Until then, show
-  // a friendly "ask your admin" page.
-  if (hydrated && setup?.signup_mode === 'invite_only') {
-    return (
-      <AuthShell>
-        <h1 className="text-xl font-semibold text-gray-900 flex items-center gap-2">
-          <Lock size={18} className="text-gray-500" />
-          Signups are invite-only
-        </h1>
-        <p className="mt-2 text-sm text-gray-600">
-          This instance only lets admins add new users. Ask your admin to send you an invite, then
-          sign in with the credentials they share.
-        </p>
-        <div className="mt-6">
-          <Link
-            to="/signin"
-            className="inline-flex items-center justify-center w-full rounded-md bg-indigo-600 px-3 py-2 text-sm font-medium text-white hover:bg-indigo-700"
-          >
-            Back to sign in
-          </Link>
-        </div>
-      </AuthShell>
-    )
-  }
+  // Invite-only mode requires a token; local-multi-tenant mode doesn't.
+  const inviteRequired = setup?.signup_mode === 'invite_only'
 
   const submit = async (e: React.FormEvent) => {
     e.preventDefault()
     clearError()
     setSubmitting(true)
     try {
-      await signup(email, password)
+      if (inviteRequired) {
+        await signupWithInvite(email, password, inviteToken)
+      } else {
+        await signup(email, password)
+      }
     } catch {
       // error surfaces via store.
     } finally {
@@ -58,12 +39,34 @@ export function SignupPage() {
 
   return (
     <AuthShell>
-      <h1 className="text-xl font-semibold text-gray-900">Create your account</h1>
+      <h1 className="text-xl font-semibold text-gray-900">
+        {inviteRequired ? 'Accept your invite' : 'Create your account'}
+      </h1>
       <p className="mt-1 text-sm text-gray-500">
-        Each user gets their own private book. Households are joined by invite later.
+        {inviteRequired
+          ? 'Enter your invite token along with the credentials you want to use. Accepting an invite joins you to the household automatically.'
+          : 'Each user gets their own private book. Households are joined by invite later.'}
       </p>
 
       <form onSubmit={submit} className="mt-6 space-y-4">
+        {inviteRequired && (
+          <label className="block">
+            <div className="text-sm font-medium text-gray-700 mb-1">Invite token</div>
+            <input
+              type="text"
+              required
+              value={inviteToken}
+              onChange={(e) => setInviteToken(e.target.value)}
+              placeholder="Paste the token your admin shared"
+              autoFocus
+              className="w-full rounded-md border border-gray-300 px-3 py-2 font-mono text-xs focus:border-indigo-500 focus:outline-none"
+            />
+            <div className="mt-1 text-[11px] text-gray-500">
+              Tokens expire after 7 days. If yours doesn't work, ask the household owner to mint a
+              new one.
+            </div>
+          </label>
+        )}
         <label className="block">
           <div className="text-sm font-medium text-gray-700 mb-1">Email</div>
           <input
@@ -71,7 +74,7 @@ export function SignupPage() {
             required
             value={email}
             onChange={(e) => setEmail(e.target.value)}
-            autoFocus
+            autoFocus={!inviteRequired}
             className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-indigo-500 focus:outline-none"
           />
         </label>
@@ -95,10 +98,16 @@ export function SignupPage() {
 
         <button
           type="submit"
-          disabled={submitting || !email || !password}
+          disabled={submitting || !email || !password || (inviteRequired && !inviteToken.trim())}
           className="w-full rounded-md bg-indigo-600 px-3 py-2 text-sm font-medium text-white hover:bg-indigo-700 disabled:opacity-40"
         >
-          {submitting ? 'Creating account…' : 'Sign up'}
+          {submitting
+            ? inviteRequired
+              ? 'Accepting invite…'
+              : 'Creating account…'
+            : inviteRequired
+              ? 'Accept invite & sign up'
+              : 'Sign up'}
         </button>
       </form>
 

--- a/frontend/src/store/authStore.ts
+++ b/frontend/src/store/authStore.ts
@@ -6,6 +6,7 @@ import {
   signin as apiSignin,
   signout as apiSignout,
   signup as apiSignup,
+  signupWithInvite as apiSignupWithInvite,
 } from '../api/auth'
 import type { AuthUser, SetupStatus, SignupMode } from '../types/auth'
 
@@ -27,6 +28,7 @@ type AuthState = {
   setupAdmin: (email: string, password: string, mode: SignupMode) => Promise<void>
   signin: (email: string, password: string) => Promise<void>
   signup: (email: string, password: string) => Promise<void>
+  signupWithInvite: (email: string, password: string, token: string) => Promise<void>
   signout: () => Promise<void>
   clearError: () => void
 }
@@ -100,6 +102,17 @@ export const useAuthStore = create<AuthState>((set) => ({
     set({ error: null })
     try {
       const u = await apiSignup(email, password)
+      set({ user: u })
+    } catch (err) {
+      set({ error: errMsg(err) })
+      throw err
+    }
+  },
+
+  signupWithInvite: async (email, password, token) => {
+    set({ error: null })
+    try {
+      const u = await apiSignupWithInvite(email, password, token)
       set({ user: u })
     } catch (err) {
       set({ error: errMsg(err) })


### PR DESCRIPTION
## Summary
Closes the gap left by M8 #139: brand-new users couldn't self-onboard in `invite_only` mode, because `POST /auth/signup` returns `SIGNUP_CLOSED` and `POST /invites/:token/accept` requires an existing session.

**Backend**
- `auth.Service.SignupWithInvite` — validates the invite token (peek-only) → validates credentials → creates the user → consumes the invite on the new user's behalf. If the accept call races and fails post-create, the user is hard-deleted so retries with a fresh token aren't blocked by the unique-email constraint.
- `auth.InviteAcceptor` interface lets `*household.Service` drop in directly (matching method names) — keeps the dependency arrow one-way.
- `household.Service.ValidateInvite` is the new non-consuming probe; `AcceptInviteForUser` is a thin wrapper matching the interface signature.
- `UserRepository.HardDelete` — used only by the rollback path in this flow.
- `POST /auth/signup-with-invite` handler with codes `INVITE_NOT_FOUND` (404), `INVITE_EXPIRED` (410), `INVITE_ACCEPTED` (409), `INVITE_UNAVAILABLE` (503), `INVALID_REQUEST` (400) for empty token / bad creds.

**Frontend**
- `SignupPage` renders the invite-token field in invite_only mode and calls the new endpoint. In local_multi_tenant mode it keeps using `/auth/signup`.
- `SigninPage` now links to /signup in both modes (the link wording flips: "Accept invite" vs "Sign up").
- `authStore.signupWithInvite` + `api/auth.ts:signupWithInvite`.

## Test plan
- [x] `go test -race ./...` — full backend green, six new tests cover: happy path, invalid token (user not created), accept-race (user rolled back), empty token (short-circuit), bad credentials (no accept call), unconfigured service (`ErrInviteUnavailable`).
- [x] `pnpm lint && pnpm build` — frontend clean.
- [ ] Manual: invite_only instance → admin mints token on /h/members → fresh user visits /signup, pastes token + creds → lands on /dashboard with active household membership.

Closes #145