### PR TITLE
feat(household): owner-transfer endpoint + settings UI (#152)

### DIFF
--- a/backend/internal/handler/household_handler.go
+++ b/backend/internal/handler/household_handler.go
@@ -42,6 +42,7 @@ func (h *HouseholdHandler) Register(g *gin.RouterGroup) {
 	g.GET("/households/:id/members", h.ListMembers)
 	g.PATCH("/households/:id/members/:userID", h.UpdateMemberRole)
 	g.DELETE("/households/:id/members/:userID", h.RemoveMember)
+	g.POST("/households/:id/transfer-owner", h.TransferOwner)
 
 	g.GET("/accounts/:id/shares", h.ListShares)
 	g.PUT("/accounts/:id/shares/:householdID", h.SetShare)
@@ -69,6 +70,10 @@ type setShareRequest struct {
 
 type updateMemberRoleRequest struct {
 	Role string `json:"role"`
+}
+
+type transferOwnerRequest struct {
+	UserID int64 `json:"user_id"`
 }
 
 // --- handlers ---
@@ -226,6 +231,27 @@ func (h *HouseholdHandler) RemoveMember(c *gin.Context) {
 		return
 	}
 	if err := h.svc.RemoveMember(c.Request.Context(), auth.MustUserID(c.Request.Context()), id, targetUserID); err != nil {
+		h.writeError(c, err)
+		return
+	}
+	c.Status(http.StatusNoContent)
+}
+
+func (h *HouseholdHandler) TransferOwner(c *gin.Context) {
+	id, ok := parseID(c)
+	if !ok {
+		return
+	}
+	var req transferOwnerRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error(), "code": "INVALID_REQUEST"})
+		return
+	}
+	if req.UserID <= 0 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "user_id must be a positive integer", "code": "INVALID_REQUEST"})
+		return
+	}
+	if err := h.svc.TransferOwner(c.Request.Context(), auth.MustUserID(c.Request.Context()), id, req.UserID); err != nil {
 		h.writeError(c, err)
 		return
 	}

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -85,7 +85,7 @@ func New(cfg config.Config, gormDB *gorm.DB) *gin.Engine {
 		repository.NewInstanceConfigRepository(gormDB),
 		userRepo,
 		cfg.SessionSecret,
-	)
+	).WithDB(gormDB)
 	householdHandler := handler.NewHouseholdHandler(householdSvc)
 
 	// Now that the household service exists, wire it into auth so the

--- a/backend/internal/service/household/errors.go
+++ b/backend/internal/service/household/errors.go
@@ -23,4 +23,5 @@ var (
 	ErrInstanceNotReady = errors.New("instance not configured")
 	ErrCannotModifySelf = errors.New("cannot modify your own membership through owner actions; use Leave")
 	ErrMemberNotFound   = errors.New("member not found in this household")
+	ErrTxUnavailable    = errors.New("transactional operations require WithDB wiring")
 )

--- a/backend/internal/service/household/service.go
+++ b/backend/internal/service/household/service.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"time"
 
+	"gorm.io/gorm"
+
 	"github.com/gregwym/offbook/backend/internal/model"
 	"github.com/gregwym/offbook/backend/internal/repository"
 	"github.com/gregwym/offbook/backend/internal/service/auth"
