### PR TITLE
feat(household): per-member contribution tiles on /h/dashboard (#149)

### DIFF
--- a/backend/internal/service/household/aggregator.go
+++ b/backend/internal/service/household/aggregator.go
@@ -51,15 +51,33 @@ func (a *Aggregator) SetClock(fn func() time.Time) { a.now = fn }
 // household + aggregates only across opt-in shared accounts. All money fields
 // are strings to preserve precision across the wire.
 type HouseholdDashboard struct {
-	Period           PeriodWindow           `json:"period"`
-	NetWorth         string                 `json:"net_worth"`         // sum across balance_only + balance_and_txns shares
-	Income           string                 `json:"income"`            // period; balance_and_txns only
-	Spending         string                 `json:"spending"`          // period; balance_and_txns only
-	AccountCount     int                    `json:"account_count"`     // shared accounts count (any visibility)
-	TransactionCount int64                  `json:"transaction_count"` // period; balance_and_txns only
-	ByCategory       []CategorySpendingItem `json:"by_category"`       // period; balance_and_txns only
-	LiveMemberCount  int                    `json:"live_member_count"`
-	InGraceCount     int                    `json:"in_grace_count"`
+	Period           PeriodWindow                  `json:"period"`
+	NetWorth         string                        `json:"net_worth"`         // sum across balance_only + balance_and_txns shares
+	Income           string                        `json:"income"`            // period; balance_and_txns only
+	Spending         string                        `json:"spending"`          // period; balance_and_txns only
+	AccountCount     int                           `json:"account_count"`     // shared accounts count (any visibility)
+	TransactionCount int64                         `json:"transaction_count"` // period; balance_and_txns only
+	ByCategory       []CategorySpendingItem        `json:"by_category"`       // period; balance_and_txns only
+	LiveMemberCount  int                           `json:"live_member_count"`
+	InGraceCount     int                           `json:"in_grace_count"`
+	Members          []HouseholdMemberContribution `json:"members"` // per-member breakdown for the same period
+}
+
+// HouseholdMemberContribution is one row of the per-member tile strip on
+// /h/dashboard. Each value is scoped to that member's shared accounts —
+// `private` accounts contribute nothing here, and `balance_only` accounts
+// only feed `NetWorthContribution` (their txns aren't visible).
+//
+// Privacy: this is still aggregator output — no raw transactions, no
+// account names, just one row per active member with their own user_id
+// (which the requester is already a peer of in the household scope, so
+// it is not PII at this layer).
+type HouseholdMemberContribution struct {
+	UserID               int64  `json:"user_id"`
+	Role                 string `json:"role"`
+	NetWorthContribution string `json:"net_worth_contribution"`
+	SpendingContribution string `json:"spending_contribution"`
+	AccountCount         int    `json:"account_count"`
 }
 
 // PeriodWindow is the resolved [from, to) window. Mirrors service.PeriodWindow
@@ -180,6 +198,11 @@ func (a *Aggregator) Dashboard(ctx context.Context, householdID int64, period st
 		})
 	}
 
+	members, err := a.perMemberContributions(ctx, live, netWorthShares, txShares, from, to)
+	if err != nil {
+		return nil, fmt.Errorf("per-member: %w", err)
+	}
+
 	return &HouseholdDashboard{
 		Period:           PeriodWindow{Key: period, From: from, To: to},
 		NetWorth:         netWorth.String(),
@@ -190,7 +213,60 @@ func (a *Aggregator) Dashboard(ctx context.Context, householdID int64, period st
 		ByCategory:       cats,
 		LiveMemberCount:  len(live),
 		InGraceCount:     len(inGrace),
+		Members:          members,
 	}, nil
+}
+
+// perMemberContributions partitions the household's shared accounts by
+// owning user_id and computes each active member's contribution to net
+// worth (balance_only ∪ balance_and_txns) and period spending
+// (balance_and_txns only). The result is ordered to match `live`'s
+// canonical role-then-id sort.
+//
+// Members with no shared accounts at all are omitted — the UI's tile
+// strip rendering each member regardless can fall back to the role chip
+// from /h/members. This keeps the dashboard endpoint focused on aggregate
+// contributions.
+func (a *Aggregator) perMemberContributions(
+	ctx context.Context,
+	live []model.HouseholdMember,
+	netWorthShares, txShares []repository.AccountShareView,
+	from, to time.Time,
+) ([]HouseholdMemberContribution, error) {
+	// Bucket account IDs by user.
+	netWorthByUser := map[int64][]int64{}
+	for _, s := range netWorthShares {
+		netWorthByUser[s.UserID] = append(netWorthByUser[s.UserID], s.AccountID)
+	}
+	txByUser := map[int64][]int64{}
+	for _, s := range txShares {
+		txByUser[s.UserID] = append(txByUser[s.UserID], s.AccountID)
+	}
+
+	out := make([]HouseholdMemberContribution, 0, len(live))
+	for _, m := range live {
+		nwIDs := netWorthByUser[m.UserID]
+		txIDs := txByUser[m.UserID]
+		if len(nwIDs) == 0 && len(txIDs) == 0 {
+			continue
+		}
+		nw, err := a.repo.SumBalances(ctx, nwIDs)
+		if err != nil {
+			return nil, fmt.Errorf("sum balances for user %d: %w", m.UserID, err)
+		}
+		_, spend, err := a.repo.PeriodIncomeSpending(ctx, txIDs, from, to)
+		if err != nil {
+			return nil, fmt.Errorf("period spend for user %d: %w", m.UserID, err)
+		}
+		out = append(out, HouseholdMemberContribution{
+			UserID:               m.UserID,
+			Role:                 m.Role,
+			NetWorthContribution: nw.String(),
+			SpendingContribution: spend.String(),
+			AccountCount:         len(nwIDs),
+		})
+	}
+	return out, nil
 }
 
 // BudgetPace rolls up each shared_budget for the household against its

