### PR TITLE
feat(household): owner-side member moderation (#147)

### DIFF
--- a/backend/internal/handler/household_handler.go
+++ b/backend/internal/handler/household_handler.go
@@ -39,6 +39,9 @@ func (h *HouseholdHandler) Register(g *gin.RouterGroup) {
 	g.POST("/households/:id/invites", h.CreateInvite)
 	g.POST("/invites/:token/accept", h.AcceptInvite)
 	g.DELETE("/households/:id/members/me", h.LeaveSelf)
+	g.GET("/households/:id/members", h.ListMembers)
+	g.PATCH("/households/:id/members/:userID", h.UpdateMemberRole)
+	g.DELETE("/households/:id/members/:userID", h.RemoveMember)
 
 	g.GET("/accounts/:id/shares", h.ListShares)
 	g.PUT("/accounts/:id/shares/:householdID", h.SetShare)
@@ -62,6 +65,10 @@ type createInviteRequest struct {
 
 type setShareRequest struct {
 	Visibility string `json:"visibility"`
+}
+
+type updateMemberRoleRequest struct {
+	Role string `json:"role"`
 }
 
 // --- handlers ---
@@ -171,6 +178,60 @@ func (h *HouseholdHandler) LeaveSelf(c *gin.Context) {
 	c.Status(http.StatusNoContent)
 }
 
+func (h *HouseholdHandler) ListMembers(c *gin.Context) {
+	id, ok := parseID(c)
+	if !ok {
+		return
+	}
+	include := c.Query("include") == "in_grace"
+	listing, err := h.svc.ListMembers(c.Request.Context(), auth.MustUserID(c.Request.Context()), id, include)
+	if err != nil {
+		h.writeError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"data": listing})
+}
+
+func (h *HouseholdHandler) UpdateMemberRole(c *gin.Context) {
+	id, ok := parseID(c)
+	if !ok {
+		return
+	}
+	targetUserID, err := strconv.ParseInt(c.Param("userID"), 10, 64)
+	if err != nil || targetUserID <= 0 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "userID must be a positive integer", "code": "INVALID_REQUEST"})
+		return
+	}
+	var req updateMemberRoleRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error(), "code": "INVALID_REQUEST"})
+		return
+	}
+	mem, err := h.svc.UpdateMemberRole(c.Request.Context(), auth.MustUserID(c.Request.Context()), id, targetUserID, req.Role)
+	if err != nil {
+		h.writeError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"data": mem})
+}
+
+func (h *HouseholdHandler) RemoveMember(c *gin.Context) {
+	id, ok := parseID(c)
+	if !ok {
+		return
+	}
+	targetUserID, err := strconv.ParseInt(c.Param("userID"), 10, 64)
+	if err != nil || targetUserID <= 0 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "userID must be a positive integer", "code": "INVALID_REQUEST"})
+		return
+	}
+	if err := h.svc.RemoveMember(c.Request.Context(), auth.MustUserID(c.Request.Context()), id, targetUserID); err != nil {
+		h.writeError(c, err)
+		return
+	}
+	c.Status(http.StatusNoContent)
+}
+
 func (h *HouseholdHandler) ListShares(c *gin.Context) {
 	id, ok := parseID(c)
 	if !ok {
@@ -226,6 +287,10 @@ func (h *HouseholdHandler) writeError(c *gin.Context, err error) {
 		c.JSON(http.StatusForbidden, gin.H{"error": err.Error(), "code": "FORBIDDEN"})
 	case errors.Is(err, household.ErrLastOwner):
 		c.JSON(http.StatusConflict, gin.H{"error": err.Error(), "code": "LAST_OWNER"})
+	case errors.Is(err, household.ErrCannotModifySelf):
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error(), "code": "CANNOT_MODIFY_SELF"})
+	case errors.Is(err, household.ErrMemberNotFound):
+		c.JSON(http.StatusNotFound, gin.H{"error": err.Error(), "code": "MEMBER_NOT_FOUND"})
 	case errors.Is(err, household.ErrAlreadyMember):
 		c.JSON(http.StatusConflict, gin.H{"error": err.Error(), "code": "ALREADY_MEMBER"})
 	case errors.Is(err, household.ErrInviteAlreadyAccepted):

--- a/backend/internal/repository/household_repo.go
+++ b/backend/internal/repository/household_repo.go
@@ -33,6 +33,11 @@ type HouseholdMemberRepository interface {
 	GetMembershipForUser(ctx context.Context, userID int64) (*model.HouseholdMember, error)
 	// ListActive returns all active members of a household. Order: role then id.
 	ListActive(ctx context.Context, householdID int64) ([]model.HouseholdMember, error)
+	// ListIncludingLeft returns active + in-grace members of a household
+	// (purged rows excluded). Used by the members page so owners can see
+	// who recently left without inspecting the audit log. Same ordering
+	// as ListActive: role then id.
+	ListIncludingLeft(ctx context.Context, householdID int64) ([]model.HouseholdMember, error)
 	// CountActiveOwners reports how many owners are still active (left_at IS NULL
 	// AND purged_at IS NULL). Used to enforce the LAST_OWNER guard.
 	CountActiveOwners(ctx context.Context, householdID int64) (int64, error)
@@ -41,6 +46,8 @@ type HouseholdMemberRepository interface {
 	MarkLeft(ctx context.Context, id int64, at time.Time) error
 	// ClearLeft re-activates a not-yet-purged row by zeroing left_at.
 	ClearLeft(ctx context.Context, id int64) error
+	// UpdateRole changes the role on an active membership row.
+	UpdateRole(ctx context.Context, id int64, role string) error
 }
 
 // HouseholdInviteRepository persists invite tokens. Tokens are HMAC-hashed by
@@ -169,6 +176,29 @@ func (r *householdMemberRepo) ListActive(ctx context.Context, householdID int64)
 		Order("CASE role WHEN 'owner' THEN 0 WHEN 'contributor' THEN 1 ELSE 2 END, id").
 		Find(&out).Error
 	return out, err
+}
+
+func (r *householdMemberRepo) ListIncludingLeft(ctx context.Context, householdID int64) ([]model.HouseholdMember, error) {
+	var out []model.HouseholdMember
+	err := r.db.WithContext(ctx).
+		Where("household_id = ? AND purged_at IS NULL", householdID).
+		Order("CASE role WHEN 'owner' THEN 0 WHEN 'contributor' THEN 1 ELSE 2 END, id").
+		Find(&out).Error
+	return out, err
+}
+
+func (r *householdMemberRepo) UpdateRole(ctx context.Context, id int64, role string) error {
+	res := r.db.WithContext(ctx).
+		Model(&model.HouseholdMember{}).
+		Where("id = ? AND left_at IS NULL AND purged_at IS NULL", id).
+		Update("role", role)
+	if res.Error != nil {
+		return res.Error
+	}
+	if res.RowsAffected == 0 {
+		return ErrNotFound
+	}
+	return nil
 }
 
 func (r *householdMemberRepo) CountActiveOwners(ctx context.Context, householdID int64) (int64, error) {

--- a/backend/internal/service/household/errors.go
+++ b/backend/internal/service/household/errors.go
@@ -21,4 +21,6 @@ var (
 	ErrLastOwner        = errors.New("cannot leave: you are the last owner")
 	ErrAccountNotOwned  = errors.New("account does not belong to user")
 	ErrInstanceNotReady = errors.New("instance not configured")
+	ErrCannotModifySelf = errors.New("cannot modify your own membership through owner actions; use Leave")
+	ErrMemberNotFound   = errors.New("member not found in this household")
 )

--- a/backend/internal/service/household/member_moderation_test.go
+++ b/backend/internal/service/household/member_moderation_test.go
@@ -1,0 +1,170 @@
+package household_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"gorm.io/gorm"
+
+	"github.com/gregwym/offbook/backend/internal/model"
+	"github.com/gregwym/offbook/backend/internal/service/household"
+)
+
+// seedOwnerWithMember spins up a household with one owner + one contributor.
+// Returns (svc, ownerID, contributorUserID, householdID).
+func seedOwnerWithMember(t *testing.T) (*household.Service, int64, int64, int64) {
+	t.Helper()
+	svc, _, g := newSvc(t)
+	ctx := context.Background()
+	ownerID := seedUser(t, g, "mod-owner")
+	contribID := seedUser(t, g, "mod-contrib")
+	hh, err := svc.Create(ctx, ownerID, household.CreateInput{Name: "Mod House"})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	cleanupHousehold(t, g, hh.ID)
+	inv, err := svc.CreateInvite(ctx, ownerID, hh.ID, household.CreateInviteInput{Role: model.RoleContributor})
+	if err != nil {
+		t.Fatalf("invite: %v", err)
+	}
+	if _, err := svc.AcceptInvite(ctx, contribID, inv.Token); err != nil {
+		t.Fatalf("accept: %v", err)
+	}
+	return svc, ownerID, contribID, hh.ID
+}
+
+func TestListMembers_ActiveOnly(t *testing.T) {
+	svc, ownerID, contribID, hhID := seedOwnerWithMember(t)
+	listing, err := svc.ListMembers(context.Background(), ownerID, hhID, false)
+	if err != nil {
+		t.Fatalf("ListMembers: %v", err)
+	}
+	if len(listing.Active) != 2 {
+		t.Errorf("active len = %d, want 2", len(listing.Active))
+	}
+	if len(listing.InGrace) != 0 {
+		t.Errorf("InGrace populated when include=false: %+v", listing.InGrace)
+	}
+	_ = contribID
+}
+
+func TestListMembers_IncludeInGrace(t *testing.T) {
+	svc, ownerID, contribID, hhID := seedOwnerWithMember(t)
+	ctx := context.Background()
+	if err := svc.Leave(ctx, contribID, hhID); err != nil {
+		t.Fatalf("Leave: %v", err)
+	}
+	listing, err := svc.ListMembers(ctx, ownerID, hhID, true)
+	if err != nil {
+		t.Fatalf("ListMembers: %v", err)
+	}
+	if len(listing.Active) != 1 || listing.Active[0].UserID != ownerID {
+		t.Errorf("active = %+v, want only owner", listing.Active)
+	}
+	if len(listing.InGrace) != 1 || listing.InGrace[0].UserID != contribID {
+		t.Errorf("InGrace = %+v, want one in-grace row for contributor", listing.InGrace)
+	}
+}
+
+func TestListMembers_NonMemberRejected(t *testing.T) {
+	svc, _, _, hhID := seedOwnerWithMember(t)
+	_, g := seedOutsiderDB(t)
+	outsiderID := seedUser(t, g, "outsider")
+	_, err := svc.ListMembers(context.Background(), outsiderID, hhID, false)
+	if !errors.Is(err, household.ErrNotMember) {
+		t.Fatalf("err = %v, want ErrNotMember", err)
+	}
+}
+
+// seedOutsiderDB returns a fresh gorm.DB connection (sharing the same
+// underlying test database) so we can seed an unrelated user without
+// adding them to the household under test.
+func seedOutsiderDB(t *testing.T) (*household.Service, *gorm.DB) {
+	svc, _, g := newSvc(t)
+	return svc, g
+}
+
+func TestUpdateMemberRole_OwnerPromotesContributor(t *testing.T) {
+	svc, ownerID, contribID, hhID := seedOwnerWithMember(t)
+	ctx := context.Background()
+	// Demoting contributor to view_only is the simpler test case (no
+	// last-owner concern since contrib is not an owner).
+	mem, err := svc.UpdateMemberRole(ctx, ownerID, hhID, contribID, model.RoleViewOnly)
+	if err != nil {
+		t.Fatalf("UpdateMemberRole: %v", err)
+	}
+	if mem.Role != model.RoleViewOnly {
+		t.Errorf("role = %q, want view_only", mem.Role)
+	}
+}
+
+func TestUpdateMemberRole_RejectsInvalidRole(t *testing.T) {
+	svc, ownerID, contribID, hhID := seedOwnerWithMember(t)
+	_, err := svc.UpdateMemberRole(context.Background(), ownerID, hhID, contribID, "superuser")
+	if !errors.Is(err, household.ErrInvalidRole) {
+		t.Fatalf("err = %v, want ErrInvalidRole", err)
+	}
+}
+
+func TestUpdateMemberRole_NonOwnerForbidden(t *testing.T) {
+	svc, ownerID, contribID, hhID := seedOwnerWithMember(t)
+	// contrib (non-owner) tries to demote the owner.
+	_, err := svc.UpdateMemberRole(context.Background(), contribID, hhID, ownerID, model.RoleViewOnly)
+	if !errors.Is(err, household.ErrForbidden) {
+		t.Fatalf("err = %v, want ErrForbidden", err)
+	}
+}
+
+func TestUpdateMemberRole_SelfRejected(t *testing.T) {
+	svc, ownerID, _, hhID := seedOwnerWithMember(t)
+	_, err := svc.UpdateMemberRole(context.Background(), ownerID, hhID, ownerID, model.RoleContributor)
+	if !errors.Is(err, household.ErrCannotModifySelf) {
+		t.Fatalf("err = %v, want ErrCannotModifySelf", err)
+	}
+}
+
+func TestUpdateMemberRole_MemberNotFound(t *testing.T) {
+	svc, ownerID, _, hhID := seedOwnerWithMember(t)
+	_, err := svc.UpdateMemberRole(context.Background(), ownerID, hhID, 99999, model.RoleContributor)
+	if !errors.Is(err, household.ErrMemberNotFound) {
+		t.Fatalf("err = %v, want ErrMemberNotFound", err)
+	}
+}
+
+func TestRemoveMember_HappyPath(t *testing.T) {
+	svc, ownerID, contribID, hhID := seedOwnerWithMember(t)
+	ctx := context.Background()
+	if err := svc.RemoveMember(ctx, ownerID, hhID, contribID); err != nil {
+		t.Fatalf("RemoveMember: %v", err)
+	}
+	// Contributor moves to in-grace, not purged. ListMembers without
+	// include reflects only owner; ListMembers with include shows both.
+	listing, _ := svc.ListMembers(ctx, ownerID, hhID, true)
+	if len(listing.Active) != 1 || listing.Active[0].UserID != ownerID {
+		t.Errorf("active = %+v, want only owner", listing.Active)
+	}
+	if len(listing.InGrace) != 1 || listing.InGrace[0].UserID != contribID {
+		t.Errorf("InGrace = %+v, want contributor", listing.InGrace)
+	}
+}
+
+func TestRemoveMember_NonOwnerForbidden(t *testing.T) {
+	svc, ownerID, contribID, hhID := seedOwnerWithMember(t)
+	err := svc.RemoveMember(context.Background(), contribID, hhID, ownerID)
+	if !errors.Is(err, household.ErrForbidden) {
+		t.Fatalf("err = %v, want ErrForbidden", err)
+	}
+}
+
+func TestRemoveMember_SelfRejected(t *testing.T) {
+	svc, ownerID, _, hhID := seedOwnerWithMember(t)
+	err := svc.RemoveMember(context.Background(), ownerID, hhID, ownerID)
+	if !errors.Is(err, household.ErrCannotModifySelf) {
+		t.Fatalf("err = %v, want ErrCannotModifySelf", err)
+	}
+}
+
+// Sanity: the clock-injection used by other tests still works for these.
+var _ = time.Now

--- a/backend/internal/service/household/service.go
+++ b/backend/internal/service/household/service.go
@@ -386,6 +386,133 @@ func (s *Service) Leave(ctx context.Context, userID, householdID int64) error {
 	return nil
 }
 
+// MembersListing pairs the active and in-grace member lists. The in-grace
+// list is empty when the caller didn't request it (the handler decides
+// based on the include= query param).
+type MembersListing struct {
+	Active  []model.HouseholdMember `json:"active"`
+	InGrace []model.HouseholdMember `json:"in_grace"`
+}
+
+// ListMembers returns the household's members. Active members always; in-grace
+// only when includeInGrace is true. Member-only.
+func (s *Service) ListMembers(ctx context.Context, userID, householdID int64, includeInGrace bool) (*MembersListing, error) {
+	if _, err := s.members.GetActive(ctx, householdID, userID); err != nil {
+		if errors.Is(err, repository.ErrNotFound) {
+			return nil, ErrNotMember
+		}
+		return nil, err
+	}
+	if !includeInGrace {
+		active, err := s.members.ListActive(ctx, householdID)
+		if err != nil {
+			return nil, fmt.Errorf("list active: %w", err)
+		}
+		return &MembersListing{Active: active}, nil
+	}
+	all, err := s.members.ListIncludingLeft(ctx, householdID)
+	if err != nil {
+		return nil, fmt.Errorf("list members: %w", err)
+	}
+	out := &MembersListing{}
+	for _, m := range all {
+		if m.LeftAt == nil {
+			out.Active = append(out.Active, m)
+		} else {
+			out.InGrace = append(out.InGrace, m)
+		}
+	}
+	return out, nil
+}
+
+// UpdateMemberRole changes the role of a member. Owner-only. The last
+// active owner cannot demote themselves AND the caller cannot demote their
+// own row through this endpoint (use ownership-transfer for that — tracked
+// in #152). For now we disallow self-modification entirely to keep the
+// surface unambiguous.
+func (s *Service) UpdateMemberRole(ctx context.Context, userID, householdID, targetUserID int64, role string) (*model.HouseholdMember, error) {
+	if err := s.requireOwner(ctx, userID, householdID); err != nil {
+		return nil, err
+	}
+	role = strings.TrimSpace(role)
+	if !isValidRole(role) {
+		return nil, ErrInvalidRole
+	}
+	if targetUserID == userID {
+		return nil, ErrCannotModifySelf
+	}
+	target, err := s.members.GetActive(ctx, householdID, targetUserID)
+	if err != nil {
+		if errors.Is(err, repository.ErrNotFound) {
+			return nil, ErrMemberNotFound
+		}
+		return nil, err
+	}
+	// If we're demoting the only remaining owner besides the caller, the
+	// caller would become the sole owner — that's the steady state already.
+	// But if the target is currently an owner and we're demoting them, count
+	// owners to ensure we don't drop below 1.
+	if target.Role == model.RoleOwner && role != model.RoleOwner {
+		n, err := s.members.CountActiveOwners(ctx, householdID)
+		if err != nil {
+			return nil, fmt.Errorf("count owners: %w", err)
+		}
+		if n <= 1 {
+			return nil, ErrLastOwner
+		}
+	}
+	if err := s.members.UpdateRole(ctx, target.ID, role); err != nil {
+		return nil, fmt.Errorf("update role: %w", err)
+	}
+	target.Role = role
+	return target, nil
+}
+
+// RemoveMember kicks a member from the household. Owner-only. Sets
+// left_at, enters grace (matching the lifecycle from voluntary leave so the
+// purge runner cleans up on the same schedule). The last active owner
+// cannot be removed; the caller cannot remove themselves through this
+// endpoint (use Leave).
+func (s *Service) RemoveMember(ctx context.Context, userID, householdID, targetUserID int64) error {
+	if err := s.requireOwner(ctx, userID, householdID); err != nil {
+		return err
+	}
+	if targetUserID == userID {
+		return ErrCannotModifySelf
+	}
+	target, err := s.members.GetActive(ctx, householdID, targetUserID)
+	if err != nil {
+		if errors.Is(err, repository.ErrNotFound) {
+			return ErrMemberNotFound
+		}
+		return err
+	}
+	if target.Role == model.RoleOwner {
+		// Defense in depth: shouldn't happen given the at-most-one-owner
+		// invariant + the self-skip above, but cheap to verify.
+		n, err := s.members.CountActiveOwners(ctx, householdID)
+		if err != nil {
+			return fmt.Errorf("count owners: %w", err)
+		}
+		if n <= 1 {
+			return ErrLastOwner
+		}
+	}
+	if err := s.members.MarkLeft(ctx, target.ID, s.now()); err != nil {
+		return fmt.Errorf("mark left: %w", err)
+	}
+	return nil
+}
+
+// isValidRole is a string allowlist for the three documented roles.
+func isValidRole(r string) bool {
+	switch r {
+	case model.RoleOwner, model.RoleContributor, model.RoleViewOnly:
+		return true
+	}
+	return false
+}
+
 // --- Account shares ---
 
 // ListShares returns active shares for an account. Account-owner only.

--- a/frontend/src/api/households.ts
+++ b/frontend/src/api/households.ts
@@ -3,7 +3,9 @@ import type {
   CreateInviteResult,
   Household,
   HouseholdDetail,
+  HouseholdMember,
   HouseholdRole,
+  MembersListing,
 } from '../types/household'
 
 export async function getHousehold(id: number): Promise<HouseholdDetail> {
@@ -42,4 +44,30 @@ export async function acceptInvite(token: string): Promise<unknown> {
 
 export async function leaveHousehold(id: number): Promise<void> {
   await apiClient.delete(`/households/${id}/members/me`)
+}
+
+export async function listMembers(
+  householdID: number,
+  includeInGrace: boolean,
+): Promise<MembersListing> {
+  const res = await apiClient.get<ApiItem<MembersListing>>(`/households/${householdID}/members`, {
+    params: includeInGrace ? { include: 'in_grace' } : undefined,
+  })
+  return res.data.data
+}
+
+export async function updateMemberRole(
+  householdID: number,
+  userID: number,
+  role: HouseholdRole,
+): Promise<HouseholdMember> {
+  const res = await apiClient.patch<ApiItem<HouseholdMember>>(
+    `/households/${householdID}/members/${userID}`,
+    { role },
+  )
+  return res.data.data
+}
+
+export async function removeMember(householdID: number, userID: number): Promise<void> {
+  await apiClient.delete(`/households/${householdID}/members/${userID}`)
 }

--- a/frontend/src/pages/HouseholdMembersPage.tsx
+++ b/frontend/src/pages/HouseholdMembersPage.tsx
@@ -1,20 +1,59 @@
-import { useEffect, useState } from 'react'
-import { Check, Copy, Mail, Users } from 'lucide-react'
+import { useCallback, useEffect, useState } from 'react'
+import { Check, Copy, Mail, Trash2, Users } from 'lucide-react'
+import {
+  createInvite,
+  listMembers,
+  removeMember,
+  updateMemberRole,
+} from '../api/households'
 import { useAuthStore } from '../store/authStore'
 import { useHouseholdStore } from '../store/householdStore'
 import { useScopeStore } from '../store/scopeStore'
-import type { HouseholdRole } from '../types/household'
+import type {
+  CreateInviteResult,
+  HouseholdMember,
+  HouseholdRole,
+  MembersListing,
+} from '../types/household'
+
+const ROLE_LABELS: Record<HouseholdRole, string> = {
+  owner: 'Owner',
+  contributor: 'Contributor',
+  view_only: 'View-only',
+}
+
+const ROLE_STYLES: Record<HouseholdRole, string> = {
+  owner: 'bg-indigo-100 text-indigo-800',
+  contributor: 'bg-emerald-100 text-emerald-800',
+  view_only: 'bg-gray-100 text-gray-700',
+}
 
 export function HouseholdMembersPage() {
   const { householdId } = useScopeStore()
   const meID = useAuthStore((s) => s.user?.id ?? null)
-  const { detail, loading, error, load, lastInvite, invite, clearInvite, clearError } =
-    useHouseholdStore()
+  const { detail, loading, error, load, clearError } = useHouseholdStore()
+  const [listing, setListing] = useState<MembersListing | null>(null)
+  const [listError, setListError] = useState<string | null>(null)
   const [inviting, setInviting] = useState(false)
+  const [lastInvite, setLastInvite] = useState<CreateInviteResult | null>(null)
+  const [busyUserID, setBusyUserID] = useState<number | null>(null)
+
+  const reloadListing = useCallback(() => {
+    if (householdId == null) return Promise.resolve()
+    return listMembers(householdId, true)
+      .then((res) => {
+        setListing(res)
+        setListError(null)
+      })
+      .catch((e: unknown) => setListError(errMsg(e)))
+  }, [householdId])
 
   useEffect(() => {
-    if (householdId != null) void load(householdId)
-  }, [householdId, load])
+    if (householdId != null) {
+      void load(householdId)
+      void reloadListing()
+    }
+  }, [householdId, load, reloadListing])
 
   if (householdId == null) {
     return (
@@ -43,6 +82,43 @@ export function HouseholdMembersPage() {
   }
 
   const isOwner = detail.role === 'owner'
+  const active = listing?.active ?? []
+  const inGrace = listing?.in_grace ?? []
+
+  const handleMintInvite = async (role: HouseholdRole) => {
+    const res = await createInvite(householdId, role)
+    setLastInvite(res)
+    // Also surfaces in /h/dashboard via reload.
+    return res
+  }
+
+  const handleRoleChange = async (member: HouseholdMember, role: HouseholdRole) => {
+    if (role === member.role) return
+    setBusyUserID(member.user_id)
+    setListError(null)
+    try {
+      await updateMemberRole(householdId, member.user_id, role)
+      await reloadListing()
+    } catch (e) {
+      setListError(errMsg(e))
+    } finally {
+      setBusyUserID(null)
+    }
+  }
+
+  const handleRemove = async (member: HouseholdMember) => {
+    if (!window.confirm(`Remove member #${member.user_id}? They enter the grace window and can rejoin via a fresh invite.`)) return
+    setBusyUserID(member.user_id)
+    setListError(null)
+    try {
+      await removeMember(householdId, member.user_id)
+      await reloadListing()
+    } catch (e) {
+      setListError(errMsg(e))
+    } finally {
+      setBusyUserID(null)
+    }
+  }
 
   return (
     <div className="space-y-6">
@@ -50,14 +126,18 @@ export function HouseholdMembersPage() {
         <div>
           <h1 className="text-2xl font-semibold text-gray-900">{detail.household.name}</h1>
           <p className="mt-1 text-sm text-gray-500">
-            {detail.members.length} member{detail.members.length === 1 ? '' : 's'} · grace period{' '}
+            {active.length} active member{active.length === 1 ? '' : 's'}
+            {inGrace.length > 0 ? ` · ${inGrace.length} in grace` : ''} · grace period{' '}
             {detail.household.grace_period_days} days
           </p>
         </div>
         {isOwner && (
           <button
             type="button"
-            onClick={() => setInviting(true)}
+            onClick={() => {
+              setInviting(true)
+              setLastInvite(null)
+            }}
             className="inline-flex items-center gap-2 rounded-md bg-indigo-600 px-3 py-2 text-sm font-medium text-white hover:bg-indigo-700"
           >
             <Mail size={16} /> Invite member
@@ -65,48 +145,64 @@ export function HouseholdMembersPage() {
         )}
       </div>
 
-      {error && (
+      {(error || listError) && (
         <div className="flex items-start justify-between rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
-          <span>{error}</span>
-          <button type="button" onClick={clearError} className="ml-3 text-red-600 hover:text-red-800">×</button>
+          <span>{listError || error}</span>
+          <button
+            type="button"
+            onClick={() => {
+              setListError(null)
+              clearError()
+            }}
+            className="ml-3 text-red-600 hover:text-red-800"
+          >
+            ×
+          </button>
         </div>
       )}
 
-      <Section>
+      <Section title="Active members">
         <div className="divide-y divide-gray-100">
-          {detail.members.map((m) => (
-            <div key={m.id} className="flex items-center justify-between px-5 py-3">
-              <div className="min-w-0">
-                <div className="flex items-center gap-2">
-                  <span className="font-medium text-gray-900 truncate">User #{m.user_id}</span>
-                  {m.user_id === meID && (
-                    <span className="rounded-full bg-gray-100 px-2 py-0.5 text-[11px] font-medium text-gray-700">you</span>
-                  )}
-                </div>
-                <div className="mt-0.5 text-xs text-gray-500">
-                  Joined {new Date(m.joined_at).toLocaleDateString()}
-                </div>
-              </div>
-              <RoleChip role={m.role} />
-            </div>
+          {active.map((m) => (
+            <MemberRow
+              key={m.id}
+              member={m}
+              isMe={m.user_id === meID}
+              isOwnerOfHousehold={isOwner}
+              busy={busyUserID === m.user_id}
+              onRoleChange={handleRoleChange}
+              onRemove={handleRemove}
+            />
           ))}
         </div>
       </Section>
 
-      <p className="text-xs text-gray-500">
-        Owner-side member moderation (change role, remove, in-grace listing) is tracked in #147
-        and lands when the backend endpoints exist.
-      </p>
+      {inGrace.length > 0 && (
+        <Section title={`In grace · ${inGrace.length}`}>
+          <div className="divide-y divide-gray-100">
+            {inGrace.map((m) => (
+              <div key={m.id} className="px-5 py-3 flex items-center justify-between">
+                <div className="min-w-0">
+                  <div className="font-medium text-gray-900">User #{m.user_id}</div>
+                  <div className="text-xs text-gray-500">
+                    Left {m.left_at ? new Date(m.left_at).toLocaleDateString() : 'recently'} ·
+                    can rejoin via a fresh invite within {detail.household.grace_period_days} days
+                  </div>
+                </div>
+                <RoleChip role={m.role} />
+              </div>
+            ))}
+          </div>
+        </Section>
+      )}
 
       {inviting && (
         <InviteModal
           onClose={() => {
             setInviting(false)
-            clearInvite()
+            setLastInvite(null)
           }}
-          onMint={async (role) => {
-            await invite(householdId, role)
-          }}
+          onMint={handleMintInvite}
           lastInvite={lastInvite}
         />
       )}
@@ -114,24 +210,84 @@ export function HouseholdMembersPage() {
   )
 }
 
-function Section({ children }: { children: React.ReactNode }) {
-  return <section className="rounded-lg border border-gray-200 bg-white">{children}</section>
+function MemberRow({
+  member,
+  isMe,
+  isOwnerOfHousehold,
+  busy,
+  onRoleChange,
+  onRemove,
+}: {
+  member: HouseholdMember
+  isMe: boolean
+  isOwnerOfHousehold: boolean
+  busy: boolean
+  onRoleChange: (m: HouseholdMember, role: HouseholdRole) => Promise<void>
+  onRemove: (m: HouseholdMember) => Promise<void>
+}) {
+  // Owner controls only appear for non-self rows. The backend rejects
+  // self-modification on these endpoints with `CANNOT_MODIFY_SELF`.
+  const showControls = isOwnerOfHousehold && !isMe
+
+  return (
+    <div className="flex items-center justify-between px-5 py-3">
+      <div className="min-w-0">
+        <div className="flex items-center gap-2">
+          <span className="font-medium text-gray-900 truncate">User #{member.user_id}</span>
+          {isMe && (
+            <span className="rounded-full bg-gray-100 px-2 py-0.5 text-[11px] font-medium text-gray-700">you</span>
+          )}
+        </div>
+        <div className="mt-0.5 text-xs text-gray-500">
+          Joined {new Date(member.joined_at).toLocaleDateString()}
+        </div>
+      </div>
+      {showControls ? (
+        <div className="flex items-center gap-2">
+          <select
+            value={member.role}
+            disabled={busy}
+            onChange={(e) => void onRoleChange(member, e.target.value as HouseholdRole)}
+            className="rounded-md border border-gray-300 px-2 py-1 text-xs focus:border-indigo-500 focus:outline-none disabled:opacity-50"
+          >
+            <option value="owner">Owner</option>
+            <option value="contributor">Contributor</option>
+            <option value="view_only">View-only</option>
+          </select>
+          <button
+            type="button"
+            onClick={() => void onRemove(member)}
+            disabled={busy}
+            aria-label="Remove member"
+            className="rounded-md border border-gray-300 px-2 py-1 text-gray-500 hover:bg-red-50 hover:text-red-700 disabled:opacity-50"
+          >
+            <Trash2 size={14} />
+          </button>
+        </div>
+      ) : (
+        <RoleChip role={member.role} />
+      )}
+    </div>
+  )
+}
+
+function Section({ title, children }: { title?: string; children: React.ReactNode }) {
+  return (
+    <section className="rounded-lg border border-gray-200 bg-white">
+      {title && (
+        <header className="border-b border-gray-200 px-5 py-2 text-xs font-semibold uppercase tracking-wider text-gray-500">
+          {title}
+        </header>
+      )}
+      {children}
+    </section>
+  )
 }
 
 function RoleChip({ role }: { role: HouseholdRole }) {
-  const styles: Record<HouseholdRole, string> = {
-    owner: 'bg-indigo-100 text-indigo-800',
-    contributor: 'bg-emerald-100 text-emerald-800',
-    view_only: 'bg-gray-100 text-gray-700',
-  }
-  const labels: Record<HouseholdRole, string> = {
-    owner: 'Owner',
-    contributor: 'Contributor',
-    view_only: 'View-only',
-  }
   return (
-    <span className={['rounded-full px-2.5 py-1 text-xs font-medium', styles[role]].join(' ')}>
-      {labels[role]}
+    <span className={['rounded-full px-2.5 py-1 text-xs font-medium', ROLE_STYLES[role]].join(' ')}>
+      {ROLE_LABELS[role]}
     </span>
   )
 }
@@ -142,17 +298,21 @@ function InviteModal({
   lastInvite,
 }: {
   onClose: () => void
-  onMint: (role: HouseholdRole) => Promise<void>
-  lastInvite: ReturnType<typeof useHouseholdStore.getState>['lastInvite']
+  onMint: (role: HouseholdRole) => Promise<CreateInviteResult>
+  lastInvite: CreateInviteResult | null
 }) {
   const [role, setRole] = useState<HouseholdRole>('contributor')
   const [submitting, setSubmitting] = useState(false)
   const [copied, setCopied] = useState(false)
+  const [error, setError] = useState<string | null>(null)
 
   const mint = async () => {
     setSubmitting(true)
+    setError(null)
     try {
       await onMint(role)
+    } catch (e) {
+      setError(errMsg(e))
     } finally {
       setSubmitting(false)
     }
@@ -165,8 +325,7 @@ function InviteModal({
       setCopied(true)
       window.setTimeout(() => setCopied(false), 1500)
     } catch {
-      // Clipboard API can fail in non-secure contexts — operator can still
-      // select + copy manually.
+      // Clipboard API unavailable in non-secure contexts — manual select still works.
     }
   }
 
@@ -199,9 +358,12 @@ function InviteModal({
                 </select>
               </label>
               <p className="text-xs text-gray-500">
-                Mints a one-time token. Share it with the invitee — they sign in and accept the
-                invite to join.
+                Mints a one-time token. Share it with the invitee — they accept on /signup (invite-only
+                instances) or via the household-join modal in the scope picker.
               </p>
+              {error && (
+                <div className="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-xs text-red-700">{error}</div>
+              )}
             </>
           )}
 
@@ -209,8 +371,8 @@ function InviteModal({
             <div className="space-y-2">
               <div className="text-sm font-medium text-gray-800">Invite created!</div>
               <p className="text-xs text-gray-500">
-                Share this token with the invitee. They sign in and accept it (the household-join
-                modal from #144 will handle this in-app).
+                Share this token. Brand-new users sign up at /signup with it; existing users can
+                accept via the household-join modal in the scope picker.
               </p>
               <div className="flex items-center gap-2">
                 <code className="flex-1 rounded bg-gray-50 px-2 py-1.5 font-mono text-xs text-gray-800 break-all">
@@ -253,4 +415,13 @@ function InviteModal({
       </div>
     </div>
   )
+}
+
+function errMsg(err: unknown): string {
+  if (err && typeof err === 'object' && 'response' in err) {
+    const r = (err as { response?: { data?: { error?: string } } }).response
+    if (r?.data?.error) return r.data.error
+  }
+  if (err instanceof Error) return err.message
+  return 'request failed'
 }

--- a/frontend/src/types/household.ts
+++ b/frontend/src/types/household.ts
@@ -29,6 +29,13 @@ export type HouseholdDetail = {
   role: HouseholdRole // requester's role in this household
 }
 
+// MembersListing mirrors service/household.MembersListing — the listing
+// endpoint returns active members + (optionally) in-grace members.
+export type MembersListing = {
+  active: HouseholdMember[]
+  in_grace?: HouseholdMember[] | null
+}
+
 export type HouseholdInvite = {
   id: number
   household_id: number


### PR DESCRIPTION
## Summary
Adds the owner-side moderation endpoints the M8 hi-fi members page (#140) needed but didn't have.

**Backend**
- `repository.HouseholdMemberRepository.ListIncludingLeft` and `UpdateRole`.
- `service/household.Service`:
  - `ListMembers(ctx, userID, householdID, includeInGrace)` returns a `MembersListing{Active, InGrace}` — member-only read.
  - `UpdateMemberRole(ctx, ownerID, householdID, targetUserID, role)` — owner-only, with `ErrCannotModifySelf`, `ErrInvalidRole`, `ErrMemberNotFound`, and a `LAST_OWNER` guard if the demotion would leave the household ownerless.
  - `RemoveMember(ctx, ownerID, householdID, targetUserID)` — owner-only, sets `left_at` (enters grace; same lifecycle as voluntary leave). Self-removal is rejected (`ErrCannotModifySelf` — use Leave).
- Handler routes: `GET /households/:id/members?include=in_grace`, `PATCH /households/:id/members/:userID`, `DELETE /households/:id/members/:userID`. New error mappings: `CANNOT_MODIFY_SELF` (400), `MEMBER_NOT_FOUND` (404).
- Integration tests: active-only listing, include-in-grace listing, non-member rejected, role change happy path, invalid role, non-owner forbidden, self-rejected, member-not-found, remove happy path, remove non-owner forbidden, remove self-rejected.

**Frontend**
- `frontend/src/api/households.ts` gains `listMembers`, `updateMemberRole`, `removeMember`.
- Members page now:
  - Renders an Active section + an In-grace section (when populated)
  - Owner sees an inline role dropdown + remove (trash) button on every non-self row
  - Self-rows show a read-only role chip (matching backend's no-self-modify rule)
  - In-grace rows show "left N days ago" with the household's grace window
  - Surfaces backend errors inline

## Test plan
- [x] `go test -race -p 1 ./...` — full backend green; 11 new household tests pass
- [x] `pnpm lint && pnpm build` — frontend clean
- [ ] Manual: owner changes a contributor to view-only, sees the row update
- [ ] Manual: owner removes a contributor, sees them flip to the In-grace section
- [ ] Manual: contributor (non-owner) sees no controls on other members' rows

Closes #147