@@ -65,8 +67,13 @@ type Service struct {
 	accounts   repository.AccountRepository
 	config     repository.InstanceConfigRepository
 	users      repository.UserRepository
-	secret     string
-	now        func() time.Time
+	// db is held for multi-write operations (currently only TransferOwner)
+	// that need atomicity beyond what a single repo call provides.
+	// Nil-safe: methods that don't require it work without it; tests set
+	// it via WithDB.
+	db     *gorm.DB
+	secret string
+	now    func() time.Time
 }
 
 func NewService(
@@ -94,6 +101,15 @@ func NewService(
 
 // SetClock lets tests freeze time for invite-expiry assertions.
 func (s *Service) SetClock(fn func() time.Time) { s.now = fn }
+
+// WithDB wires the gorm handle used by multi-write operations (e.g.
+// TransferOwner). Returns the receiver for chaining. Production wiring
+// always calls this; older tests that don't exercise such operations may
+// skip it.
+func (s *Service) WithDB(db *gorm.DB) *Service {
+	s.db = db
+	return s
+}
 
 // --- Household CRUD ---
 
@@ -502,6 +518,70 @@ func (s *Service) RemoveMember(ctx context.Context, userID, householdID, targetU
 		return fmt.Errorf("mark left: %w", err)
 	}
 	return nil
+}
+
+// TransferOwner promotes targetUserID to owner and demotes the caller to
+// contributor. Caller must be the current owner. Target must be an active
+// member of this household. Both role updates AND the households.owner_id
+// flip happen in a single DB transaction so a mid-flight failure can't
+// produce a "two owners" or "owner_id mismatches role" intermediate state.
+//
+// Self-transfer is rejected (no-op anyway). After the transfer the caller
+// is no longer the owner — they may then call Leave if they want to exit
+// the household.
+func (s *Service) TransferOwner(ctx context.Context, callerID, householdID, targetUserID int64) error {
+	if s.db == nil {
+		return ErrTxUnavailable
+	}
+	if err := s.requireOwner(ctx, callerID, householdID); err != nil {
+		return err
+	}
+	if targetUserID == callerID {
+		return ErrCannotModifySelf
+	}
+	target, err := s.members.GetActive(ctx, householdID, targetUserID)
+	if err != nil {
+		if errors.Is(err, repository.ErrNotFound) {
+			return ErrMemberNotFound
+		}
+		return err
+	}
+	// The caller's row is needed for the demotion step. Fetch it inside
+	// the tx below to keep both reads consistent; but pre-fetch the ID
+	// here so we can short-circuit if something's already wrong.
+	caller, err := s.members.GetActive(ctx, householdID, callerID)
+	if err != nil {
+		return fmt.Errorf("get caller membership: %w", err)
+	}
+
+	return s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		// 1. Promote target to owner.
+		if res := tx.Model(&model.HouseholdMember{}).
+			Where("id = ? AND left_at IS NULL AND purged_at IS NULL", target.ID).
+			Update("role", model.RoleOwner); res.Error != nil {
+			return fmt.Errorf("promote target: %w", res.Error)
+		} else if res.RowsAffected == 0 {
+			return ErrMemberNotFound
+		}
+		// 2. Demote caller to contributor (chosen over view_only — the
+		// previous owner deserves write access by default).
+		if res := tx.Model(&model.HouseholdMember{}).
+			Where("id = ? AND left_at IS NULL AND purged_at IS NULL", caller.ID).
+			Update("role", model.RoleContributor); res.Error != nil {
+			return fmt.Errorf("demote caller: %w", res.Error)
+		} else if res.RowsAffected == 0 {
+			return ErrForbidden
+		}
+		// 3. Flip the owner_id on the household row to match.
+		if res := tx.Model(&model.Household{}).
+			Where("id = ?", householdID).
+			Update("owner_id", targetUserID); res.Error != nil {
+			return fmt.Errorf("update owner_id: %w", res.Error)
+		} else if res.RowsAffected == 0 {
+			return ErrHouseholdNotFound
+		}
+		return nil
+	})
 }
 
 // isValidRole is a string allowlist for the three documented roles.

--- a/backend/internal/service/household/service_test.go
+++ b/backend/internal/service/household/service_test.go
@@ -80,7 +80,7 @@ func newSvc(t *testing.T) (*household.Service, *service.AccountService, *gorm.DB
 		repository.NewInstanceConfigRepository(g),
 		repository.NewUserRepository(g),
 		testSecret,
-	)
+	).WithDB(g)
 	return svc, service.NewAccountService(accRepo), g
 }
 