--- a/backend/internal/service/household/aggregator_test.go
+++ b/backend/internal/service/household/aggregator_test.go
@@ -496,4 +496,77 @@ func TestAggregator_HouseholdNotFound(t *testing.T) {
 	}
 }
 
+// TestAggregator_PerMemberContributions checks scenario (f) — Dashboard.Members
+// gives one row per active member that owns at least one shared account,
+// and each row reflects that member's contribution to net worth and
+// period spending. In-grace members are excluded; balance_only accounts
+// contribute to net worth only.
+func TestAggregator_PerMemberContributions(t *testing.T) {
+	agg, g := newAggregator(t)
+	ctx := context.Background()
+	ownerID := seedUser(t, g, "pm-owner")
+	contribID := seedUser(t, g, "pm-contrib")
+	leaverID := seedUser(t, g, "pm-leaver")
+	hh := seedHouseholdRow(t, g, ownerID, "Per-Member", 30)
+	addMember(t, g, hh.ID, ownerID, model.RoleOwner, nil)
+	addMember(t, g, hh.ID, contribID, model.RoleContributor, nil)
+	leftAt := time.Now().Add(-time.Hour)
+	addMember(t, g, hh.ID, leaverID, model.RoleContributor, &leftAt)
+
+	// Owner shares a balance_and_txns checking + a balance_only savings.
+	ownerChk := seedAccount(t, g, ownerID, "owner-chk")
+	ownerSav := seedAccount(t, g, ownerID, "owner-sav")
+	setBalance(t, g, ownerChk, "200")
+	setBalance(t, g, ownerSav, "300")
+	setShare(t, g, ownerChk.ID, hh.ID, model.VisibilityBalanceAndTxns)
+	setShare(t, g, ownerSav.ID, hh.ID, model.VisibilityBalanceOnly)
+
+	// Contributor shares one balance_and_txns account.
+	contribChk := seedAccount(t, g, contribID, "contrib-chk")
+	setBalance(t, g, contribChk, "100")
+	setShare(t, g, contribChk.ID, hh.ID, model.VisibilityBalanceAndTxns)
+
+	// In-grace leaver also has a shared account — must NOT appear.
+	leaverChk := seedAccount(t, g, leaverID, "leaver-chk")
+	setBalance(t, g, leaverChk, "9999")
+	setShare(t, g, leaverChk.ID, hh.ID, model.VisibilityBalanceAndTxns)
+
+	when := time.Now().Add(-time.Hour)
+	seedTxn(t, g, ownerID, ownerChk.ID, "-40", nil, when)   // owner spend
+	seedTxn(t, g, ownerID, ownerSav.ID, "-1000", nil, when) // balance_only, must be ignored
+	seedTxn(t, g, contribID, contribChk.ID, "-15", nil, when)
+
+	d, err := agg.Dashboard(ctx, hh.ID, household.PeriodCurrentMonth)
+	if err != nil {
+		t.Fatalf("Dashboard: %v", err)
+	}
+	if len(d.Members) != 2 {
+		t.Fatalf("Members len = %d, want 2 (leaver excluded); got %+v", len(d.Members), d.Members)
+	}
+	byUser := map[int64]household.HouseholdMemberContribution{}
+	for _, m := range d.Members {
+		byUser[m.UserID] = m
+	}
+	owner := byUser[ownerID]
+	if owner.NetWorthContribution != "500" {
+		t.Errorf("owner NetWorthContribution = %q, want 500 (200 chk + 300 sav)", owner.NetWorthContribution)
+	}
+	if owner.SpendingContribution != "40" {
+		t.Errorf("owner SpendingContribution = %q, want 40 (only balance_and_txns)", owner.SpendingContribution)
+	}
+	if owner.AccountCount != 2 {
+		t.Errorf("owner AccountCount = %d, want 2 (both visibilities count toward net worth)", owner.AccountCount)
+	}
+	contrib := byUser[contribID]
+	if contrib.NetWorthContribution != "100" {
+		t.Errorf("contrib NetWorthContribution = %q, want 100", contrib.NetWorthContribution)
+	}
+	if contrib.SpendingContribution != "15" {
+		t.Errorf("contrib SpendingContribution = %q, want 15", contrib.SpendingContribution)
+	}
+	if _, leakedLeaver := byUser[leaverID]; leakedLeaver {
+		t.Errorf("in-grace leaver leaked into Members: %+v", d.Members)
+	}
+}
+
 func ptr[T any](v T) *T { return &v }

