### PR TITLE
feat(household): shared_budgets CRUD + /h/budgets page (#163)

### DIFF
--- a/backend/internal/handler/household_handler.go
+++ b/backend/internal/handler/household_handler.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 
 	"github.com/gin-gonic/gin"
+	"github.com/shopspring/decimal"
 
 	"github.com/gregwym/offbook/backend/internal/service/auth"
 	"github.com/gregwym/offbook/backend/internal/service/household"
@@ -43,6 +44,10 @@ func (h *HouseholdHandler) Register(g *gin.RouterGroup) {
 	g.PATCH("/households/:id/members/:userID", h.UpdateMemberRole)
 	g.DELETE("/households/:id/members/:userID", h.RemoveMember)
 	g.POST("/households/:id/transfer-owner", h.TransferOwner)
+	g.POST("/households/:id/shared-budgets", h.CreateSharedBudget)
+	g.GET("/households/:id/shared-budgets", h.ListSharedBudgets)
+	g.PATCH("/households/:id/shared-budgets/:budgetID", h.UpdateSharedBudget)
+	g.DELETE("/households/:id/shared-budgets/:budgetID", h.DeleteSharedBudget)
 
 	g.GET("/accounts/:id/shares", h.ListShares)
 	g.PUT("/accounts/:id/shares/:householdID", h.SetShare)
@@ -74,6 +79,22 @@ type updateMemberRoleRequest struct {
 
 type transferOwnerRequest struct {
 	UserID int64 `json:"user_id"`
+}
+
+type createSharedBudgetRequest struct {
+	CategoryID int64           `json:"category_id"`
+	Period     string          `json:"period"`
+	Amount     decimal.Decimal `json:"amount"`
+	Rollover   *bool           `json:"rollover"`
+	IsActive   *bool           `json:"is_active"`
+}
+
+type updateSharedBudgetRequest struct {
+	CategoryID *int64           `json:"category_id"`
+	Period     *string          `json:"period"`
+	Amount     *decimal.Decimal `json:"amount"`
+	Rollover   *bool            `json:"rollover"`
+	IsActive   *bool            `json:"is_active"`
 }
 
 // --- handlers ---
@@ -258,6 +279,89 @@ func (h *HouseholdHandler) TransferOwner(c *gin.Context) {
 	c.Status(http.StatusNoContent)
 }
 
+func (h *HouseholdHandler) CreateSharedBudget(c *gin.Context) {
+	id, ok := parseID(c)
+	if !ok {
+		return
+	}
+	var req createSharedBudgetRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error(), "code": "INVALID_REQUEST"})
+		return
+	}
+	b, err := h.svc.CreateSharedBudget(c.Request.Context(), auth.MustUserID(c.Request.Context()), id, household.SharedBudgetInput{
+		CategoryID: req.CategoryID,
+		Period:     req.Period,
+		Amount:     req.Amount,
+		Rollover:   req.Rollover,
+		IsActive:   req.IsActive,
+	})
+	if err != nil {
+		h.writeError(c, err)
+		return
+	}
+	c.JSON(http.StatusCreated, gin.H{"data": b})
+}
+
+func (h *HouseholdHandler) ListSharedBudgets(c *gin.Context) {
+	id, ok := parseID(c)
+	if !ok {
+		return
+	}
+	out, err := h.svc.ListSharedBudgets(c.Request.Context(), auth.MustUserID(c.Request.Context()), id)
+	if err != nil {
+		h.writeError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"data": out, "total": int64(len(out))})
+}
+
+func (h *HouseholdHandler) UpdateSharedBudget(c *gin.Context) {
+	id, ok := parseID(c)
+	if !ok {
+		return
+	}
+	budgetID, err := strconv.ParseInt(c.Param("budgetID"), 10, 64)
+	if err != nil || budgetID <= 0 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "budgetID must be a positive integer", "code": "INVALID_REQUEST"})
+		return
+	}
+	var req updateSharedBudgetRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error(), "code": "INVALID_REQUEST"})
+		return
+	}
+	b, err := h.svc.UpdateSharedBudget(c.Request.Context(), auth.MustUserID(c.Request.Context()), id, budgetID, household.UpdateSharedBudgetInput{
+		CategoryID: req.CategoryID,
+		Period:     req.Period,
+		Amount:     req.Amount,
+		Rollover:   req.Rollover,
+		IsActive:   req.IsActive,
+	})
+	if err != nil {
+		h.writeError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"data": b})
+}
+
+func (h *HouseholdHandler) DeleteSharedBudget(c *gin.Context) {
+	id, ok := parseID(c)
+	if !ok {
+		return
+	}
+	budgetID, err := strconv.ParseInt(c.Param("budgetID"), 10, 64)
+	if err != nil || budgetID <= 0 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "budgetID must be a positive integer", "code": "INVALID_REQUEST"})
+		return
+	}
+	if err := h.svc.SoftDeleteSharedBudget(c.Request.Context(), auth.MustUserID(c.Request.Context()), id, budgetID); err != nil {
+		h.writeError(c, err)
+		return
+	}
+	c.Status(http.StatusNoContent)
+}
+
 func (h *HouseholdHandler) ListShares(c *gin.Context) {
 	id, ok := parseID(c)
 	if !ok {
@@ -323,6 +427,13 @@ func (h *HouseholdHandler) writeError(c *gin.Context, err error) {
 		c.JSON(http.StatusConflict, gin.H{"error": err.Error(), "code": "INVITE_ACCEPTED"})
 	case errors.Is(err, household.ErrInviteExpired):
 		c.JSON(http.StatusGone, gin.H{"error": err.Error(), "code": "INVITE_EXPIRED"})
+	case errors.Is(err, household.ErrBudgetNotFound):
+		c.JSON(http.StatusNotFound, gin.H{"error": err.Error(), "code": "BUDGET_NOT_FOUND"})
+	case errors.Is(err, household.ErrUnknownCategory):
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error(), "code": "UNKNOWN_CATEGORY"})
+	case errors.Is(err, household.ErrInvalidBudgetPeriod),
+		errors.Is(err, household.ErrInvalidBudgetAmount):
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error(), "code": "INVALID_BUDGET"})
 	case errors.Is(err, household.ErrEmptyName),
 		errors.Is(err, household.ErrInvalidRole),
 		errors.Is(err, household.ErrInvalidGrace),