--- a/backend/internal/service/household/transfer_owner_test.go
+++ b/backend/internal/service/household/transfer_owner_test.go
@@ -1,0 +1,93 @@
+package household_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/gregwym/offbook/backend/internal/model"
+	"github.com/gregwym/offbook/backend/internal/service/household"
+)
+
+// TestTransferOwner_HappyPath: owner promotes a contributor; the promotion
+// flips both roles AND households.owner_id atomically.
+func TestTransferOwner_HappyPath(t *testing.T) {
+	svc, ownerID, contribID, hhID := seedOwnerWithMember(t)
+	ctx := context.Background()
+
+	if err := svc.TransferOwner(ctx, ownerID, hhID, contribID); err != nil {
+		t.Fatalf("TransferOwner: %v", err)
+	}
+
+	// Verify post-state via the existing Get() endpoint.
+	asOldOwner, err := svc.Get(ctx, ownerID, hhID)
+	if err != nil {
+		t.Fatalf("Get as old owner: %v", err)
+	}
+	if asOldOwner.Role != model.RoleContributor {
+		t.Errorf("old owner role = %q, want contributor", asOldOwner.Role)
+	}
+	if asOldOwner.Household.OwnerID != contribID {
+		t.Errorf("Household.OwnerID = %d, want %d (new owner)", asOldOwner.Household.OwnerID, contribID)
+	}
+	// New owner sees themselves as owner.
+	asNewOwner, err := svc.Get(ctx, contribID, hhID)
+	if err != nil {
+		t.Fatalf("Get as new owner: %v", err)
+	}
+	if asNewOwner.Role != model.RoleOwner {
+		t.Errorf("new owner role = %q, want owner", asNewOwner.Role)
+	}
+}
+
+// TestTransferOwner_NonOwnerForbidden: a contributor cannot trigger transfer.
+func TestTransferOwner_NonOwnerForbidden(t *testing.T) {
+	svc, ownerID, contribID, hhID := seedOwnerWithMember(t)
+	err := svc.TransferOwner(context.Background(), contribID, hhID, ownerID)
+	if !errors.Is(err, household.ErrForbidden) {
+		t.Fatalf("err = %v, want ErrForbidden", err)
+	}
+}
+
+// TestTransferOwner_SelfRejected: owner can't transfer to themselves
+// (no-op + would be confusing).
+func TestTransferOwner_SelfRejected(t *testing.T) {
+	svc, ownerID, _, hhID := seedOwnerWithMember(t)
+	err := svc.TransferOwner(context.Background(), ownerID, hhID, ownerID)
+	if !errors.Is(err, household.ErrCannotModifySelf) {
+		t.Fatalf("err = %v, want ErrCannotModifySelf", err)
+	}
+}
+
+// TestTransferOwner_TargetMustBeMember: transferring to a stranger 404s.
+func TestTransferOwner_TargetMustBeMember(t *testing.T) {
+	svc, ownerID, _, hhID := seedOwnerWithMember(t)
+	err := svc.TransferOwner(context.Background(), ownerID, hhID, 99999)
+	if !errors.Is(err, household.ErrMemberNotFound) {
+		t.Fatalf("err = %v, want ErrMemberNotFound", err)
+	}
+}
+
+// TestTransferOwner_RequiresDBWiring: a service constructed without
+// WithDB returns ErrTxUnavailable rather than corrupting state.
+func TestTransferOwner_RequiresDBWiring(t *testing.T) {
+	svc, _, g := newSvc(t)
+	// Strip the DB wiring that newSvc applied so we can verify the guard.
+	// (newSvc already calls WithDB; this test simulates a misconfigured
+	// constructor by re-creating the service without it.)
+	_ = g
+	ownerID := seedUser(t, g, "tx-owner")
+	contribID := seedUser(t, g, "tx-contrib")
+	hh, err := svc.Create(context.Background(), ownerID, household.CreateInput{Name: "TX House"})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	cleanupHousehold(t, g, hh.ID)
+	// Override db to nil via the public WithDB API.
+	svc.WithDB(nil)
+
+	err = svc.TransferOwner(context.Background(), ownerID, hh.ID, contribID)
+	if !errors.Is(err, household.ErrTxUnavailable) {
+		t.Fatalf("err = %v, want ErrTxUnavailable", err)
+	}
+}

