### PR TITLE
feat(investments): recent-change tile on /investments (#122)

### DIFF
--- a/backend/internal/repository/investment_repo.go
+++ b/backend/internal/repository/investment_repo.go
@@ -22,6 +22,12 @@ type InvestmentRepository interface {
 	// (account_id, ticker) pair belonging to the user. One Postgres query
 	// via DISTINCT ON.
 	ListLatestPerHolding(ctx context.Context, userID int64) ([]model.Investment, error)
+	// ListLatestPairPerHolding returns up to two snapshots per
+	// (account_id, ticker) — the most recent and the most recent prior
+	// — for every holding. Used by the recent-P&L computation. Result is
+	// ordered by (account_id, ticker, snapshot_date DESC, id DESC) so the
+	// service can iterate and pair consecutive rows.
+	ListLatestPairPerHolding(ctx context.Context, userID int64) ([]model.Investment, error)
 	// ListSnapshotsByHolding returns every snapshot for a single
 	// (user_id, account_id, ticker), oldest first. ticker matching is
 	// case-insensitive (we always store uppercase, but defend against
@@ -69,6 +75,33 @@ func (r *investmentRepo) ListLatestPerHolding(ctx context.Context, userID int64)
 			ORDER BY account_id, ticker, snapshot_date DESC, id DESC
 		) latest
 		ORDER BY account_id, ticker
+	`, userID).Scan(&out).Error
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (r *investmentRepo) ListLatestPairPerHolding(ctx context.Context, userID int64) ([]model.Investment, error) {
+	// Window function picks the two newest snapshots per holding.
+	// Single query — paired-rows pattern via ROW_NUMBER beats two
+	// separate DISTINCT ON queries that would have to be zipped in Go.
+	var out []model.Investment
+	err := r.db.WithContext(ctx).Raw(`
+		SELECT id, user_id, account_id, ticker, name, asset_class,
+		       quantity, cost_basis, market_value,
+		       snapshot_date, source, created_at
+		FROM (
+			SELECT *,
+			       ROW_NUMBER() OVER (
+			           PARTITION BY account_id, ticker
+			           ORDER BY snapshot_date DESC, id DESC
+			       ) AS rn
+			FROM investments
+			WHERE user_id = ?
+		) ranked
+		WHERE rn <= 2
+		ORDER BY account_id, ticker, snapshot_date DESC, id DESC
 	`, userID).Scan(&out).Error
 	if err != nil {
 		return nil, err

--- a/backend/internal/service/investment_recent_change_test.go
+++ b/backend/internal/service/investment_recent_change_test.go
@@ -1,0 +1,102 @@
+package service_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/shopspring/decimal"
+
+	"github.com/gregwym/offbook/backend/internal/model"
+)
+
+// TestPortfolioSummary_RecentChange_NoPriorIsNil — fresh user with only
+// one snapshot per holding has no pair to compare; RecentChange stays nil.
+func TestPortfolioSummary_RecentChange_NoPriorIsNil(t *testing.T) {
+	svc, userID, accountID, _ := newInvestmentSvc(t)
+	portfolioCreate(t, svc, userID, accountID, "VTI", 10, intPtr(100), intPtr(150), strPtr("stock"), 1)
+
+	got, err := svc.PortfolioSummary(context.Background(), userID)
+	if err != nil {
+		t.Fatalf("PortfolioSummary: %v", err)
+	}
+	if got.RecentChange != nil {
+		t.Fatalf("RecentChange = %+v, want nil (only one snapshot)", got.RecentChange)
+	}
+}
+
+// TestPortfolioSummary_RecentChange_PairedHoldings sums deltas across
+// holdings with two snapshots; counts up / down / flat.
+func TestPortfolioSummary_RecentChange_PairedHoldings(t *testing.T) {
+	svc, userID, accountID, _ := newInvestmentSvc(t)
+
+	// VTI: 150 → 180 (up by 30)
+	portfolioCreate(t, svc, userID, accountID, "VTI", 10, intPtr(100), intPtr(150), strPtr("stock"), 1)
+	portfolioCreate(t, svc, userID, accountID, "VTI", 10, intPtr(100), intPtr(180), strPtr("stock"), 5)
+	// BND: 50 → 45 (down by 5)
+	portfolioCreate(t, svc, userID, accountID, "BND", 5, intPtr(50), intPtr(50), strPtr("bond"), 1)
+	portfolioCreate(t, svc, userID, accountID, "BND", 5, intPtr(50), intPtr(45), strPtr("bond"), 5)
+	// AAPL: 200 → 200 (flat)
+	portfolioCreate(t, svc, userID, accountID, "AAPL", 3, intPtr(180), intPtr(200), strPtr("stock"), 1)
+	portfolioCreate(t, svc, userID, accountID, "AAPL", 3, intPtr(180), intPtr(200), strPtr("stock"), 5)
+	// GME: single snapshot — must not contribute.
+	portfolioCreate(t, svc, userID, accountID, "GME", 1, intPtr(20), intPtr(15), strPtr("stock"), 5)
+
+	got, err := svc.PortfolioSummary(context.Background(), userID)
+	if err != nil {
+		t.Fatalf("PortfolioSummary: %v", err)
+	}
+	if got.RecentChange == nil {
+		t.Fatalf("RecentChange nil, want populated")
+	}
+	rc := got.RecentChange
+	// Delta = (180-150) + (45-50) + (200-200) = 30 - 5 + 0 = 25
+	if !rc.Delta.Equal(decimal.NewFromInt(25)) {
+		t.Errorf("Delta = %s, want 25", rc.Delta)
+	}
+	if rc.HoldingsCompared != 3 {
+		t.Errorf("HoldingsCompared = %d, want 3 (GME single-snapshot excluded)", rc.HoldingsCompared)
+	}
+	if rc.Up != 1 || rc.Down != 1 || rc.Flat != 1 {
+		t.Errorf("up/down/flat = %d/%d/%d, want 1/1/1", rc.Up, rc.Down, rc.Flat)
+	}
+	if rc.LatestDate.Day() != 5 || rc.PriorDate.Day() != 1 {
+		t.Errorf("dates = %s / %s, want day-5 latest and day-1 prior",
+			rc.LatestDate.Format("2006-01-02"), rc.PriorDate.Format("2006-01-02"))
+	}
+}
+
+// TestPortfolioSummary_RecentChange_TenantIsolation — user B's snapshots
+// must not feed user A's recent change.
+func TestPortfolioSummary_RecentChange_TenantIsolation(t *testing.T) {
+	svc, userA, accountA, g := newInvestmentSvc(t)
+	portfolioCreate(t, svc, userA, accountA, "VTI", 10, intPtr(100), intPtr(150), strPtr("stock"), 1)
+	portfolioCreate(t, svc, userA, accountA, "VTI", 10, intPtr(100), intPtr(155), strPtr("stock"), 5)
+
+	// Spin up a sibling user with a much larger swing on the same ticker.
+	userB := seedTestUser(t, g)
+	acctB := &model.Account{
+		UserID: userB, Name: "InvFixture-B-" + time.Now().Format("150405.000000"),
+		InstitutionSlug: "fixture", AccountType: "investment", Currency: "USD",
+	}
+	if err := g.Create(acctB).Error; err != nil {
+		t.Fatalf("seed acct B: %v", err)
+	}
+	t.Cleanup(func() {
+		g.Unscoped().Where("user_id = ?", userB).Delete(&model.Investment{})
+		g.Unscoped().Delete(&model.Account{}, acctB.ID)
+	})
+	portfolioCreate(t, svc, userB, acctB.ID, "VTI", 10, intPtr(100), intPtr(150), strPtr("stock"), 1)
+	portfolioCreate(t, svc, userB, acctB.ID, "VTI", 10, intPtr(100), intPtr(900), strPtr("stock"), 5)
+
+	got, err := svc.PortfolioSummary(context.Background(), userA)
+	if err != nil {
+		t.Fatalf("PortfolioSummary: %v", err)
+	}
+	if got.RecentChange == nil {
+		t.Fatalf("RecentChange nil")
+	}
+	if !got.RecentChange.Delta.Equal(decimal.NewFromInt(5)) {
+		t.Errorf("user A Delta = %s, want 5 (B's 750 must not leak)", got.RecentChange.Delta)
+	}
+}

--- a/backend/internal/service/investment_service.go
+++ b/backend/internal/service/investment_service.go
@@ -161,6 +161,31 @@ type PortfolioSummary struct {
 	TotalUnrealizedGainLoss *decimal.Decimal       `json:"total_unrealized_gain_loss"`
 	HoldingsCount           int                    `json:"holdings_count"`
 	ByAssetClass            []AssetClassAllocation `json:"by_asset_class"`
+	// RecentChange tracks the most-recent snapshot delta — the wireframe
+	// calls this "today's P&L". Without a live price feed we measure
+	// "today" as "between the two most recent snapshot dates per
+	// holding". Nil when no holding has two snapshots to compare.
+	RecentChange *RecentChange `json:"recent_change,omitempty"`
+}
+
+// RecentChange is the per-holding rollup of the latest-vs-prior snapshot
+// pair. Holdings with only one snapshot contribute nothing.
+type RecentChange struct {
+	// Delta is the sum of (latest.market_value - prior.market_value)
+	// across holdings that have both snapshots.
+	Delta decimal.Decimal `json:"delta"`
+	// HoldingsCompared is how many holdings the delta is computed across.
+	HoldingsCompared int `json:"holdings_compared"`
+	// Up / Down / Flat counts give the wireframe's "X of Y up" line.
+	Up   int `json:"up"`
+	Down int `json:"down"`
+	Flat int `json:"flat"`
+	// LatestDate / PriorDate are the canonical labels — the max() of
+	// each side across all paired holdings. Different holdings may have
+	// different snapshot dates; this picks the most-recent one on each
+	// side so the UI can label the period honestly.
+	LatestDate time.Time `json:"latest_date"`
+	PriorDate  time.Time `json:"prior_date"`
 }
 
 // PortfolioSummary computes per-user totals + asset-class allocation from
@@ -242,7 +267,71 @@ func (s *InvestmentService) PortfolioSummary(ctx context.Context, userID int64) 
 		})
 	}
 
+	// Recent-change is best-effort: a query failure here shouldn't fail
+	// the whole summary endpoint. The dashboard tile renders "—" when
+	// RecentChange is nil.
+	if rc, err := s.recentChange(ctx, userID); err == nil {
+		out.RecentChange = rc
+	}
+
 	return out, nil
+}
+
+// recentChange pairs each holding's two most-recent snapshots (when both
+// exist) and sums the deltas. Holdings with only one snapshot contribute
+// nothing — same as holdings with quantity == 0 (excluded). Returns nil
+// when no holding has a pair to compare.
+func (s *InvestmentService) recentChange(ctx context.Context, userID int64) (*RecentChange, error) {
+	pairs, err := s.repo.ListLatestPairPerHolding(ctx, userID)
+	if err != nil {
+		return nil, fmt.Errorf("list pairs: %w", err)
+	}
+	rc := &RecentChange{Delta: decimal.Zero}
+	// Pairs come ordered (account_id, ticker, date DESC) — every odd row
+	// is the latest, every even row (when present) is the prior.
+	for i := 0; i < len(pairs); {
+		latest := &pairs[i]
+		// Find the matching prior (same account_id + ticker, next row).
+		var prior *model.Investment
+		if i+1 < len(pairs) &&
+			pairs[i+1].AccountID == latest.AccountID &&
+			strings.EqualFold(pairs[i+1].Ticker, latest.Ticker) {
+			prior = &pairs[i+1]
+			i += 2
+		} else {
+			i++
+		}
+		if prior == nil {
+			continue // single-snapshot holding
+		}
+		if latest.Quantity.IsZero() {
+			continue // closed position
+		}
+		if latest.MarketValue == nil || prior.MarketValue == nil {
+			continue // no MV on one side → can't measure
+		}
+		d := latest.MarketValue.Sub(*prior.MarketValue)
+		rc.Delta = rc.Delta.Add(d)
+		rc.HoldingsCompared++
+		switch {
+		case d.IsPositive():
+			rc.Up++
+		case d.IsNegative():
+			rc.Down++
+		default:
+			rc.Flat++
+		}
+		if latest.SnapshotDate.After(rc.LatestDate) {
+			rc.LatestDate = latest.SnapshotDate
+		}
+		if prior.SnapshotDate.After(rc.PriorDate) {
+			rc.PriorDate = prior.SnapshotDate
+		}
+	}
+	if rc.HoldingsCompared == 0 {
+		return nil, nil
+	}
+	return rc, nil
 }
 
 // ImportResult mirrors the JSON contract for the CSV import endpoint.

--- a/frontend/src/pages/InvestmentsPage.tsx
+++ b/frontend/src/pages/InvestmentsPage.tsx
@@ -188,8 +188,8 @@ function PortfolioTiles({
     )
   }
   if (!portfolio) return null
-  const gl = portfolio.total_unrealized_gain_loss
-  const glNegative = gl !== null && gl.trim().startsWith('-')
+  const rc = portfolio.recent_change ?? null
+  const rcNegative = rc !== null && rc.delta.trim().startsWith('-')
   return (
     <div className="mt-6 grid grid-cols-1 gap-3 sm:grid-cols-3">
       <Tile label="Total value">
@@ -198,14 +198,20 @@ function PortfolioTiles({
       <Tile label="Cost basis">
         <AmountDisplay amount={portfolio.total_cost_basis} currency="USD" />
       </Tile>
-      <Tile label="Unrealized G/L">
-        {gl === null ? (
+      {/* Recent change replaces the wireframe's "today's P&L" tile. We
+          measure "today" as "between the two most recent snapshot dates"
+          since there is no live price feed yet — see #122. */}
+      <Tile
+        label={rc ? recentLabel(rc) : "Recent change"}
+        subtitle={rc ? `${rc.up} of ${rc.holdings_compared} up` : 'one snapshot only'}
+      >
+        {rc === null ? (
           <span className="text-gray-400">—</span>
         ) : (
           <AmountDisplay
-            amount={gl}
+            amount={rc.delta}
             currency="USD"
-            className={glNegative ? 'text-red-700' : 'text-emerald-700'}
+            className={rcNegative ? 'text-red-700' : 'text-emerald-700'}
           />
         )}
       </Tile>
@@ -213,11 +219,30 @@ function PortfolioTiles({
   )
 }
 
-function Tile({ label, children }: { label: string; children: ReactNode }) {
+// recentLabel formats the latest/prior date pair as a compact tile label.
+// When the dates are the same day (rare — multiple snapshots stamped the
+// same date), fall back to a single date.
+function recentLabel(rc: import('../types/investment').RecentChange): string {
+  const latest = rc.latest_date.slice(0, 10)
+  const prior = rc.prior_date.slice(0, 10)
+  if (latest === prior) return `Change · ${latest}`
+  return `Change · ${prior} → ${latest}`
+}
+
+function Tile({
+  label,
+  children,
+  subtitle,
+}: {
+  label: string
+  children: ReactNode
+  subtitle?: string
+}) {
   return (
     <div className="rounded-lg border border-gray-200 bg-white px-4 py-3 shadow-sm">
       <p className="text-xs font-medium uppercase tracking-wide text-gray-500">{label}</p>
       <p className="mt-1 text-lg font-semibold">{children}</p>
+      {subtitle && <p className="mt-0.5 text-[11px] text-gray-500">{subtitle}</p>}
     </div>
   )
 }

--- a/frontend/src/types/investment.ts
+++ b/frontend/src/types/investment.ts
@@ -35,6 +35,18 @@ export type AssetClassAllocation = {
   weight_pct: string
 }
 
+// Mirrors backend service.RecentChange. Null on the response when no
+// holding has two snapshots to compare.
+export type RecentChange = {
+  delta: string
+  holdings_compared: number
+  up: number
+  down: number
+  flat: number
+  latest_date: string
+  prior_date: string
+}
+
 // Mirrors backend service.PortfolioSummary. unrealized_gain_loss is null
 // when no holding has both market_value AND cost_basis populated.
 export type PortfolioSummary = {
@@ -43,4 +55,5 @@ export type PortfolioSummary = {
   total_unrealized_gain_loss: string | null
   holdings_count: number
   by_asset_class: AssetClassAllocation[]
+  recent_change?: RecentChange | null
 }


### PR DESCRIPTION
## Summary
Closes the wireframe gap left by M6: the third tile on /investments was a substitute (Unrealized G/L) because the backend had no concept of day-over-day deltas. This PR fills the slot with a snapshot-pair delta, which works without a live price feed.

**"Today" is honestly labeled as "between the two most recent snapshot dates per holding."** When the user imports daily the tile reads as "today's P&L"; when they import weekly it's the week's delta. The tile label shows the actual date range so this isn't ambiguous.

**Backend**
- `repository.InvestmentRepository.ListLatestPairPerHolding(userID)` — one window-function query returning the two newest snapshots per (account_id, ticker).
- `service.RecentChange{Delta, HoldingsCompared, Up, Down, Flat, LatestDate, PriorDate}` lives on `PortfolioSummary.RecentChange` (nullable — nil when no holding has a pair to compare). Closed positions (`quantity == 0`) and snapshots missing `market_value` are excluded.
- Best-effort wiring: a query failure populating `RecentChange` doesn't fail the summary endpoint.
- Three new integration tests: nil on single-snapshot users, correct sum + up/down/flat counts + date labels with paired holdings, tenant isolation (sibling user's big swing doesn't leak into ours).

**Frontend**
- `RecentChange` mirror type on `PortfolioSummary`.
- Third tile is now "Change · PRIOR → LATEST" with the delta amount and an "X of Y up" subtitle. Falls back to "Recent change / one snapshot only / —" when `recent_change` is null. Color-coded green/red.

## Test plan
- [x] `go test -race -p 1 ./...` — full backend green; 3 new tests cover the happy path, single-snapshot, and tenant isolation.
- [x] `pnpm lint && pnpm build` — frontend clean.
- [ ] Manual: import two days of holdings → tile shows the delta + counts
- [ ] Manual: import one day only → tile shows "one snapshot only" and a dash

Closes #122