--- a/backend/internal/repository/shared_budget_repo.go
+++ b/backend/internal/repository/shared_budget_repo.go
@@ -1,0 +1,85 @@
+package repository
+
+import (
+	"context"
+	"errors"
+
+	"gorm.io/gorm"
+
+	"github.com/gregwym/offbook/backend/internal/model"
+)
+
+// SharedBudgetRepository is the data-access contract for shared_budgets.
+// Reads/writes are scoped by household_id — the household service is the
+// only caller and enforces membership/role at the service layer. The
+// aggregator has its own read-only view of this table; this repository
+// owns the CRUD side.
+type SharedBudgetRepository interface {
+	Create(ctx context.Context, b *model.SharedBudget) error
+	GetByID(ctx context.Context, householdID, id int64) (*model.SharedBudget, error)
+	List(ctx context.Context, householdID int64) ([]model.SharedBudget, error)
+	Update(ctx context.Context, b *model.SharedBudget) error
+	SoftDelete(ctx context.Context, householdID, id int64) error
+}
+
+type sharedBudgetRepo struct {
+	db *gorm.DB
+}
+
+func NewSharedBudgetRepository(db *gorm.DB) SharedBudgetRepository {
+	return &sharedBudgetRepo{db: db}
+}
+
+func (r *sharedBudgetRepo) Create(ctx context.Context, b *model.SharedBudget) error {
+	return r.db.WithContext(ctx).Create(b).Error
+}
+
+func (r *sharedBudgetRepo) GetByID(ctx context.Context, householdID, id int64) (*model.SharedBudget, error) {
+	var b model.SharedBudget
+	if err := r.db.WithContext(ctx).
+		Where("household_id = ?", householdID).
+		First(&b, id).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, ErrNotFound
+		}
+		return nil, err
+	}
+	return &b, nil
+}
+
+func (r *sharedBudgetRepo) List(ctx context.Context, householdID int64) ([]model.SharedBudget, error) {
+	var out []model.SharedBudget
+	if err := r.db.WithContext(ctx).
+		Where("household_id = ?", householdID).
+		Order("is_active DESC, id ASC").
+		Find(&out).Error; err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (r *sharedBudgetRepo) Update(ctx context.Context, b *model.SharedBudget) error {
+	res := r.db.WithContext(ctx).
+		Where("household_id = ?", b.HouseholdID).
+		Save(b)
+	if res.Error != nil {
+		return res.Error
+	}
+	if res.RowsAffected == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+func (r *sharedBudgetRepo) SoftDelete(ctx context.Context, householdID, id int64) error {
+	res := r.db.WithContext(ctx).
+		Where("household_id = ?", householdID).
+		Delete(&model.SharedBudget{}, id)
+	if res.Error != nil {
+		return res.Error
+	}
+	if res.RowsAffected == 0 {
+		return ErrNotFound
+	}
+	return nil
+}

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -85,7 +85,12 @@ func New(cfg config.Config, gormDB *gorm.DB) *gin.Engine {
 		repository.NewInstanceConfigRepository(gormDB),
 		userRepo,
 		cfg.SessionSecret,
-	).WithDB(gormDB)
+	).
+		WithDB(gormDB).
+		WithSharedBudgets(
+			repository.NewSharedBudgetRepository(gormDB),
+			categoryRepo,
+		)
 	householdHandler := handler.NewHouseholdHandler(householdSvc)
 
 	// Now that the household service exists, wire it into auth so the

--- a/backend/internal/service/household/service.go
+++ b/backend/internal/service/household/service.go
@@ -67,6 +67,11 @@ type Service struct {
 	accounts   repository.AccountRepository
 	config     repository.InstanceConfigRepository
 	users      repository.UserRepository
+	// Optional shared_budgets repos — wired via WithSharedBudgets. Nil-safe;
+	// the CreateSharedBudget/etc. paths gate on these being set indirectly
+	// via requireCategoryExists.
+	sharedBudgets repository.SharedBudgetRepository
+	categories    repository.CategoryRepository
 	// db is held for multi-write operations (currently only TransferOwner)
 	// that need atomicity beyond what a single repo call provides.
 	// Nil-safe: methods that don't require it work without it; tests set

--- a/backend/internal/service/household/shared_budgets.go
+++ b/backend/internal/service/household/shared_budgets.go
@@ -1,0 +1,195 @@
+package household
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/shopspring/decimal"
+
+	"github.com/gregwym/offbook/backend/internal/model"
+	"github.com/gregwym/offbook/backend/internal/repository"
+)
+
+// SharedBudgetInput is the validated payload for creating a shared budget.
+// Same shape as the personal-budget input minus user_id (household_id is
+// derived from the path).
+type SharedBudgetInput struct {
+	CategoryID int64
+	Period     string
+	Amount     decimal.Decimal
+	Rollover   *bool
+	IsActive   *bool
+}
+
+// UpdateSharedBudgetInput is a sparse patch.
+type UpdateSharedBudgetInput struct {
+	CategoryID *int64
+	Period     *string
+	Amount     *decimal.Decimal
+	Rollover   *bool
+	IsActive   *bool
+}
+
+// Shared-budget errors complement the household-wide ones in errors.go.
+// We intentionally don't reuse the personal-budget errors (different
+// package boundary, simpler mapping in the handler).
+var (
+	ErrInvalidBudgetPeriod = errors.New("period must be one of: monthly, weekly, annual")
+	ErrInvalidBudgetAmount = errors.New("amount must be > 0")
+	ErrUnknownCategory     = errors.New("category does not exist")
+	ErrBudgetNotFound      = errors.New("shared budget not found")
+)
+
+var validBudgetPeriods = map[string]struct{}{
+	"monthly": {}, "weekly": {}, "annual": {},
+}
+
+// WithSharedBudgets wires the optional repos that the shared-budget CRUD
+// path needs. Returns the receiver so it composes with WithDB.
+func (s *Service) WithSharedBudgets(repo repository.SharedBudgetRepository, categories repository.CategoryRepository) *Service {
+	s.sharedBudgets = repo
+	s.categories = categories
+	return s
+}
+
+// CreateSharedBudget creates a budget owned by the household. Owner or
+// contributor may create; view_only is read-only.
+func (s *Service) CreateSharedBudget(ctx context.Context, userID, householdID int64, in SharedBudgetInput) (*model.SharedBudget, error) {
+	if err := s.requireContributor(ctx, userID, householdID); err != nil {
+		return nil, err
+	}
+	period := strings.TrimSpace(in.Period)
+	if _, ok := validBudgetPeriods[period]; !ok {
+		return nil, ErrInvalidBudgetPeriod
+	}
+	if !in.Amount.IsPositive() {
+		return nil, ErrInvalidBudgetAmount
+	}
+	if err := s.requireCategoryExists(ctx, in.CategoryID); err != nil {
+		return nil, err
+	}
+	b := &model.SharedBudget{
+		HouseholdID: householdID,
+		CategoryID:  in.CategoryID,
+		Period:      period,
+		Amount:      in.Amount,
+		Rollover:    in.Rollover != nil && *in.Rollover,
+		IsActive:    true,
+	}
+	if in.IsActive != nil {
+		b.IsActive = *in.IsActive
+	}
+	if err := s.sharedBudgets.Create(ctx, b); err != nil {
+		return nil, fmt.Errorf("create shared_budget: %w", err)
+	}
+	return b, nil
+}
+
+// ListSharedBudgets returns every shared budget for the household. Any
+// active member may read (matches the read-side aggregator's audience).
+func (s *Service) ListSharedBudgets(ctx context.Context, userID, householdID int64) ([]model.SharedBudget, error) {
+	if _, err := s.members.GetActive(ctx, householdID, userID); err != nil {
+		if errors.Is(err, repository.ErrNotFound) {
+			return nil, ErrNotMember
+		}
+		return nil, err
+	}
+	return s.sharedBudgets.List(ctx, householdID)
+}
+
+// UpdateSharedBudget applies a sparse patch. Owner or contributor may edit.
+func (s *Service) UpdateSharedBudget(ctx context.Context, userID, householdID, id int64, in UpdateSharedBudgetInput) (*model.SharedBudget, error) {
+	if err := s.requireContributor(ctx, userID, householdID); err != nil {
+		return nil, err
+	}
+	b, err := s.sharedBudgets.GetByID(ctx, householdID, id)
+	if err != nil {
+		if errors.Is(err, repository.ErrNotFound) {
+			return nil, ErrBudgetNotFound
+		}
+		return nil, err
+	}
+	if in.CategoryID != nil {
+		if err := s.requireCategoryExists(ctx, *in.CategoryID); err != nil {
+			return nil, err
+		}
+		b.CategoryID = *in.CategoryID
+	}
+	if in.Period != nil {
+		p := strings.TrimSpace(*in.Period)
+		if _, ok := validBudgetPeriods[p]; !ok {
+			return nil, ErrInvalidBudgetPeriod
+		}
+		b.Period = p
+	}
+	if in.Amount != nil {
+		if !in.Amount.IsPositive() {
+			return nil, ErrInvalidBudgetAmount
+		}
+		b.Amount = *in.Amount
+	}
+	if in.Rollover != nil {
+		b.Rollover = *in.Rollover
+	}
+	if in.IsActive != nil {
+		b.IsActive = *in.IsActive
+	}
+	if err := s.sharedBudgets.Update(ctx, b); err != nil {
+		if errors.Is(err, repository.ErrNotFound) {
+			return nil, ErrBudgetNotFound
+		}
+		return nil, fmt.Errorf("update shared_budget: %w", err)
+	}
+	return b, nil
+}
+
+// SoftDeleteSharedBudget removes a budget. Owner or contributor may delete.
+func (s *Service) SoftDeleteSharedBudget(ctx context.Context, userID, householdID, id int64) error {
+	if err := s.requireContributor(ctx, userID, householdID); err != nil {
+		return err
+	}
+	if err := s.sharedBudgets.SoftDelete(ctx, householdID, id); err != nil {
+		if errors.Is(err, repository.ErrNotFound) {
+			return ErrBudgetNotFound
+		}
+		return fmt.Errorf("soft-delete shared_budget: %w", err)
+	}
+	return nil
+}
+
+// requireContributor accepts owner OR contributor; view_only is rejected
+// with ErrForbidden. Non-members get ErrNotMember.
+func (s *Service) requireContributor(ctx context.Context, userID, householdID int64) error {
+	mem, err := s.members.GetActive(ctx, householdID, userID)
+	if err != nil {
+		if errors.Is(err, repository.ErrNotFound) {
+			return ErrNotMember
+		}
+		return err
+	}
+	switch mem.Role {
+	case model.RoleOwner, model.RoleContributor:
+		return nil
+	default:
+		return ErrForbidden
+	}
+}
+
+// requireCategoryExists is a thin guard so we surface a clean error code
+// instead of a foreign-key violation when the caller passes a bad id.
+func (s *Service) requireCategoryExists(ctx context.Context, categoryID int64) error {
+	if s.categories == nil {
+		// Defensive: if WithSharedBudgets wasn't called we'd hit the FK
+		// error path below — but the cleaner thing is to fail early.
+		return ErrUnknownCategory
+	}
+	if _, err := s.categories.GetByID(ctx, categoryID); err != nil {
+		if errors.Is(err, repository.ErrNotFound) {
+			return ErrUnknownCategory
+		}
+		return fmt.Errorf("validate category: %w", err)
+	}
+	return nil
+}

--- a/backend/internal/service/household/shared_budgets_test.go
+++ b/backend/internal/service/household/shared_budgets_test.go
@@ -1,0 +1,338 @@
+package household_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/shopspring/decimal"
+	"gorm.io/gorm"
+
+	"github.com/gregwym/offbook/backend/internal/model"
+	"github.com/gregwym/offbook/backend/internal/repository"
+	"github.com/gregwym/offbook/backend/internal/service/household"
+)
+
+// withSharedBudgets returns a household.Service that has the SharedBudget
+// repos wired. newSvc already calls WithDB; we layer the budget repos on
+// top so older tests don't need to know about them.
+func withSharedBudgets(t *testing.T) (*household.Service, *gorm.DB, *model.Category) {
+	t.Helper()
+	svc, _, g := newSvc(t)
+	svc.WithSharedBudgets(
+		repository.NewSharedBudgetRepository(g),
+		repository.NewCategoryRepository(g),
+	)
+	cat := &model.Category{
+		Name: "SB Test Cat",
+		Slug: fmt.Sprintf("sb-test-%d", time.Now().UnixNano()),
+	}
+	if err := g.Create(cat).Error; err != nil {
+		t.Fatalf("seed category: %v", err)
+	}
+	t.Cleanup(func() {
+		g.Unscoped().Where("category_id = ?", cat.ID).Delete(&model.SharedBudget{})
+		g.Unscoped().Delete(&model.Category{}, cat.ID)
+	})
+	return svc, g, cat
+}
+
+// seedSharedBudgetHousehold spins up a household with one owner and one
+// contributor and returns IDs the tests need.
+func seedSharedBudgetHousehold(t *testing.T, svc *household.Service, g *gorm.DB) (ownerID, contribID, viewOnlyID, householdID int64) {
+	t.Helper()
+	ctx := context.Background()
+	ownerID = seedUser(t, g, "sb-owner")
+	contribID = seedUser(t, g, "sb-contrib")
+	viewOnlyID = seedUser(t, g, "sb-view")
+	hh, err := svc.Create(ctx, ownerID, household.CreateInput{Name: "SB House"})
+	if err != nil {
+		t.Fatalf("create household: %v", err)
+	}
+	cleanupHousehold(t, g, hh.ID)
+
+	contribInv, err := svc.CreateInvite(ctx, ownerID, hh.ID, household.CreateInviteInput{Role: model.RoleContributor})
+	if err != nil {
+		t.Fatalf("invite contrib: %v", err)
+	}
+	if _, err := svc.AcceptInvite(ctx, contribID, contribInv.Token); err != nil {
+		t.Fatalf("accept contrib: %v", err)
+	}
+
+	viewInv, err := svc.CreateInvite(ctx, ownerID, hh.ID, household.CreateInviteInput{Role: model.RoleViewOnly})
+	if err != nil {
+		t.Fatalf("invite view: %v", err)
+	}
+	if _, err := svc.AcceptInvite(ctx, viewOnlyID, viewInv.Token); err != nil {
+		t.Fatalf("accept view: %v", err)
+	}
+	return ownerID, contribID, viewOnlyID, hh.ID
+}
+
+func TestCreateSharedBudget_HappyPath(t *testing.T) {
+	svc, g, cat := withSharedBudgets(t)
+	ownerID, _, _, hhID := seedSharedBudgetHousehold(t, svc, g)
+
+	b, err := svc.CreateSharedBudget(context.Background(), ownerID, hhID, household.SharedBudgetInput{
+		CategoryID: cat.ID,
+		Period:     "monthly",
+		Amount:     decimal.NewFromInt(500),
+	})
+	if err != nil {
+		t.Fatalf("CreateSharedBudget: %v", err)
+	}
+	if b.HouseholdID != hhID {
+		t.Errorf("HouseholdID = %d, want %d", b.HouseholdID, hhID)
+	}
+	if b.CategoryID != cat.ID || b.Period != "monthly" || !b.Amount.Equal(decimal.NewFromInt(500)) {
+		t.Errorf("budget = %+v, want monthly $500 in cat %d", b, cat.ID)
+	}
+	if !b.IsActive {
+		t.Errorf("IsActive = false, want true by default")
+	}
+}
+
+func TestCreateSharedBudget_ContributorAllowed(t *testing.T) {
+	svc, g, cat := withSharedBudgets(t)
+	_, contribID, _, hhID := seedSharedBudgetHousehold(t, svc, g)
+	_, err := svc.CreateSharedBudget(context.Background(), contribID, hhID, household.SharedBudgetInput{
+		CategoryID: cat.ID,
+		Period:     "monthly",
+		Amount:     decimal.NewFromInt(100),
+	})
+	if err != nil {
+		t.Errorf("contributor blocked: %v", err)
+	}
+}
+
+func TestCreateSharedBudget_ViewOnlyForbidden(t *testing.T) {
+	svc, g, cat := withSharedBudgets(t)
+	_, _, viewOnlyID, hhID := seedSharedBudgetHousehold(t, svc, g)
+	_, err := svc.CreateSharedBudget(context.Background(), viewOnlyID, hhID, household.SharedBudgetInput{
+		CategoryID: cat.ID,
+		Period:     "monthly",
+		Amount:     decimal.NewFromInt(100),
+	})
+	if !errors.Is(err, household.ErrForbidden) {
+		t.Fatalf("err = %v, want ErrForbidden", err)
+	}
+}
+
+func TestCreateSharedBudget_NonMemberRejected(t *testing.T) {
+	svc, g, cat := withSharedBudgets(t)
+	_, _, _, hhID := seedSharedBudgetHousehold(t, svc, g)
+	outsiderID := seedUser(t, g, "sb-outsider")
+	_, err := svc.CreateSharedBudget(context.Background(), outsiderID, hhID, household.SharedBudgetInput{
+		CategoryID: cat.ID,
+		Period:     "monthly",
+		Amount:     decimal.NewFromInt(100),
+	})
+	if !errors.Is(err, household.ErrNotMember) {
+		t.Fatalf("err = %v, want ErrNotMember", err)
+	}
+}
+
+func TestCreateSharedBudget_ValidationRejectsBadPeriod(t *testing.T) {
+	svc, g, cat := withSharedBudgets(t)
+	ownerID, _, _, hhID := seedSharedBudgetHousehold(t, svc, g)
+	_, err := svc.CreateSharedBudget(context.Background(), ownerID, hhID, household.SharedBudgetInput{
+		CategoryID: cat.ID,
+		Period:     "fortnightly",
+		Amount:     decimal.NewFromInt(100),
+	})
+	if !errors.Is(err, household.ErrInvalidBudgetPeriod) {
+		t.Fatalf("err = %v, want ErrInvalidBudgetPeriod", err)
+	}
+}
+
+func TestCreateSharedBudget_ValidationRejectsZeroAmount(t *testing.T) {
+	svc, g, cat := withSharedBudgets(t)
+	ownerID, _, _, hhID := seedSharedBudgetHousehold(t, svc, g)
+	_, err := svc.CreateSharedBudget(context.Background(), ownerID, hhID, household.SharedBudgetInput{
+		CategoryID: cat.ID,
+		Period:     "monthly",
+		Amount:     decimal.Zero,
+	})
+	if !errors.Is(err, household.ErrInvalidBudgetAmount) {
+		t.Fatalf("err = %v, want ErrInvalidBudgetAmount", err)
+	}
+}
+
+func TestCreateSharedBudget_UnknownCategory(t *testing.T) {
+	svc, g, _ := withSharedBudgets(t)
+	ownerID, _, _, hhID := seedSharedBudgetHousehold(t, svc, g)
+	_, err := svc.CreateSharedBudget(context.Background(), ownerID, hhID, household.SharedBudgetInput{
+		CategoryID: 999_999_999,
+		Period:     "monthly",
+		Amount:     decimal.NewFromInt(100),
+	})
+	if !errors.Is(err, household.ErrUnknownCategory) {
+		t.Fatalf("err = %v, want ErrUnknownCategory", err)
+	}
+}
+
+func TestListSharedBudgets_MemberReadsAll(t *testing.T) {
+	svc, g, cat := withSharedBudgets(t)
+	ownerID, _, viewOnlyID, hhID := seedSharedBudgetHousehold(t, svc, g)
+
+	if _, err := svc.CreateSharedBudget(context.Background(), ownerID, hhID, household.SharedBudgetInput{
+		CategoryID: cat.ID, Period: "monthly", Amount: decimal.NewFromInt(100),
+	}); err != nil {
+		t.Fatalf("seed budget: %v", err)
+	}
+
+	// View-only can read — read is gated only on membership.
+	got, err := svc.ListSharedBudgets(context.Background(), viewOnlyID, hhID)
+	if err != nil {
+		t.Fatalf("ListSharedBudgets: %v", err)
+	}
+	if len(got) != 1 {
+		t.Errorf("got %d budgets, want 1", len(got))
+	}
+}
+
+func TestListSharedBudgets_NonMemberRejected(t *testing.T) {
+	svc, g, _ := withSharedBudgets(t)
+	_, _, _, hhID := seedSharedBudgetHousehold(t, svc, g)
+	outsiderID := seedUser(t, g, "sb-outsider")
+	_, err := svc.ListSharedBudgets(context.Background(), outsiderID, hhID)
+	if !errors.Is(err, household.ErrNotMember) {
+		t.Fatalf("err = %v, want ErrNotMember", err)
+	}
+}
+
+func TestUpdateSharedBudget_HappyPath(t *testing.T) {
+	svc, g, cat := withSharedBudgets(t)
+	ownerID, _, _, hhID := seedSharedBudgetHousehold(t, svc, g)
+
+	b, err := svc.CreateSharedBudget(context.Background(), ownerID, hhID, household.SharedBudgetInput{
+		CategoryID: cat.ID, Period: "monthly", Amount: decimal.NewFromInt(100),
+	})
+	if err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	newAmount := decimal.NewFromInt(250)
+	newActive := false
+	updated, err := svc.UpdateSharedBudget(context.Background(), ownerID, hhID, b.ID, household.UpdateSharedBudgetInput{
+		Amount:   &newAmount,
+		IsActive: &newActive,
+	})
+	if err != nil {
+		t.Fatalf("UpdateSharedBudget: %v", err)
+	}
+	if !updated.Amount.Equal(decimal.NewFromInt(250)) {
+		t.Errorf("amount = %s, want 250", updated.Amount)
+	}
+	if updated.IsActive {
+		t.Errorf("IsActive = true, want false")
+	}
+}
+
+func TestUpdateSharedBudget_ViewOnlyForbidden(t *testing.T) {
+	svc, g, cat := withSharedBudgets(t)
+	ownerID, _, viewOnlyID, hhID := seedSharedBudgetHousehold(t, svc, g)
+	b, err := svc.CreateSharedBudget(context.Background(), ownerID, hhID, household.SharedBudgetInput{
+		CategoryID: cat.ID, Period: "monthly", Amount: decimal.NewFromInt(100),
+	})
+	if err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	a := decimal.NewFromInt(200)
+	_, err = svc.UpdateSharedBudget(context.Background(), viewOnlyID, hhID, b.ID, household.UpdateSharedBudgetInput{
+		Amount: &a,
+	})
+	if !errors.Is(err, household.ErrForbidden) {
+		t.Fatalf("err = %v, want ErrForbidden", err)
+	}
+}
+
+func TestUpdateSharedBudget_NotFound(t *testing.T) {
+	svc, g, _ := withSharedBudgets(t)
+	ownerID, _, _, hhID := seedSharedBudgetHousehold(t, svc, g)
+	a := decimal.NewFromInt(1)
+	_, err := svc.UpdateSharedBudget(context.Background(), ownerID, hhID, 999_999, household.UpdateSharedBudgetInput{
+		Amount: &a,
+	})
+	if !errors.Is(err, household.ErrBudgetNotFound) {
+		t.Fatalf("err = %v, want ErrBudgetNotFound", err)
+	}
+}
+
+func TestSoftDeleteSharedBudget_HappyPath(t *testing.T) {
+	svc, g, cat := withSharedBudgets(t)
+	ownerID, _, _, hhID := seedSharedBudgetHousehold(t, svc, g)
+	b, err := svc.CreateSharedBudget(context.Background(), ownerID, hhID, household.SharedBudgetInput{
+		CategoryID: cat.ID, Period: "monthly", Amount: decimal.NewFromInt(100),
+	})
+	if err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	if err := svc.SoftDeleteSharedBudget(context.Background(), ownerID, hhID, b.ID); err != nil {
+		t.Fatalf("SoftDelete: %v", err)
+	}
+	got, err := svc.ListSharedBudgets(context.Background(), ownerID, hhID)
+	if err != nil {
+		t.Fatalf("list after delete: %v", err)
+	}
+	for _, row := range got {
+		if row.ID == b.ID {
+			t.Errorf("budget %d still in list after delete", b.ID)
+		}
+	}
+}
+
+func TestSoftDeleteSharedBudget_ViewOnlyForbidden(t *testing.T) {
+	svc, g, cat := withSharedBudgets(t)
+	ownerID, _, viewOnlyID, hhID := seedSharedBudgetHousehold(t, svc, g)
+	b, err := svc.CreateSharedBudget(context.Background(), ownerID, hhID, household.SharedBudgetInput{
+		CategoryID: cat.ID, Period: "monthly", Amount: decimal.NewFromInt(100),
+	})
+	if err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	err = svc.SoftDeleteSharedBudget(context.Background(), viewOnlyID, hhID, b.ID)
+	if !errors.Is(err, household.ErrForbidden) {
+		t.Fatalf("err = %v, want ErrForbidden", err)
+	}
+}
+
+// TestSharedBudget_TenantIsolation: a member of household A cannot read,
+// edit, or delete a budget in household B.
+func TestSharedBudget_TenantIsolation(t *testing.T) {
+	svc, g, catA := withSharedBudgets(t)
+	ownerA, _, _, hhA := seedSharedBudgetHousehold(t, svc, g)
+
+	// Spin up an independent household B.
+	ctx := context.Background()
+	ownerB := seedUser(t, g, "sb-ownerB")
+	hhB, err := svc.Create(ctx, ownerB, household.CreateInput{Name: "Other House"})
+	if err != nil {
+		t.Fatalf("create B: %v", err)
+	}
+	cleanupHousehold(t, g, hhB.ID)
+
+	bA, err := svc.CreateSharedBudget(ctx, ownerA, hhA, household.SharedBudgetInput{
+		CategoryID: catA.ID, Period: "monthly", Amount: decimal.NewFromInt(100),
+	})
+	if err != nil {
+		t.Fatalf("seed A: %v", err)
+	}
+
+	// Owner B tries to update A's budget by hitting A's household id with
+	// a wrong session — but they aren't a member of A, so ErrNotMember.
+	a := decimal.NewFromInt(99)
+	_, err = svc.UpdateSharedBudget(ctx, ownerB, hhA, bA.ID, household.UpdateSharedBudgetInput{Amount: &a})
+	if !errors.Is(err, household.ErrNotMember) {
+		t.Errorf("cross-tenant update err = %v, want ErrNotMember", err)
+	}
+
+	// Same household_id but wrong: owner B uses their OWN household id to
+	// try and update A's budget id. Should be ErrBudgetNotFound (budget
+	// doesn't exist in B's household scope).
+	_, err = svc.UpdateSharedBudget(ctx, ownerB, hhB.ID, bA.ID, household.UpdateSharedBudgetInput{Amount: &a})
+	if !errors.Is(err, household.ErrBudgetNotFound) {
+		t.Errorf("scoped-to-wrong-household err = %v, want ErrBudgetNotFound", err)
+	}
+}