--- a/frontend/src/pages/HouseholdDashboardPage.tsx
+++ b/frontend/src/pages/HouseholdDashboardPage.tsx
@@ -126,6 +126,40 @@ function DashboardBody() {
         </div>
       )}
 
+      {dashboard.members.length > 0 && (
+        <section className="rounded-lg border border-gray-200 bg-white">
+          <header className="flex items-center gap-2 border-b border-gray-200 px-5 py-3">
+            <Activity size={16} className="text-gray-500" />
+            <h2 className="text-base font-medium text-gray-900">Per-member contribution</h2>
+          </header>
+          <div className="grid grid-cols-1 gap-3 p-4 md:grid-cols-2 lg:grid-cols-3">
+            {dashboard.members.map((m) => (
+              <div key={m.user_id} className="rounded-md border border-gray-200 p-3">
+                <div className="flex items-center justify-between">
+                  <div className="text-sm font-medium text-gray-900">User #{m.user_id}</div>
+                  <span className="rounded-full bg-gray-100 px-2 py-0.5 text-[10px] font-medium uppercase text-gray-600">
+                    {m.role.replace('_', '-')}
+                  </span>
+                </div>
+                <div className="mt-2 text-xs uppercase tracking-wide text-gray-500">Net worth</div>
+                <div className="text-base font-semibold text-gray-900">
+                  <AmountDisplay amount={m.net_worth_contribution} />
+                </div>
+                <div className="mt-1 text-xs uppercase tracking-wide text-gray-500">
+                  Spending (period)
+                </div>
+                <div className="text-base font-semibold text-gray-900">
+                  <AmountDisplay amount={m.spending_contribution} />
+                </div>
+                <div className="mt-1 text-[11px] text-gray-400">
+                  {m.account_count} shared account{m.account_count === 1 ? '' : 's'}
+                </div>
+              </div>
+            ))}
+          </div>
+        </section>
+      )}
+
       <section className="rounded-lg border border-gray-200 bg-white">
         <header className="flex items-center gap-2 border-b border-gray-200 px-5 py-3">
           <Activity size={16} className="text-gray-500" />
@@ -146,11 +180,6 @@ function DashboardBody() {
           </div>
         )}
       </section>
-
-      <p className="text-xs text-gray-500">
-        Per-member contribution tiles will land once the aggregator returns the breakdown — tracked
-        in #149.
-      </p>
     </>
   )
 }

--- a/frontend/src/types/householdAggregator.ts
+++ b/frontend/src/types/householdAggregator.ts
@@ -14,6 +14,14 @@ export type CategorySpendingItem = {
   amount: string // decimal string (NUMERIC(30,18))
 }
 
+export type HouseholdMemberContribution = {
+  user_id: number
+  role: 'owner' | 'contributor' | 'view_only'
+  net_worth_contribution: string
+  spending_contribution: string
+  account_count: number
+}
+
 export type HouseholdDashboard = {
   period: HouseholdPeriod
   net_worth: string
@@ -24,4 +32,5 @@ export type HouseholdDashboard = {
   by_category: CategorySpendingItem[]
   live_member_count: number
   in_grace_count: number
+  members: HouseholdMemberContribution[]
 }


### PR DESCRIPTION
## Summary
Closes the last M8 backlog item.

**Backend**
- `service/household.HouseholdMemberContribution`: `{user_id, role, net_worth_contribution, spending_contribution, account_count}`.
- `Aggregator.Dashboard` now returns `Members []HouseholdMemberContribution` alongside the existing totals. Per-member numbers are computed by bucketing the same `netWorthShares` / `txShares` lists by `user_id`, then calling `SumBalances` + `PeriodIncomeSpending` once per active member.
- Privacy: only active members with at least one shared account appear (`private` accounts contribute nothing); `balance_only` accounts feed net-worth only, never spending. In-grace members are excluded. The existing reflection-based "no raw transactions" test auto-covers the new field.
- New integration test `TestAggregator_PerMemberContributions` asserts: one row per active member with shares, owner's net-worth = chk + sav, owner's spending excludes the balance_only txn, contributor's row reflects only their account, leaver doesn't leak in.

**Frontend**
- `HouseholdDashboard` type gains `members`; new `HouseholdMemberContribution` type mirrors the backend.
- `/h/dashboard` renders a per-member tile strip (3 cols on lg) above the Spend-by-category list when `members.length > 0`. Each tile shows the role chip, net-worth, period spending, and shared-account count. The "tracked in #149" footnote is removed.

## Test plan
- [x] `go test -race -p 1 ./...` — full backend green; new aggregator test passes
- [x] `pnpm lint && pnpm build` — frontend clean
- [ ] Manual: household with two members both sharing accounts → both tiles render
- [ ] Manual: one member leaves → tile disappears from the strip (in-grace banner still shows)
- [ ] Manual: a `balance_only`-only sharer renders with 0 spending

Closes #149