--- a/frontend/src/api/households.ts
+++ b/frontend/src/api/households.ts
@@ -71,3 +71,7 @@ export async function updateMemberRole(
 export async function removeMember(householdID: number, userID: number): Promise<void> {
   await apiClient.delete(`/households/${householdID}/members/${userID}`)
 }
+
+export async function transferOwner(householdID: number, userID: number): Promise<void> {
+  await apiClient.post(`/households/${householdID}/transfer-owner`, { user_id: userID })
+}

--- a/frontend/src/pages/HouseholdSettingsPage.tsx
+++ b/frontend/src/pages/HouseholdSettingsPage.tsx
@@ -1,12 +1,16 @@
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { Building2, DoorOpen, UserCog } from 'lucide-react'
+import { listMembers, transferOwner } from '../api/households'
+import { useAuthStore } from '../store/authStore'
 import { useHouseholdStore } from '../store/householdStore'
 import { useScopeStore } from '../store/scopeStore'
+import type { HouseholdMember } from '../types/household'
 
 export function HouseholdSettingsPage() {
   const { householdId } = useScopeStore()
   const hydrateScope = useScopeStore((s) => s.hydrate)
+  const meID = useAuthStore((s) => s.user?.id ?? null)
   const { detail, loading, error, load, updateHousehold, leave, clearError } =
     useHouseholdStore()
   const navigate = useNavigate()
@@ -18,10 +22,29 @@ export function HouseholdSettingsPage() {
   const [graceEdit, setGraceEdit] = useState<string | null>(null)
   const [saving, setSaving] = useState(false)
   const [leaving, setLeaving] = useState(false)
+  // Member list for the transfer-owner dropdown. Only loaded when the
+  // page renders the Ownership section (i.e. caller is owner).
+  const [otherActive, setOtherActive] = useState<HouseholdMember[]>([])
+  const [transferTarget, setTransferTarget] = useState<number | ''>('')
+  const [transferring, setTransferring] = useState(false)
+  const [transferError, setTransferError] = useState<string | null>(null)
 
   useEffect(() => {
     if (householdId != null) void load(householdId)
   }, [householdId, load])
+
+  const reloadMembers = useCallback(() => {
+    if (householdId == null || meID == null) return Promise.resolve()
+    return listMembers(householdId, false)
+      .then((res) => setOtherActive(res.active.filter((m) => m.user_id !== meID)))
+      .catch(() => setOtherActive([]))
+  }, [householdId, meID])
+
+  useEffect(() => {
+    if (detail?.role === 'owner') {
+      void reloadMembers()
+    }
+  }, [detail, reloadMembers])
 
   const name = nameEdit ?? detail?.household.name ?? ''
   const grace = graceEdit ?? (detail ? String(detail.household.grace_period_days) : '30')
@@ -160,19 +183,73 @@ export function HouseholdSettingsPage() {
             <UserCog size={16} className="text-gray-500" />
             <h2 className="text-base font-medium text-gray-900">Ownership</h2>
           </header>
-          <div className="px-5 py-4">
-            <button
-              type="button"
-              disabled
-              title="Backend endpoint pending — tracked in #152"
-              className="rounded-md border border-gray-300 bg-gray-50 px-3 py-1.5 text-sm font-medium text-gray-400 cursor-not-allowed"
-            >
-              Transfer ownership…
-            </button>
-            <p className="mt-1 text-xs text-gray-500">
-              Coming in #152. Until then, the sole owner cannot leave (the `LAST_OWNER` guard returns
-              a conflict — dissolve the household instead).
-            </p>
+          <div className="px-5 py-4 space-y-2">
+            {otherActive.length === 0 ? (
+              <p className="text-xs text-gray-500">
+                Transfer ownership requires at least one other active member. Invite someone first
+                from the Members page.
+              </p>
+            ) : (
+              <>
+                <div className="flex items-center gap-2">
+                  <select
+                    value={transferTarget === '' ? '' : String(transferTarget)}
+                    onChange={(e) =>
+                      setTransferTarget(e.target.value === '' ? '' : Number.parseInt(e.target.value, 10))
+                    }
+                    disabled={transferring}
+                    className="flex-1 max-w-xs rounded-md border border-gray-300 px-3 py-1.5 text-sm focus:border-indigo-500 focus:outline-none disabled:opacity-50"
+                  >
+                    <option value="">Transfer ownership to…</option>
+                    {otherActive.map((m) => (
+                      <option key={m.user_id} value={m.user_id}>
+                        User #{m.user_id} · {m.role}
+                      </option>
+                    ))}
+                  </select>
+                  <button
+                    type="button"
+                    disabled={transferring || transferTarget === ''}
+                    onClick={async () => {
+                      if (transferTarget === '' || householdId == null) return
+                      if (
+                        !window.confirm(
+                          `Transfer ownership to user #${transferTarget}? You become a contributor; ` +
+                            `they become owner immediately.`,
+                        )
+                      )
+                        return
+                      setTransferring(true)
+                      setTransferError(null)
+                      try {
+                        await transferOwner(householdId, transferTarget)
+                        // Refresh detail + members so the page reflects the new
+                        // role (no more owner-only controls).
+                        await load(householdId)
+                        await reloadMembers()
+                        setTransferTarget('')
+                      } catch (e) {
+                        setTransferError(errMsg(e))
+                      } finally {
+                        setTransferring(false)
+                      }
+                    }}
+                    className="rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-indigo-700 disabled:opacity-40"
+                  >
+                    {transferring ? 'Transferring…' : 'Transfer'}
+                  </button>
+                </div>
+                {transferError && (
+                  <div className="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-xs text-red-700">
+                    {transferError}
+                  </div>
+                )}
+                <p className="text-xs text-gray-500">
+                  After transfer, the new owner can mint invites, kick members, and change the grace
+                  period; you keep contributor access until you leave or are removed.
+                </p>
+              </>
+            )}
           </div>
         </section>
       )}
@@ -201,4 +278,13 @@ export function HouseholdSettingsPage() {
       </section>
     </div>
   )
+}
+
+function errMsg(err: unknown): string {
+  if (err && typeof err === 'object' && 'response' in err) {
+    const r = (err as { response?: { data?: { error?: string } } }).response
+    if (r?.data?.error) return r.data.error
+  }
+  if (err instanceof Error) return err.message
+  return 'request failed'
 }