--- a/frontend/src/api/householdAggregator.ts
+++ b/frontend/src/api/householdAggregator.ts
@@ -1,10 +1,23 @@
-import { apiClient, type ApiItem } from './client'
-import type { HouseholdDashboard, HouseholdPeriodKey } from '../types/householdAggregator'
+import { apiClient, type ApiItem, type ApiList } from './client'
+import type {
+  BudgetPaceItem,
+  HouseholdDashboard,
+  HouseholdPeriodKey,
+} from '../types/householdAggregator'
 
 export async function getHouseholdDashboard(
   period: HouseholdPeriodKey = 'current_month',
 ): Promise<HouseholdDashboard> {
   const res = await apiClient.get<ApiItem<HouseholdDashboard>>('/h/dashboard', {
+    params: { period },
+  })
+  return res.data.data
+}
+
+export async function getBudgetPace(
+  period: HouseholdPeriodKey = 'current_month',
+): Promise<BudgetPaceItem[]> {
+  const res = await apiClient.get<ApiList<BudgetPaceItem>>('/h/budgets/pace', {
     params: { period },
   })
   return res.data.data

--- a/frontend/src/api/households.ts
+++ b/frontend/src/api/households.ts
@@ -1,11 +1,14 @@
-import { apiClient, type ApiItem } from './client'
+import { apiClient, type ApiItem, type ApiList } from './client'
 import type {
   CreateInviteResult,
+  CreateSharedBudgetInput,
   Household,
   HouseholdDetail,
   HouseholdMember,
   HouseholdRole,
   MembersListing,
+  SharedBudget,
+  UpdateSharedBudgetInput,
 } from '../types/household'
 
 export async function getHousehold(id: number): Promise<HouseholdDetail> {
@@ -74,4 +77,36 @@ export async function removeMember(householdID: number, userID: number): Promise
 
 export async function transferOwner(householdID: number, userID: number): Promise<void> {
   await apiClient.post(`/households/${householdID}/transfer-owner`, { user_id: userID })
+}
+
+export async function listSharedBudgets(householdID: number): Promise<SharedBudget[]> {
+  const res = await apiClient.get<ApiList<SharedBudget>>(`/households/${householdID}/shared-budgets`)
+  return res.data.data
+}
+
+export async function createSharedBudget(
+  householdID: number,
+  input: CreateSharedBudgetInput,
+): Promise<SharedBudget> {
+  const res = await apiClient.post<ApiItem<SharedBudget>>(
+    `/households/${householdID}/shared-budgets`,
+    input,
+  )
+  return res.data.data
+}
+
+export async function updateSharedBudget(
+  householdID: number,
+  budgetID: number,
+  input: UpdateSharedBudgetInput,
+): Promise<SharedBudget> {
+  const res = await apiClient.patch<ApiItem<SharedBudget>>(
+    `/households/${householdID}/shared-budgets/${budgetID}`,
+    input,
+  )
+  return res.data.data
+}
+
+export async function deleteSharedBudget(householdID: number, budgetID: number): Promise<void> {
+  await apiClient.delete(`/households/${householdID}/shared-budgets/${budgetID}`)
 }

--- a/frontend/src/pages/HouseholdBudgetsPage.tsx
+++ b/frontend/src/pages/HouseholdBudgetsPage.tsx
@@ -1,5 +1,373 @@
-import { PageStub } from '../components/PageStub'
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { Pencil, Plus, Target, Trash2 } from 'lucide-react'
+import { AmountDisplay } from '../components/AmountDisplay'
+import {
+  createSharedBudget,
+  deleteSharedBudget,
+  listSharedBudgets,
+  updateSharedBudget,
+} from '../api/households'
+import { getBudgetPace } from '../api/householdAggregator'
+import { useCategoriesStore } from '../store/categoriesStore'
+import { useHouseholdStore } from '../store/householdStore'
+import { useScopeStore } from '../store/scopeStore'
+import type { Category } from '../types/category'
+import type {
+  CreateSharedBudgetInput,
+  SharedBudget,
+  UpdateSharedBudgetInput,
+} from '../types/household'
+import type { BudgetPaceItem } from '../types/householdAggregator'
+
+const PERIODS = ['monthly', 'weekly', 'annual'] as const
 
 export function HouseholdBudgetsPage() {
-  return <PageStub title="Household Budgets" description="Shared budgets CRUD coming later." />
+  const { householdId } = useScopeStore()
+  const { detail, load: loadDetail } = useHouseholdStore()
+  const { categories, fetch: fetchCategories } = useCategoriesStore()
+
+  const [budgets, setBudgets] = useState<SharedBudget[]>([])
+  const [pace, setPace] = useState<BudgetPaceItem[]>([])
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [adding, setAdding] = useState(false)
+  const [editing, setEditing] = useState<SharedBudget | null>(null)
+
+  const reload = useCallback(() => {
+    if (householdId == null) return Promise.resolve()
+    return Promise.all([listSharedBudgets(householdId), getBudgetPace('current_month')])
+      .then(([bs, p]) => {
+        setBudgets(bs)
+        setPace(p)
+        setError(null)
+      })
+      .catch((e: unknown) => setError(errMsg(e)))
+      .finally(() => setLoading(false))
+  }, [householdId])
+
+  useEffect(() => {
+    if (householdId != null) {
+      void loadDetail(householdId)
+      void fetchCategories()
+      void reload()
+    }
+  }, [householdId, loadDetail, fetchCategories, reload])
+
+  const paceByBudget = useMemo(() => {
+    const m = new Map<number, BudgetPaceItem>()
+    for (const p of pace) m.set(p.budget_id, p)
+    return m
+  }, [pace])
+
+  const categoryName = useCallback(
+    (id: number) => categories.find((c) => c.id === id)?.name ?? `category #${id}`,
+    [categories],
+  )
+
+  if (householdId == null) {
+    return (
+      <div className="rounded-lg border border-gray-200 bg-white p-8 text-center">
+        <Target size={28} className="mx-auto text-gray-300 mb-2" />
+        <h1 className="text-base font-medium text-gray-900">No household yet</h1>
+        <p className="text-sm text-gray-500 mt-1">
+          Use the scope switcher in the sidebar to create or join a household.
+        </p>
+      </div>
+    )
+  }
+
+  // Only owner + contributor can mutate. The backend re-checks this; the
+  // UI gate just hides controls that would 403.
+  const canMutate = detail?.role === 'owner' || detail?.role === 'contributor'
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold text-gray-900">Shared budgets</h1>
+          <p className="mt-1 text-sm text-gray-500">
+            Household-wide spending envelopes. Pace shown for the current month.
+          </p>
+        </div>
+        {canMutate && (
+          <button
+            type="button"
+            onClick={() => setAdding(true)}
+            className="inline-flex items-center gap-2 rounded-md bg-indigo-600 px-3 py-2 text-sm font-medium text-white hover:bg-indigo-700"
+          >
+            <Plus size={16} /> New shared budget
+          </button>
+        )}
+      </div>
+
+      {error && (
+        <div className="flex items-start justify-between rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
+          <span>{error}</span>
+          <button type="button" onClick={() => setError(null)} className="ml-3 text-red-600 hover:text-red-800">×</button>
+        </div>
+      )}
+
+      <section className="rounded-lg border border-gray-200 bg-white">
+        {loading && budgets.length === 0 && (
+          <div className="px-5 py-6 text-center text-sm text-gray-400">Loading…</div>
+        )}
+        {!loading && budgets.length === 0 && (
+          <div className="px-5 py-6 text-center text-sm text-gray-400">
+            No shared budgets yet.{' '}
+            {canMutate ? 'Create one to start tracking household spending.' : 'Ask an owner or contributor to create one.'}
+          </div>
+        )}
+        <div className="divide-y divide-gray-100">
+          {budgets.map((b) => {
+            const p = paceByBudget.get(b.id)
+            const paceNum = p ? Number.parseFloat(p.pace) : 0
+            const overBudget = paceNum >= 1
+            const warning = paceNum >= 0.8 && paceNum < 1
+            return (
+              <div key={b.id} className="flex items-center justify-between gap-4 px-5 py-3">
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-center gap-2">
+                    <span className="font-medium text-gray-900 truncate">{categoryName(b.category_id)}</span>
+                    {!b.is_active && (
+                      <span className="rounded-full bg-gray-100 px-2 py-0.5 text-[11px] font-medium text-gray-600">paused</span>
+                    )}
+                  </div>
+                  <div className="mt-0.5 text-xs text-gray-500">
+                    {b.period} · limit <AmountDisplay amount={b.amount} />
+                  </div>
+                </div>
+                <div className="text-right">
+                  {p ? (
+                    <>
+                      <div
+                        className={[
+                          'text-sm font-medium',
+                          overBudget ? 'text-red-700' : warning ? 'text-amber-700' : 'text-gray-900',
+                        ].join(' ')}
+                      >
+                        <AmountDisplay amount={p.spent} /> <span className="text-gray-400">/</span>{' '}
+                        <AmountDisplay amount={p.budget} />
+                      </div>
+                      <div className="text-[11px] text-gray-500">
+                        {Math.round(paceNum * 100)}% of budget
+                      </div>
+                    </>
+                  ) : (
+                    <div className="text-xs text-gray-400">no spend yet</div>
+                  )}
+                </div>
+                {canMutate && (
+                  <div className="flex shrink-0 gap-1">
+                    <button
+                      type="button"
+                      onClick={() => setEditing(b)}
+                      aria-label="Edit"
+                      className="rounded p-1 text-gray-500 hover:bg-gray-100 hover:text-gray-900"
+                    >
+                      <Pencil size={14} />
+                    </button>
+                    <button
+                      type="button"
+                      onClick={async () => {
+                        if (!householdId) return
+                        if (!window.confirm(`Delete shared budget "${categoryName(b.category_id)}"?`)) return
+                        try {
+                          await deleteSharedBudget(householdId, b.id)
+                          await reload()
+                        } catch (e) {
+                          setError(errMsg(e))
+                        }
+                      }}
+                      aria-label="Delete"
+                      className="rounded p-1 text-gray-500 hover:bg-red-50 hover:text-red-700"
+                    >
+                      <Trash2 size={14} />
+                    </button>
+                  </div>
+                )}
+              </div>
+            )
+          })}
+        </div>
+      </section>
+
+      {(adding || editing) && (
+        <BudgetFormModal
+          mode={editing ? 'edit' : 'create'}
+          initial={editing}
+          categories={categories}
+          onClose={() => {
+            setAdding(false)
+            setEditing(null)
+          }}
+          onSubmit={async (input, id) => {
+            if (!householdId) return
+            try {
+              if (editing && id != null) {
+                await updateSharedBudget(householdId, id, input as UpdateSharedBudgetInput)
+              } else {
+                await createSharedBudget(householdId, input as CreateSharedBudgetInput)
+              }
+              await reload()
+              setAdding(false)
+              setEditing(null)
+            } catch (e) {
+              setError(errMsg(e))
+            }
+          }}
+        />
+      )}
+    </div>
+  )
+}
+
+function BudgetFormModal({
+  mode,
+  initial,
+  categories,
+  onClose,
+  onSubmit,
+}: {
+  mode: 'create' | 'edit'
+  initial: SharedBudget | null
+  categories: Category[]
+  onClose: () => void
+  onSubmit: (input: CreateSharedBudgetInput | UpdateSharedBudgetInput, id?: number) => Promise<void>
+}) {
+  const [categoryID, setCategoryID] = useState<number>(initial?.category_id ?? categories[0]?.id ?? 0)
+  const [period, setPeriod] = useState<(typeof PERIODS)[number]>(initial?.period ?? 'monthly')
+  const [amount, setAmount] = useState(initial?.amount ?? '0')
+  const [isActive, setIsActive] = useState(initial?.is_active ?? true)
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setError(null)
+    setSubmitting(true)
+    try {
+      if (mode === 'edit' && initial) {
+        await onSubmit(
+          {
+            category_id: categoryID,
+            period,
+            amount,
+            is_active: isActive,
+          },
+          initial.id,
+        )
+      } else {
+        await onSubmit({
+          category_id: categoryID,
+          period,
+          amount,
+          is_active: isActive,
+        })
+      }
+    } catch (e) {
+      setError(errMsg(e))
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
+      role="dialog"
+      aria-modal="true"
+      onClick={onClose}
+    >
+      <form
+        onClick={(e) => e.stopPropagation()}
+        onSubmit={submit}
+        className="w-full max-w-md rounded-lg bg-white shadow-xl"
+      >
+        <div className="border-b border-gray-200 px-5 py-3">
+          <h3 className="text-base font-medium text-gray-900">
+            {mode === 'edit' ? 'Edit shared budget' : 'New shared budget'}
+          </h3>
+        </div>
+        <div className="px-5 py-4 space-y-4">
+          <label className="block text-sm">
+            <div className="font-medium text-gray-700 mb-1">Category</div>
+            <select
+              value={categoryID || ''}
+              onChange={(e) => setCategoryID(Number.parseInt(e.target.value, 10))}
+              required
+              className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-indigo-500 focus:outline-none"
+            >
+              <option value="" disabled>
+                Select a category
+              </option>
+              {categories.map((c) => (
+                <option key={c.id} value={c.id}>
+                  {c.name}
+                </option>
+              ))}
+            </select>
+          </label>
+          <div className="grid grid-cols-2 gap-3">
+            <label className="block text-sm">
+              <div className="font-medium text-gray-700 mb-1">Period</div>
+              <select
+                value={period}
+                onChange={(e) => setPeriod(e.target.value as (typeof PERIODS)[number])}
+                className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-indigo-500 focus:outline-none"
+              >
+                {PERIODS.map((p) => (
+                  <option key={p} value={p}>
+                    {p}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label className="block text-sm">
+              <div className="font-medium text-gray-700 mb-1">Amount</div>
+              <input
+                type="text"
+                inputMode="decimal"
+                required
+                value={amount}
+                onChange={(e) => setAmount(e.target.value)}
+                className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-indigo-500 focus:outline-none"
+              />
+            </label>
+          </div>
+          <label className="flex items-center gap-2 text-sm">
+            <input type="checkbox" checked={isActive} onChange={(e) => setIsActive(e.target.checked)} />
+            Active
+          </label>
+          {error && (
+            <div className="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-xs text-red-700">{error}</div>
+          )}
+        </div>
+        <div className="flex items-center justify-end gap-2 border-t border-gray-200 px-5 py-3">
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-md border border-gray-300 px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50"
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            disabled={submitting || !categoryID}
+            className="rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-indigo-700 disabled:opacity-40"
+          >
+            {submitting ? 'Saving…' : mode === 'edit' ? 'Save' : 'Create'}
+          </button>
+        </div>
+      </form>
+    </div>
+  )
+}
+
+function errMsg(err: unknown): string {
+  if (err && typeof err === 'object' && 'response' in err) {
+    const r = (err as { response?: { data?: { error?: string } } }).response
+    if (r?.data?.error) return r.data.error
+  }
+  if (err instanceof Error) return err.message
+  return 'request failed'
 }

--- a/frontend/src/types/household.ts
+++ b/frontend/src/types/household.ts
@@ -53,3 +53,32 @@ export type CreateInviteResult = {
   invite: HouseholdInvite
   token: string
 }
+
+// SharedBudget mirrors backend model.SharedBudget.
+export type SharedBudget = {
+  id: number
+  household_id: number
+  category_id: number
+  period: 'monthly' | 'weekly' | 'annual'
+  amount: string
+  rollover: boolean
+  is_active: boolean
+  created_at: string
+  updated_at: string
+}
+
+export type CreateSharedBudgetInput = {
+  category_id: number
+  period: 'monthly' | 'weekly' | 'annual'
+  amount: string
+  rollover?: boolean
+  is_active?: boolean
+}
+
+export type UpdateSharedBudgetInput = {
+  category_id?: number
+  period?: 'monthly' | 'weekly' | 'annual'
+  amount?: string
+  rollover?: boolean
+  is_active?: boolean
+}

--- a/frontend/src/types/householdAggregator.ts
+++ b/frontend/src/types/householdAggregator.ts
@@ -22,6 +22,16 @@ export type HouseholdMemberContribution = {
   account_count: number
 }
 
+// BudgetPaceItem mirrors service/household.BudgetPaceItem.
+export type BudgetPaceItem = {
+  budget_id: number
+  category_id: number
+  period: 'monthly' | 'weekly' | 'annual'
+  budget: string
+  spent: string
+  pace: string // ratio 0..N (1.0 = on budget)
+}
+
 export type HouseholdDashboard = {
   period: HouseholdPeriod
   net_worth: string


### PR DESCRIPTION
## Summary
Closes the M2.5 "Out of scope (deferred)" item for shared budgets.

**Backend**
- `repository.SharedBudgetRepository` for household-scoped CRUD (the aggregator's existing read view is kept untouched).
- `service/household.SharedBudgetInput` / `UpdateSharedBudgetInput`; `CreateSharedBudget`, `ListSharedBudgets`, `UpdateSharedBudget`, `SoftDeleteSharedBudget`. Mutating paths gate on `requireContributor` (owner or contributor); reading on membership. Validation rejects bad periods, non-positive amounts, and unknown categories — clean error codes (`INVALID_BUDGET`, `UNKNOWN_CATEGORY`, `BUDGET_NOT_FOUND`).
- New routes under the existing `/households/:id` group.
- `Service.WithSharedBudgets(repo, categoryRepo)` setter wires the optional dependencies in the router.
- 13 integration tests cover happy path, contributor-vs-view-only role gating, non-member rejection, validation (bad period / zero amount / unknown category), update + delete + scoping (a sibling household's owner cannot mutate budgets in this household).

**Frontend**
- `HouseholdBudgetsPage` replaces the PageStub. Lists shared budgets paired with current-month pace from the existing `/h/budgets/pace` endpoint; owner + contributor see the New/Edit/Delete controls (view-only sees the list only). Color-coded pace text (green / amber at 80% / red at 100%+).
- Modal create + edit form. Period (monthly/weekly/annual), category, amount, active toggle.

## Test plan
- [x] `go test -race -p 1 ./...` — full backend green; new 13 tests pass.
- [x] `pnpm lint && pnpm build` — frontend clean.
- [ ] Manual: owner creates two shared budgets; spending in `balance_and_txns` accounts shows up in Pace.
- [ ] Manual: view-only member sees no controls; backend rejects a curl PATCH.
- [ ] Manual: a non-member can't list budgets in another household.

Closes #163