### PR DESCRIPTION
## Summary
Adds the missing owner-transfer flow.

**Backend**
- `household.Service.TransferOwner(callerID, householdID, targetUserID)` — caller must be the current owner; target must be an active member; self-transfer is rejected (`ErrCannotModifySelf`).
- Atomic via `db.Transaction`: target → owner, caller → contributor, `households.owner_id` flipped. Mid-flight failure rolls back so we never observe two-owner or owner_id-mismatch state.
- `household.Service.WithDB(*gorm.DB)` setter so older test fixtures keep working without it; `TransferOwner` returns `ErrTxUnavailable` if the service was constructed without a DB handle.
- Route: `POST /households/:id/transfer-owner` body `{user_id}`. Reuses the existing `writeError` for `FORBIDDEN`, `CANNOT_MODIFY_SELF`, `MEMBER_NOT_FOUND` codes.
- Integration tests: happy path (role + owner_id flip), non-owner forbidden, self-rejected, target-must-be-member, requires-db-wiring guard.

**Frontend**
- `api/households.ts:transferOwner`.
- `/h/settings` Ownership section now lists every *other* active member in a dropdown and exposes a Transfer button. After success it re-hydrates `householdStore` so the owner-only controls disappear immediately. Backend errors surface inline. Empty-state copy when there's no one to transfer to.

## Test plan
- [x] `go test -race -p 1 ./...` — full backend green, 5 new tests pass
- [x] `pnpm lint && pnpm build` — frontend clean
- [ ] Manual: owner transfers to a contributor → both users see the role swap immediately; the old owner's settings page loses owner controls
- [ ] Manual: transfer with no other members → CTA is replaced by an explainer pointing to invites

Closes #152