### PR TITLE
feat(household): shared_goals CRUD + /h/goals page (#165)

### DIFF
--- a/backend/internal/handler/household_handler.go
+++ b/backend/internal/handler/household_handler.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"net/http"
 	"strconv"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/shopspring/decimal"
@@ -48,6 +49,11 @@ func (h *HouseholdHandler) Register(g *gin.RouterGroup) {
 	g.GET("/households/:id/shared-budgets", h.ListSharedBudgets)
 	g.PATCH("/households/:id/shared-budgets/:budgetID", h.UpdateSharedBudget)
 	g.DELETE("/households/:id/shared-budgets/:budgetID", h.DeleteSharedBudget)
+	g.POST("/households/:id/shared-goals", h.CreateSharedGoal)
+	g.GET("/households/:id/shared-goals", h.ListSharedGoals)
+	g.PATCH("/households/:id/shared-goals/:goalID", h.UpdateSharedGoal)
+	g.DELETE("/households/:id/shared-goals/:goalID", h.DeleteSharedGoal)
+	g.POST("/households/:id/shared-goals/:goalID/contributions", h.ContributeToSharedGoal)
 
 	g.GET("/accounts/:id/shares", h.ListShares)
 	g.PUT("/accounts/:id/shares/:householdID", h.SetShare)
@@ -95,6 +101,23 @@ type updateSharedBudgetRequest struct {
 	Amount     *decimal.Decimal `json:"amount"`
 	Rollover   *bool            `json:"rollover"`
 	IsActive   *bool            `json:"is_active"`
+}
+
+type createSharedGoalRequest struct {
+	Name         string          `json:"name"`
+	TargetAmount decimal.Decimal `json:"target_amount"`
+	TargetDate   *string         `json:"target_date"` // YYYY-MM-DD
+}
+
+type updateSharedGoalRequest struct {
+	Name            *string          `json:"name"`
+	TargetAmount    *decimal.Decimal `json:"target_amount"`
+	TargetDate      *string          `json:"target_date"`
+	ClearTargetDate bool             `json:"clear_target_date"`
+}
+
+type sharedGoalContributionRequest struct {
+	Amount decimal.Decimal `json:"amount"`
 }
 
 // --- handlers ---
@@ -362,6 +385,125 @@ func (h *HouseholdHandler) DeleteSharedBudget(c *gin.Context) {
 	c.Status(http.StatusNoContent)
 }
 
+func (h *HouseholdHandler) CreateSharedGoal(c *gin.Context) {
+	id, ok := parseID(c)
+	if !ok {
+		return
+	}
+	var req createSharedGoalRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error(), "code": "INVALID_REQUEST"})
+		return
+	}
+	in := household.SharedGoalInput{
+		Name:         req.Name,
+		TargetAmount: req.TargetAmount,
+	}
+	if req.TargetDate != nil && *req.TargetDate != "" {
+		d, err := time.Parse("2006-01-02", *req.TargetDate)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "target_date must be YYYY-MM-DD", "code": "INVALID_REQUEST"})
+			return
+		}
+		in.TargetDate = &d
+	}
+	g, err := h.svc.CreateSharedGoal(c.Request.Context(), auth.MustUserID(c.Request.Context()), id, in)
+	if err != nil {
+		h.writeError(c, err)
+		return
+	}
+	c.JSON(http.StatusCreated, gin.H{"data": g})
+}
+
+func (h *HouseholdHandler) ListSharedGoals(c *gin.Context) {
+	id, ok := parseID(c)
+	if !ok {
+		return
+	}
+	out, err := h.svc.ListSharedGoals(c.Request.Context(), auth.MustUserID(c.Request.Context()), id)
+	if err != nil {
+		h.writeError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"data": out, "total": int64(len(out))})
+}
+
+func (h *HouseholdHandler) UpdateSharedGoal(c *gin.Context) {
+	id, ok := parseID(c)
+	if !ok {
+		return
+	}
+	goalID, err := strconv.ParseInt(c.Param("goalID"), 10, 64)
+	if err != nil || goalID <= 0 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "goalID must be a positive integer", "code": "INVALID_REQUEST"})
+		return
+	}
+	var req updateSharedGoalRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error(), "code": "INVALID_REQUEST"})
+		return
+	}
+	in := household.UpdateSharedGoalInput{
+		Name:            req.Name,
+		TargetAmount:    req.TargetAmount,
+		ClearTargetDate: req.ClearTargetDate,
+	}
+	if req.TargetDate != nil && *req.TargetDate != "" {
+		d, err := time.Parse("2006-01-02", *req.TargetDate)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "target_date must be YYYY-MM-DD", "code": "INVALID_REQUEST"})
+			return
+		}
+		in.TargetDate = &d
+	}
+	g, err := h.svc.UpdateSharedGoal(c.Request.Context(), auth.MustUserID(c.Request.Context()), id, goalID, in)
+	if err != nil {
+		h.writeError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"data": g})
+}
+
+func (h *HouseholdHandler) DeleteSharedGoal(c *gin.Context) {
+	id, ok := parseID(c)
+	if !ok {
+		return
+	}
+	goalID, err := strconv.ParseInt(c.Param("goalID"), 10, 64)
+	if err != nil || goalID <= 0 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "goalID must be a positive integer", "code": "INVALID_REQUEST"})
+		return
+	}
+	if err := h.svc.SoftDeleteSharedGoal(c.Request.Context(), auth.MustUserID(c.Request.Context()), id, goalID); err != nil {
+		h.writeError(c, err)
+		return
+	}
+	c.Status(http.StatusNoContent)
+}
+
+func (h *HouseholdHandler) ContributeToSharedGoal(c *gin.Context) {
+	id, ok := parseID(c)
+	if !ok {
+		return
+	}
+	goalID, err := strconv.ParseInt(c.Param("goalID"), 10, 64)
+	if err != nil || goalID <= 0 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "goalID must be a positive integer", "code": "INVALID_REQUEST"})
+		return
+	}
+	var req sharedGoalContributionRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error(), "code": "INVALID_REQUEST"})
+		return
+	}
+	g, err := h.svc.ContributeToSharedGoal(c.Request.Context(), auth.MustUserID(c.Request.Context()), id, goalID, req.Amount)
+	if err != nil {
+		h.writeError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"data": g})
+}
+
 func (h *HouseholdHandler) ListShares(c *gin.Context) {
 	id, ok := parseID(c)
 	if !ok {
@@ -429,11 +571,17 @@ func (h *HouseholdHandler) writeError(c *gin.Context, err error) {
 		c.JSON(http.StatusGone, gin.H{"error": err.Error(), "code": "INVITE_EXPIRED"})
 	case errors.Is(err, household.ErrBudgetNotFound):
 		c.JSON(http.StatusNotFound, gin.H{"error": err.Error(), "code": "BUDGET_NOT_FOUND"})
+	case errors.Is(err, household.ErrSharedGoalNotFound):
+		c.JSON(http.StatusNotFound, gin.H{"error": err.Error(), "code": "GOAL_NOT_FOUND"})
 	case errors.Is(err, household.ErrUnknownCategory):
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error(), "code": "UNKNOWN_CATEGORY"})
 	case errors.Is(err, household.ErrInvalidBudgetPeriod),
 		errors.Is(err, household.ErrInvalidBudgetAmount):
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error(), "code": "INVALID_BUDGET"})
+	case errors.Is(err, household.ErrSharedGoalEmptyName),
+		errors.Is(err, household.ErrSharedGoalInvalidTarget),
+		errors.Is(err, household.ErrSharedGoalZeroContribution):
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error(), "code": "INVALID_GOAL"})
 	case errors.Is(err, household.ErrEmptyName),
 		errors.Is(err, household.ErrInvalidRole),
 		errors.Is(err, household.ErrInvalidGrace),

--- a/backend/internal/repository/shared_goal_repo.go
+++ b/backend/internal/repository/shared_goal_repo.go
@@ -1,0 +1,107 @@
+package repository
+
+import (
+	"context"
+	"errors"
+
+	"github.com/shopspring/decimal"
+	"gorm.io/gorm"
+
+	"github.com/gregwym/offbook/backend/internal/model"
+)
+
+// SharedGoalRepository is the data-access contract for shared_goals.
+// Reads/writes are scoped by household_id; the household service is the
+// only caller and enforces membership/role.
+type SharedGoalRepository interface {
+	Create(ctx context.Context, g *model.SharedGoal) error
+	GetByID(ctx context.Context, householdID, id int64) (*model.SharedGoal, error)
+	List(ctx context.Context, householdID int64) ([]model.SharedGoal, error)
+	Update(ctx context.Context, g *model.SharedGoal) error
+	SoftDelete(ctx context.Context, householdID, id int64) error
+	// AddContribution atomically adds delta to current_amount. Returns
+	// the post-update row; ErrNotFound when the goal is gone (soft-
+	// deleted or wrong household).
+	AddContribution(ctx context.Context, householdID, id int64, delta decimal.Decimal) (*model.SharedGoal, error)
+}
+
+type sharedGoalRepo struct {
+	db *gorm.DB
+}
+
+func NewSharedGoalRepository(db *gorm.DB) SharedGoalRepository {
+	return &sharedGoalRepo{db: db}
+}
+
+func (r *sharedGoalRepo) Create(ctx context.Context, g *model.SharedGoal) error {
+	return r.db.WithContext(ctx).Create(g).Error
+}
+
+func (r *sharedGoalRepo) GetByID(ctx context.Context, householdID, id int64) (*model.SharedGoal, error) {
+	var g model.SharedGoal
+	if err := r.db.WithContext(ctx).
+		Where("household_id = ?", householdID).
+		First(&g, id).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, ErrNotFound
+		}
+		return nil, err
+	}
+	return &g, nil
+}
+
+func (r *sharedGoalRepo) List(ctx context.Context, householdID int64) ([]model.SharedGoal, error) {
+	var out []model.SharedGoal
+	if err := r.db.WithContext(ctx).
+		Where("household_id = ?", householdID).
+		Order("id ASC").
+		Find(&out).Error; err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (r *sharedGoalRepo) Update(ctx context.Context, g *model.SharedGoal) error {
+	res := r.db.WithContext(ctx).
+		Where("household_id = ?", g.HouseholdID).
+		Save(g)
+	if res.Error != nil {
+		return res.Error
+	}
+	if res.RowsAffected == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+func (r *sharedGoalRepo) SoftDelete(ctx context.Context, householdID, id int64) error {
+	res := r.db.WithContext(ctx).
+		Where("household_id = ?", householdID).
+		Delete(&model.SharedGoal{}, id)
+	if res.Error != nil {
+		return res.Error
+	}
+	if res.RowsAffected == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+func (r *sharedGoalRepo) AddContribution(ctx context.Context, householdID, id int64, delta decimal.Decimal) (*model.SharedGoal, error) {
+	// Mirror personal savings_goal AddContribution — single UPDATE so
+	// concurrent contributions serialize on the row.
+	res := r.db.WithContext(ctx).
+		Model(&model.SharedGoal{}).
+		Where("household_id = ? AND id = ? AND deleted_at IS NULL", householdID, id).
+		Updates(map[string]interface{}{
+			"current_amount": gorm.Expr("current_amount + ?", delta),
+			"updated_at":     gorm.Expr("NOW()"),
+		})
+	if res.Error != nil {
+		return nil, res.Error
+	}
+	if res.RowsAffected == 0 {
+		return nil, ErrNotFound
+	}
+	return r.GetByID(ctx, householdID, id)
+}

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -90,7 +90,8 @@ func New(cfg config.Config, gormDB *gorm.DB) *gin.Engine {
 		WithSharedBudgets(
 			repository.NewSharedBudgetRepository(gormDB),
 			categoryRepo,
-		)
+		).
+		WithSharedGoals(repository.NewSharedGoalRepository(gormDB))
 	householdHandler := handler.NewHouseholdHandler(householdSvc)
 
 	// Now that the household service exists, wire it into auth so the

--- a/backend/internal/service/household/service.go
+++ b/backend/internal/service/household/service.go
@@ -72,6 +72,10 @@ type Service struct {
 	// via requireCategoryExists.
 	sharedBudgets repository.SharedBudgetRepository
 	categories    repository.CategoryRepository
+	// Optional shared_goals repo — wired via WithSharedGoals. Nil-safe in
+	// the same way; the goal CRUD methods are only reachable through the
+	// router, which always wires them.
+	sharedGoals repository.SharedGoalRepository
 	// db is held for multi-write operations (currently only TransferOwner)
 	// that need atomicity beyond what a single repo call provides.
 	// Nil-safe: methods that don't require it work without it; tests set

--- a/backend/internal/service/household/shared_goals.go
+++ b/backend/internal/service/household/shared_goals.go
@@ -1,0 +1,157 @@
+package household
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/shopspring/decimal"
+
+	"github.com/gregwym/offbook/backend/internal/model"
+	"github.com/gregwym/offbook/backend/internal/repository"
+)
+
+// SharedGoalInput is the validated payload for creating a shared goal.
+type SharedGoalInput struct {
+	Name         string
+	TargetAmount decimal.Decimal
+	TargetDate   *time.Time
+}
+
+// UpdateSharedGoalInput is a sparse patch. ClearTargetDate=true removes
+// the existing date — mirrors the personal SavingsGoal API.
+type UpdateSharedGoalInput struct {
+	Name            *string
+	TargetAmount    *decimal.Decimal
+	TargetDate      *time.Time
+	ClearTargetDate bool
+}
+
+// Shared-goal errors complement the household-wide ones in errors.go.
+var (
+	ErrSharedGoalNotFound         = errors.New("shared goal not found")
+	ErrSharedGoalEmptyName        = errors.New("name must not be empty")
+	ErrSharedGoalInvalidTarget    = errors.New("target_amount must be > 0")
+	ErrSharedGoalZeroContribution = errors.New("contribution amount must not be zero")
+)
+
+// WithSharedGoals wires the optional repo that the shared-goal CRUD path
+// needs. Returns the receiver so it composes with WithDB / WithSharedBudgets.
+func (s *Service) WithSharedGoals(repo repository.SharedGoalRepository) *Service {
+	s.sharedGoals = repo
+	return s
+}
+
+// CreateSharedGoal creates a goal owned by the household. Owner or
+// contributor may create.
+func (s *Service) CreateSharedGoal(ctx context.Context, userID, householdID int64, in SharedGoalInput) (*model.SharedGoal, error) {
+	if err := s.requireContributor(ctx, userID, householdID); err != nil {
+		return nil, err
+	}
+	name := strings.TrimSpace(in.Name)
+	if name == "" {
+		return nil, ErrSharedGoalEmptyName
+	}
+	if !in.TargetAmount.IsPositive() {
+		return nil, ErrSharedGoalInvalidTarget
+	}
+	g := &model.SharedGoal{
+		HouseholdID:   householdID,
+		Name:          name,
+		TargetAmount:  in.TargetAmount,
+		CurrentAmount: decimal.Zero,
+		TargetDate:    in.TargetDate,
+	}
+	if err := s.sharedGoals.Create(ctx, g); err != nil {
+		return nil, fmt.Errorf("create shared_goal: %w", err)
+	}
+	return g, nil
+}
+
+// ListSharedGoals returns every shared goal for the household. Any active
+// member may read.
+func (s *Service) ListSharedGoals(ctx context.Context, userID, householdID int64) ([]model.SharedGoal, error) {
+	if _, err := s.members.GetActive(ctx, householdID, userID); err != nil {
+		if errors.Is(err, repository.ErrNotFound) {
+			return nil, ErrNotMember
+		}
+		return nil, err
+	}
+	return s.sharedGoals.List(ctx, householdID)
+}
+
+// UpdateSharedGoal applies a sparse patch. Owner or contributor may edit.
+func (s *Service) UpdateSharedGoal(ctx context.Context, userID, householdID, id int64, in UpdateSharedGoalInput) (*model.SharedGoal, error) {
+	if err := s.requireContributor(ctx, userID, householdID); err != nil {
+		return nil, err
+	}
+	g, err := s.sharedGoals.GetByID(ctx, householdID, id)
+	if err != nil {
+		if errors.Is(err, repository.ErrNotFound) {
+			return nil, ErrSharedGoalNotFound
+		}
+		return nil, err
+	}
+	if in.Name != nil {
+		name := strings.TrimSpace(*in.Name)
+		if name == "" {
+			return nil, ErrSharedGoalEmptyName
+		}
+		g.Name = name
+	}
+	if in.TargetAmount != nil {
+		if !in.TargetAmount.IsPositive() {
+			return nil, ErrSharedGoalInvalidTarget
+		}
+		g.TargetAmount = *in.TargetAmount
+	}
+	if in.ClearTargetDate {
+		g.TargetDate = nil
+	} else if in.TargetDate != nil {
+		td := *in.TargetDate
+		g.TargetDate = &td
+	}
+	if err := s.sharedGoals.Update(ctx, g); err != nil {
+		if errors.Is(err, repository.ErrNotFound) {
+			return nil, ErrSharedGoalNotFound
+		}
+		return nil, fmt.Errorf("update shared_goal: %w", err)
+	}
+	return g, nil
+}
+
+// SoftDeleteSharedGoal removes a goal. Owner or contributor.
+func (s *Service) SoftDeleteSharedGoal(ctx context.Context, userID, householdID, id int64) error {
+	if err := s.requireContributor(ctx, userID, householdID); err != nil {
+		return err
+	}
+	if err := s.sharedGoals.SoftDelete(ctx, householdID, id); err != nil {
+		if errors.Is(err, repository.ErrNotFound) {
+			return ErrSharedGoalNotFound
+		}
+		return fmt.Errorf("soft-delete shared_goal: %w", err)
+	}
+	return nil
+}
+
+// ContributeToSharedGoal atomically adjusts current_amount by `delta`.
+// Positive = deposit, negative = withdrawal. Zero is rejected as a likely
+// caller bug (mirrors personal SavingsGoalService.Contribute).
+func (s *Service) ContributeToSharedGoal(ctx context.Context, userID, householdID, id int64, delta decimal.Decimal) (*model.SharedGoal, error) {
+	if err := s.requireContributor(ctx, userID, householdID); err != nil {
+		return nil, err
+	}
+	if delta.IsZero() {
+		return nil, ErrSharedGoalZeroContribution
+	}
+	g, err := s.sharedGoals.AddContribution(ctx, householdID, id, delta)
+	if err != nil {
+		if errors.Is(err, repository.ErrNotFound) {
+			return nil, ErrSharedGoalNotFound
+		}
+		return nil, fmt.Errorf("add contribution: %w", err)
+	}
+	return g, nil
+}

--- a/backend/internal/service/household/shared_goals_test.go
+++ b/backend/internal/service/household/shared_goals_test.go
@@ -1,0 +1,278 @@
+package household_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/shopspring/decimal"
+	"gorm.io/gorm"
+
+	"github.com/gregwym/offbook/backend/internal/model"
+	"github.com/gregwym/offbook/backend/internal/repository"
+	"github.com/gregwym/offbook/backend/internal/service/household"
+)
+
+// withSharedGoals wires the SharedGoal repo on top of newSvc's defaults.
+func withSharedGoals(t *testing.T) (*household.Service, *gorm.DB) {
+	t.Helper()
+	svc, _, g := newSvc(t)
+	svc.WithSharedGoals(repository.NewSharedGoalRepository(g))
+	return svc, g
+}
+
+// seedSharedGoalHousehold mirrors the shared-budget seeder: owner +
+// contributor + view-only on one household.
+func seedSharedGoalHousehold(t *testing.T, svc *household.Service, g *gorm.DB) (ownerID, contribID, viewOnlyID, hhID int64) {
+	t.Helper()
+	ctx := context.Background()
+	ownerID = seedUser(t, g, "sg-owner")
+	contribID = seedUser(t, g, "sg-contrib")
+	viewOnlyID = seedUser(t, g, "sg-view")
+	hh, err := svc.Create(ctx, ownerID, household.CreateInput{Name: "SG House"})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	cleanupHousehold(t, g, hh.ID)
+	t.Cleanup(func() {
+		g.Unscoped().Where("household_id = ?", hh.ID).Delete(&model.SharedGoal{})
+	})
+
+	ci, err := svc.CreateInvite(ctx, ownerID, hh.ID, household.CreateInviteInput{Role: model.RoleContributor})
+	if err != nil {
+		t.Fatalf("invite contrib: %v", err)
+	}
+	if _, err := svc.AcceptInvite(ctx, contribID, ci.Token); err != nil {
+		t.Fatalf("accept contrib: %v", err)
+	}
+	vi, err := svc.CreateInvite(ctx, ownerID, hh.ID, household.CreateInviteInput{Role: model.RoleViewOnly})
+	if err != nil {
+		t.Fatalf("invite view: %v", err)
+	}
+	if _, err := svc.AcceptInvite(ctx, viewOnlyID, vi.Token); err != nil {
+		t.Fatalf("accept view: %v", err)
+	}
+	return ownerID, contribID, viewOnlyID, hh.ID
+}
+
+func TestCreateSharedGoal_HappyPath(t *testing.T) {
+	svc, g := withSharedGoals(t)
+	ownerID, _, _, hhID := seedSharedGoalHousehold(t, svc, g)
+	g_, err := svc.CreateSharedGoal(context.Background(), ownerID, hhID, household.SharedGoalInput{
+		Name:         "Vacation Fund",
+		TargetAmount: decimal.NewFromInt(2000),
+	})
+	if err != nil {
+		t.Fatalf("CreateSharedGoal: %v", err)
+	}
+	if g_.HouseholdID != hhID || g_.Name != "Vacation Fund" {
+		t.Errorf("goal = %+v, want hhID=%d name=Vacation Fund", g_, hhID)
+	}
+	if !g_.CurrentAmount.IsZero() {
+		t.Errorf("CurrentAmount = %s, want 0 at creation", g_.CurrentAmount)
+	}
+}
+
+func TestCreateSharedGoal_ViewOnlyForbidden(t *testing.T) {
+	svc, g := withSharedGoals(t)
+	_, _, viewOnlyID, hhID := seedSharedGoalHousehold(t, svc, g)
+	_, err := svc.CreateSharedGoal(context.Background(), viewOnlyID, hhID, household.SharedGoalInput{
+		Name:         "Nope",
+		TargetAmount: decimal.NewFromInt(100),
+	})
+	if !errors.Is(err, household.ErrForbidden) {
+		t.Fatalf("err = %v, want ErrForbidden", err)
+	}
+}
+
+func TestCreateSharedGoal_ValidationRejectsEmptyName(t *testing.T) {
+	svc, g := withSharedGoals(t)
+	ownerID, _, _, hhID := seedSharedGoalHousehold(t, svc, g)
+	_, err := svc.CreateSharedGoal(context.Background(), ownerID, hhID, household.SharedGoalInput{
+		Name:         "  ",
+		TargetAmount: decimal.NewFromInt(100),
+	})
+	if !errors.Is(err, household.ErrSharedGoalEmptyName) {
+		t.Fatalf("err = %v, want ErrSharedGoalEmptyName", err)
+	}
+}
+
+func TestCreateSharedGoal_ValidationRejectsNonPositiveTarget(t *testing.T) {
+	svc, g := withSharedGoals(t)
+	ownerID, _, _, hhID := seedSharedGoalHousehold(t, svc, g)
+	_, err := svc.CreateSharedGoal(context.Background(), ownerID, hhID, household.SharedGoalInput{
+		Name:         "Bad",
+		TargetAmount: decimal.Zero,
+	})
+	if !errors.Is(err, household.ErrSharedGoalInvalidTarget) {
+		t.Fatalf("err = %v, want ErrSharedGoalInvalidTarget", err)
+	}
+}
+
+func TestListSharedGoals_NonMemberRejected(t *testing.T) {
+	svc, g := withSharedGoals(t)
+	_, _, _, hhID := seedSharedGoalHousehold(t, svc, g)
+	outsiderID := seedUser(t, g, "sg-outsider")
+	_, err := svc.ListSharedGoals(context.Background(), outsiderID, hhID)
+	if !errors.Is(err, household.ErrNotMember) {
+		t.Fatalf("err = %v, want ErrNotMember", err)
+	}
+}
+
+func TestUpdateSharedGoal_HappyPath(t *testing.T) {
+	svc, g := withSharedGoals(t)
+	ownerID, _, _, hhID := seedSharedGoalHousehold(t, svc, g)
+	created, err := svc.CreateSharedGoal(context.Background(), ownerID, hhID, household.SharedGoalInput{
+		Name: "Old Name", TargetAmount: decimal.NewFromInt(100),
+	})
+	if err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	newName := "New Name"
+	newTarget := decimal.NewFromInt(500)
+	td := time.Date(2027, 1, 1, 0, 0, 0, 0, time.UTC)
+	updated, err := svc.UpdateSharedGoal(context.Background(), ownerID, hhID, created.ID, household.UpdateSharedGoalInput{
+		Name:         &newName,
+		TargetAmount: &newTarget,
+		TargetDate:   &td,
+	})
+	if err != nil {
+		t.Fatalf("UpdateSharedGoal: %v", err)
+	}
+	if updated.Name != "New Name" || !updated.TargetAmount.Equal(decimal.NewFromInt(500)) {
+		t.Errorf("update miss: %+v", updated)
+	}
+	if updated.TargetDate == nil || !updated.TargetDate.Equal(td) {
+		t.Errorf("TargetDate = %v, want %v", updated.TargetDate, td)
+	}
+}
+
+func TestUpdateSharedGoal_ClearTargetDate(t *testing.T) {
+	svc, g := withSharedGoals(t)
+	ownerID, _, _, hhID := seedSharedGoalHousehold(t, svc, g)
+	td := time.Date(2027, 1, 1, 0, 0, 0, 0, time.UTC)
+	created, err := svc.CreateSharedGoal(context.Background(), ownerID, hhID, household.SharedGoalInput{
+		Name: "Has Date", TargetAmount: decimal.NewFromInt(100), TargetDate: &td,
+	})
+	if err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	updated, err := svc.UpdateSharedGoal(context.Background(), ownerID, hhID, created.ID, household.UpdateSharedGoalInput{
+		ClearTargetDate: true,
+	})
+	if err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	if updated.TargetDate != nil {
+		t.Errorf("TargetDate = %v, want nil after clear", updated.TargetDate)
+	}
+}
+
+func TestContributeToSharedGoal_HappyPath(t *testing.T) {
+	svc, g := withSharedGoals(t)
+	ownerID, contribID, _, hhID := seedSharedGoalHousehold(t, svc, g)
+	created, err := svc.CreateSharedGoal(context.Background(), ownerID, hhID, household.SharedGoalInput{
+		Name: "Pool", TargetAmount: decimal.NewFromInt(1000),
+	})
+	if err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	// Contributor adds 200.
+	g_, err := svc.ContributeToSharedGoal(context.Background(), contribID, hhID, created.ID, decimal.NewFromInt(200))
+	if err != nil {
+		t.Fatalf("contribute +200: %v", err)
+	}
+	if !g_.CurrentAmount.Equal(decimal.NewFromInt(200)) {
+		t.Errorf("after +200 current = %s, want 200", g_.CurrentAmount)
+	}
+	// Owner withdraws 50.
+	g_, err = svc.ContributeToSharedGoal(context.Background(), ownerID, hhID, created.ID, decimal.NewFromInt(-50))
+	if err != nil {
+		t.Fatalf("contribute -50: %v", err)
+	}
+	if !g_.CurrentAmount.Equal(decimal.NewFromInt(150)) {
+		t.Errorf("after -50 current = %s, want 150", g_.CurrentAmount)
+	}
+}
+
+func TestContributeToSharedGoal_ZeroRejected(t *testing.T) {
+	svc, g := withSharedGoals(t)
+	ownerID, _, _, hhID := seedSharedGoalHousehold(t, svc, g)
+	created, err := svc.CreateSharedGoal(context.Background(), ownerID, hhID, household.SharedGoalInput{
+		Name: "Pool", TargetAmount: decimal.NewFromInt(1000),
+	})
+	if err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	_, err = svc.ContributeToSharedGoal(context.Background(), ownerID, hhID, created.ID, decimal.Zero)
+	if !errors.Is(err, household.ErrSharedGoalZeroContribution) {
+		t.Fatalf("err = %v, want ErrSharedGoalZeroContribution", err)
+	}
+}
+
+func TestContributeToSharedGoal_ViewOnlyForbidden(t *testing.T) {
+	svc, g := withSharedGoals(t)
+	ownerID, _, viewOnlyID, hhID := seedSharedGoalHousehold(t, svc, g)
+	created, _ := svc.CreateSharedGoal(context.Background(), ownerID, hhID, household.SharedGoalInput{
+		Name: "X", TargetAmount: decimal.NewFromInt(100),
+	})
+	_, err := svc.ContributeToSharedGoal(context.Background(), viewOnlyID, hhID, created.ID, decimal.NewFromInt(10))
+	if !errors.Is(err, household.ErrForbidden) {
+		t.Fatalf("err = %v, want ErrForbidden", err)
+	}
+}
+
+func TestSoftDeleteSharedGoal_HappyPath(t *testing.T) {
+	svc, g := withSharedGoals(t)
+	ownerID, _, _, hhID := seedSharedGoalHousehold(t, svc, g)
+	created, _ := svc.CreateSharedGoal(context.Background(), ownerID, hhID, household.SharedGoalInput{
+		Name: "Bye", TargetAmount: decimal.NewFromInt(100),
+	})
+	if err := svc.SoftDeleteSharedGoal(context.Background(), ownerID, hhID, created.ID); err != nil {
+		t.Fatalf("SoftDelete: %v", err)
+	}
+	list, _ := svc.ListSharedGoals(context.Background(), ownerID, hhID)
+	for _, gg := range list {
+		if gg.ID == created.ID {
+			t.Errorf("goal %d still listed after delete", created.ID)
+		}
+	}
+}
+
+// TestSharedGoal_TenantIsolation: a member of household A cannot mutate
+// a goal in household B.
+func TestSharedGoal_TenantIsolation(t *testing.T) {
+	svc, g := withSharedGoals(t)
+	ownerA, _, _, hhA := seedSharedGoalHousehold(t, svc, g)
+
+	ctx := context.Background()
+	ownerB := seedUser(t, g, "sg-ownerB")
+	hhB, err := svc.Create(ctx, ownerB, household.CreateInput{Name: "Other"})
+	if err != nil {
+		t.Fatalf("create B: %v", err)
+	}
+	cleanupHousehold(t, g, hhB.ID)
+	t.Cleanup(func() {
+		g.Unscoped().Where("household_id = ?", hhB.ID).Delete(&model.SharedGoal{})
+	})
+
+	gA, err := svc.CreateSharedGoal(ctx, ownerA, hhA, household.SharedGoalInput{
+		Name: "A Goal", TargetAmount: decimal.NewFromInt(100),
+	})
+	if err != nil {
+		t.Fatalf("seed A: %v", err)
+	}
+
+	// Owner B contributes to a goal that lives in household A — should
+	// fail as not-a-member of A.
+	_, err = svc.ContributeToSharedGoal(ctx, ownerB, hhA, gA.ID, decimal.NewFromInt(50))
+	if !errors.Is(err, household.ErrNotMember) {
+		t.Errorf("cross-tenant contrib err = %v, want ErrNotMember", err)
+	}
+	// Same goal id but scoped to household B should report not-found.
+	_, err = svc.ContributeToSharedGoal(ctx, ownerB, hhB.ID, gA.ID, decimal.NewFromInt(50))
+	if !errors.Is(err, household.ErrSharedGoalNotFound) {
+		t.Errorf("scoped-to-wrong-household err = %v, want ErrSharedGoalNotFound", err)
+	}
+}

--- a/frontend/src/api/householdAggregator.ts
+++ b/frontend/src/api/householdAggregator.ts
@@ -1,6 +1,7 @@
 import { apiClient, type ApiItem, type ApiList } from './client'
 import type {
   BudgetPaceItem,
+  GoalProgressItem,
   HouseholdDashboard,
   HouseholdPeriodKey,
 } from '../types/householdAggregator'
@@ -20,5 +21,10 @@ export async function getBudgetPace(
   const res = await apiClient.get<ApiList<BudgetPaceItem>>('/h/budgets/pace', {
     params: { period },
   })
+  return res.data.data
+}
+
+export async function getGoalProgress(): Promise<GoalProgressItem[]> {
+  const res = await apiClient.get<ApiList<GoalProgressItem>>('/h/goals/progress')
   return res.data.data
 }

--- a/frontend/src/api/households.ts
+++ b/frontend/src/api/households.ts
@@ -2,13 +2,16 @@ import { apiClient, type ApiItem, type ApiList } from './client'
 import type {
   CreateInviteResult,
   CreateSharedBudgetInput,
+  CreateSharedGoalInput,
   Household,
   HouseholdDetail,
   HouseholdMember,
   HouseholdRole,
   MembersListing,
   SharedBudget,
+  SharedGoal,
   UpdateSharedBudgetInput,
+  UpdateSharedGoalInput,
 } from '../types/household'
 
 export async function getHousehold(id: number): Promise<HouseholdDetail> {
@@ -109,4 +112,48 @@ export async function updateSharedBudget(
 
 export async function deleteSharedBudget(householdID: number, budgetID: number): Promise<void> {
   await apiClient.delete(`/households/${householdID}/shared-budgets/${budgetID}`)
+}
+
+export async function listSharedGoals(householdID: number): Promise<SharedGoal[]> {
+  const res = await apiClient.get<ApiList<SharedGoal>>(`/households/${householdID}/shared-goals`)
+  return res.data.data
+}
+
+export async function createSharedGoal(
+  householdID: number,
+  input: CreateSharedGoalInput,
+): Promise<SharedGoal> {
+  const res = await apiClient.post<ApiItem<SharedGoal>>(
+    `/households/${householdID}/shared-goals`,
+    input,
+  )
+  return res.data.data
+}
+
+export async function updateSharedGoal(
+  householdID: number,
+  goalID: number,
+  input: UpdateSharedGoalInput,
+): Promise<SharedGoal> {
+  const res = await apiClient.patch<ApiItem<SharedGoal>>(
+    `/households/${householdID}/shared-goals/${goalID}`,
+    input,
+  )
+  return res.data.data
+}
+
+export async function deleteSharedGoal(householdID: number, goalID: number): Promise<void> {
+  await apiClient.delete(`/households/${householdID}/shared-goals/${goalID}`)
+}
+
+export async function contributeToSharedGoal(
+  householdID: number,
+  goalID: number,
+  amount: string,
+): Promise<SharedGoal> {
+  const res = await apiClient.post<ApiItem<SharedGoal>>(
+    `/households/${householdID}/shared-goals/${goalID}/contributions`,
+    { amount },
+  )
+  return res.data.data
 }

--- a/frontend/src/pages/HouseholdGoalsPage.tsx
+++ b/frontend/src/pages/HouseholdGoalsPage.tsx
@@ -1,5 +1,454 @@
-import { PageStub } from '../components/PageStub'
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { Coins, Pencil, PiggyBank, Plus, Trash2 } from 'lucide-react'
+import { AmountDisplay } from '../components/AmountDisplay'
+import {
+  contributeToSharedGoal,
+  createSharedGoal,
+  deleteSharedGoal,
+  listSharedGoals,
+  updateSharedGoal,
+} from '../api/households'
+import { getGoalProgress } from '../api/householdAggregator'
+import { useHouseholdStore } from '../store/householdStore'
+import { useScopeStore } from '../store/scopeStore'
+import type {
+  CreateSharedGoalInput,
+  SharedGoal,
+  UpdateSharedGoalInput,
+} from '../types/household'
+import type { GoalProgressItem } from '../types/householdAggregator'
 
 export function HouseholdGoalsPage() {
-  return <PageStub title="Household Goals" description="Shared savings goals coming later." />
+  const { householdId } = useScopeStore()
+  const { detail, load: loadDetail } = useHouseholdStore()
+
+  const [goals, setGoals] = useState<SharedGoal[]>([])
+  const [progress, setProgress] = useState<GoalProgressItem[]>([])
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [adding, setAdding] = useState(false)
+  const [editing, setEditing] = useState<SharedGoal | null>(null)
+  const [contributing, setContributing] = useState<SharedGoal | null>(null)
+
+  const reload = useCallback(() => {
+    if (householdId == null) return Promise.resolve()
+    return Promise.all([listSharedGoals(householdId), getGoalProgress()])
+      .then(([gs, p]) => {
+        setGoals(gs)
+        setProgress(p)
+        setError(null)
+      })
+      .catch((e: unknown) => setError(errMsg(e)))
+      .finally(() => setLoading(false))
+  }, [householdId])
+
+  useEffect(() => {
+    if (householdId != null) {
+      void loadDetail(householdId)
+      void reload()
+    }
+  }, [householdId, loadDetail, reload])
+
+  const progressByGoal = useMemo(() => {
+    const m = new Map<number, GoalProgressItem>()
+    for (const p of progress) m.set(p.goal_id, p)
+    return m
+  }, [progress])
+
+  if (householdId == null) {
+    return (
+      <div className="rounded-lg border border-gray-200 bg-white p-8 text-center">
+        <PiggyBank size={28} className="mx-auto text-gray-300 mb-2" />
+        <h1 className="text-base font-medium text-gray-900">No household yet</h1>
+        <p className="text-sm text-gray-500 mt-1">
+          Use the scope switcher in the sidebar to create or join a household.
+        </p>
+      </div>
+    )
+  }
+
+  const canMutate = detail?.role === 'owner' || detail?.role === 'contributor'
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold text-gray-900">Shared goals</h1>
+          <p className="mt-1 text-sm text-gray-500">
+            Household-wide savings targets. Contributions add to a single total.
+          </p>
+        </div>
+        {canMutate && (
+          <button
+            type="button"
+            onClick={() => setAdding(true)}
+            className="inline-flex items-center gap-2 rounded-md bg-indigo-600 px-3 py-2 text-sm font-medium text-white hover:bg-indigo-700"
+          >
+            <Plus size={16} /> New shared goal
+          </button>
+        )}
+      </div>
+
+      {error && (
+        <div className="flex items-start justify-between rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
+          <span>{error}</span>
+          <button type="button" onClick={() => setError(null)} className="ml-3 text-red-600 hover:text-red-800">×</button>
+        </div>
+      )}
+
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
+        {loading && goals.length === 0 && (
+          <div className="col-span-full rounded-lg border border-gray-200 bg-white px-4 py-6 text-center text-sm text-gray-400">
+            Loading…
+          </div>
+        )}
+        {!loading && goals.length === 0 && (
+          <div className="col-span-full rounded-lg border border-dashed border-gray-300 bg-white px-4 py-6 text-center text-sm text-gray-500">
+            <PiggyBank size={24} className="mx-auto mb-1 text-gray-300" />
+            No shared goals yet.{' '}
+            {canMutate
+              ? 'Create one to start tracking household savings.'
+              : 'Ask an owner or contributor to create one.'}
+          </div>
+        )}
+        {goals.map((g) => (
+          <GoalCard
+            key={g.id}
+            goal={g}
+            progress={progressByGoal.get(g.id)}
+            canMutate={canMutate}
+            onEdit={() => setEditing(g)}
+            onContribute={() => setContributing(g)}
+            onDelete={async () => {
+              if (!householdId) return
+              if (!window.confirm(`Delete shared goal "${g.name}"?`)) return
+              try {
+                await deleteSharedGoal(householdId, g.id)
+                await reload()
+              } catch (e) {
+                setError(errMsg(e))
+              }
+            }}
+          />
+        ))}
+      </div>
+
+      {(adding || editing) && (
+        <GoalFormModal
+          mode={editing ? 'edit' : 'create'}
+          initial={editing}
+          onClose={() => {
+            setAdding(false)
+            setEditing(null)
+          }}
+          onSubmit={async (input, id) => {
+            if (!householdId) return
+            try {
+              if (editing && id != null) {
+                await updateSharedGoal(householdId, id, input as UpdateSharedGoalInput)
+              } else {
+                await createSharedGoal(householdId, input as CreateSharedGoalInput)
+              }
+              await reload()
+              setAdding(false)
+              setEditing(null)
+            } catch (e) {
+              setError(errMsg(e))
+            }
+          }}
+        />
+      )}
+
+      {contributing && (
+        <ContributeModal
+          goal={contributing}
+          onClose={() => setContributing(null)}
+          onSubmit={async (amount) => {
+            if (!householdId) return
+            try {
+              await contributeToSharedGoal(householdId, contributing.id, amount)
+              await reload()
+              setContributing(null)
+            } catch (e) {
+              setError(errMsg(e))
+            }
+          }}
+        />
+      )}
+    </div>
+  )
+}
+
+function GoalCard({
+  goal,
+  progress,
+  canMutate,
+  onEdit,
+  onContribute,
+  onDelete,
+}: {
+  goal: SharedGoal
+  progress: GoalProgressItem | undefined
+  canMutate: boolean
+  onEdit: () => void
+  onContribute: () => void
+  onDelete: () => void
+}) {
+  const ratio = progress ? Number.parseFloat(progress.progress) : 0
+  const pct = Math.max(0, Math.min(1, ratio)) * 100
+  return (
+    <div className="rounded-lg border border-gray-200 bg-white px-4 py-3 shadow-sm">
+      <div className="flex items-start justify-between">
+        <div className="min-w-0">
+          <div className="truncate font-medium text-gray-900">{goal.name}</div>
+          <div className="mt-0.5 text-xs text-gray-500">
+            {goal.target_date ? `By ${new Date(goal.target_date).toLocaleDateString()}` : 'No deadline'}
+          </div>
+        </div>
+        {canMutate && (
+          <div className="flex shrink-0 gap-1">
+            <button
+              type="button"
+              onClick={onEdit}
+              aria-label="Edit"
+              className="rounded p-1 text-gray-500 hover:bg-gray-100 hover:text-gray-900"
+            >
+              <Pencil size={14} />
+            </button>
+            <button
+              type="button"
+              onClick={onDelete}
+              aria-label="Delete"
+              className="rounded p-1 text-gray-500 hover:bg-red-50 hover:text-red-700"
+            >
+              <Trash2 size={14} />
+            </button>
+          </div>
+        )}
+      </div>
+      <div className="mt-3">
+        <div className="flex items-baseline justify-between text-sm">
+          <span>
+            <AmountDisplay amount={goal.current_amount} /> <span className="text-gray-400">/</span>{' '}
+            <AmountDisplay amount={goal.target_amount} />
+          </span>
+          <span className="text-xs text-gray-500">{Math.round(pct)}%</span>
+        </div>
+        <div className="mt-1 h-2 w-full overflow-hidden rounded-full bg-gray-100">
+          <div className="h-full bg-emerald-500" style={{ width: `${pct}%` }} />
+        </div>
+      </div>
+      {canMutate && (
+        <button
+          type="button"
+          onClick={onContribute}
+          className="mt-3 inline-flex w-full items-center justify-center gap-1 rounded-md border border-gray-300 bg-white px-3 py-1.5 text-xs font-medium text-gray-700 hover:bg-gray-50"
+        >
+          <Coins size={14} /> Contribute
+        </button>
+      )}
+    </div>
+  )
+}
+
+function GoalFormModal({
+  mode,
+  initial,
+  onClose,
+  onSubmit,
+}: {
+  mode: 'create' | 'edit'
+  initial: SharedGoal | null
+  onClose: () => void
+  onSubmit: (input: CreateSharedGoalInput | UpdateSharedGoalInput, id?: number) => Promise<void>
+}) {
+  const [name, setName] = useState(initial?.name ?? '')
+  const [target, setTarget] = useState(initial?.target_amount ?? '0')
+  const [targetDate, setTargetDate] = useState(initial?.target_date ?? '')
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setError(null)
+    setSubmitting(true)
+    try {
+      const payload: CreateSharedGoalInput & UpdateSharedGoalInput = {
+        name,
+        target_amount: target,
+      }
+      if (targetDate) payload.target_date = targetDate
+      else if (mode === 'edit' && initial?.target_date) payload.clear_target_date = true
+
+      if (mode === 'edit' && initial) {
+        await onSubmit(payload as UpdateSharedGoalInput, initial.id)
+      } else {
+        await onSubmit(payload as CreateSharedGoalInput)
+      }
+    } catch (e) {
+      setError(errMsg(e))
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
+      role="dialog"
+      aria-modal="true"
+      onClick={onClose}
+    >
+      <form
+        onClick={(e) => e.stopPropagation()}
+        onSubmit={submit}
+        className="w-full max-w-md rounded-lg bg-white shadow-xl"
+      >
+        <div className="border-b border-gray-200 px-5 py-3">
+          <h3 className="text-base font-medium text-gray-900">
+            {mode === 'edit' ? 'Edit shared goal' : 'New shared goal'}
+          </h3>
+        </div>
+        <div className="px-5 py-4 space-y-3">
+          <label className="block text-sm">
+            <div className="font-medium text-gray-700 mb-1">Name</div>
+            <input
+              type="text"
+              required
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-indigo-500 focus:outline-none"
+            />
+          </label>
+          <div className="grid grid-cols-2 gap-3">
+            <label className="block text-sm">
+              <div className="font-medium text-gray-700 mb-1">Target amount</div>
+              <input
+                type="text"
+                inputMode="decimal"
+                required
+                value={target}
+                onChange={(e) => setTarget(e.target.value)}
+                className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-indigo-500 focus:outline-none"
+              />
+            </label>
+            <label className="block text-sm">
+              <div className="font-medium text-gray-700 mb-1">Target date</div>
+              <input
+                type="date"
+                value={targetDate ?? ''}
+                onChange={(e) => setTargetDate(e.target.value)}
+                className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-indigo-500 focus:outline-none"
+              />
+            </label>
+          </div>
+          {error && (
+            <div className="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-xs text-red-700">{error}</div>
+          )}
+        </div>
+        <div className="flex items-center justify-end gap-2 border-t border-gray-200 px-5 py-3">
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-md border border-gray-300 px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50"
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            disabled={submitting || !name || !target}
+            className="rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-indigo-700 disabled:opacity-40"
+          >
+            {submitting ? 'Saving…' : mode === 'edit' ? 'Save' : 'Create'}
+          </button>
+        </div>
+      </form>
+    </div>
+  )
+}
+
+function ContributeModal({
+  goal,
+  onClose,
+  onSubmit,
+}: {
+  goal: SharedGoal
+  onClose: () => void
+  onSubmit: (amount: string) => Promise<void>
+}) {
+  const [amount, setAmount] = useState('0')
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
+      role="dialog"
+      aria-modal="true"
+      onClick={onClose}
+    >
+      <form
+        onClick={(e) => e.stopPropagation()}
+        onSubmit={async (e) => {
+          e.preventDefault()
+          setError(null)
+          setSubmitting(true)
+          try {
+            await onSubmit(amount)
+          } catch (e) {
+            setError(errMsg(e))
+          } finally {
+            setSubmitting(false)
+          }
+        }}
+        className="w-full max-w-md rounded-lg bg-white shadow-xl"
+      >
+        <div className="border-b border-gray-200 px-5 py-3">
+          <h3 className="text-base font-medium text-gray-900">Contribute to {goal.name}</h3>
+        </div>
+        <div className="px-5 py-4 space-y-3">
+          <label className="block text-sm">
+            <div className="font-medium text-gray-700 mb-1">Amount</div>
+            <input
+              type="text"
+              inputMode="decimal"
+              required
+              value={amount}
+              onChange={(e) => setAmount(e.target.value)}
+              className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-indigo-500 focus:outline-none"
+            />
+            <p className="mt-1 text-[11px] text-gray-500">Negative values withdraw from the pool.</p>
+          </label>
+          {error && (
+            <div className="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-xs text-red-700">{error}</div>
+          )}
+        </div>
+        <div className="flex items-center justify-end gap-2 border-t border-gray-200 px-5 py-3">
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-md border border-gray-300 px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50"
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            disabled={submitting || !amount}
+            className="rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-indigo-700 disabled:opacity-40"
+          >
+            {submitting ? 'Saving…' : 'Contribute'}
+          </button>
+        </div>
+      </form>
+    </div>
+  )
+}
+
+function errMsg(err: unknown): string {
+  if (err && typeof err === 'object' && 'response' in err) {
+    const r = (err as { response?: { data?: { error?: string } } }).response
+    if (r?.data?.error) return r.data.error
+  }
+  if (err instanceof Error) return err.message
+  return 'request failed'
 }

--- a/frontend/src/types/household.ts
+++ b/frontend/src/types/household.ts
@@ -82,3 +82,28 @@ export type UpdateSharedBudgetInput = {
   rollover?: boolean
   is_active?: boolean
 }
+
+// SharedGoal mirrors backend model.SharedGoal.
+export type SharedGoal = {
+  id: number
+  household_id: number
+  name: string
+  target_amount: string
+  current_amount: string
+  target_date?: string | null
+  created_at: string
+  updated_at: string
+}
+
+export type CreateSharedGoalInput = {
+  name: string
+  target_amount: string
+  target_date?: string // YYYY-MM-DD
+}
+
+export type UpdateSharedGoalInput = {
+  name?: string
+  target_amount?: string
+  target_date?: string
+  clear_target_date?: boolean
+}

--- a/frontend/src/types/householdAggregator.ts
+++ b/frontend/src/types/householdAggregator.ts
@@ -32,6 +32,16 @@ export type BudgetPaceItem = {
   pace: string // ratio 0..N (1.0 = on budget)
 }
 
+// GoalProgressItem mirrors service/household.GoalProgressItem.
+export type GoalProgressItem = {
+  goal_id: number
+  name: string
+  target_amount: string
+  current_amount: string
+  progress: string // ratio 0..1
+  target_date?: string | null
+}
+
 export type HouseholdDashboard = {
   period: HouseholdPeriod
   net_worth: string


### PR DESCRIPTION
## Summary
Symmetric counterpart to #163 — closes the last M2.5 "Out of scope (deferred)" item from the household surface.

**Backend**
- `repository.SharedGoalRepository` for household-scoped CRUD + an atomic `AddContribution` (mirrors the personal `savings_goal_repo` pattern: single UPDATE with SQL expression so concurrent contributions serialize on the row).
- `service/household` gains `SharedGoalInput` / `UpdateSharedGoalInput`; `CreateSharedGoal`, `ListSharedGoals`, `UpdateSharedGoal`, `SoftDeleteSharedGoal`, `ContributeToSharedGoal`. Mutating paths gate on `requireContributor` (owner or contributor); reads on membership. Validation rejects empty name, non-positive target, zero contributions.
- Routes: `POST/GET /households/:id/shared-goals`, `PATCH/DELETE /households/:id/shared-goals/:goalID`, `POST /households/:id/shared-goals/:goalID/contributions`. New error code `GOAL_NOT_FOUND` (404) and `INVALID_GOAL` (400).
- `Service.WithSharedGoals(repo)` setter composes with the existing `WithDB` / `WithSharedBudgets` chain.
- 11 integration tests: happy path, view-only forbidden, empty-name + non-positive-target validation, non-member can't list, update + clear-target-date, contribute happy path (positive + negative), zero rejected, view-only can't contribute, soft-delete, tenant isolation.

**Frontend**
- `HouseholdGoalsPage` replaces the PageStub. Card grid showing each goal's progress bar (consumed from the existing aggregator `/h/goals/progress`), Edit / Delete / Contribute controls for owner + contributor (view-only sees the list only). Create + Edit + Contribute modals.
- `api/householdAggregator.ts` gains a typed `getGoalProgress()` wrapper.

## Test plan
- [x] `go test -race -p 1 ./internal/service/household/...` — 11 new tests pass alongside the prior 28 household tests.
- [x] `pnpm lint && pnpm build` — frontend clean.
- [ ] Manual: owner creates a goal, contributor contributes +200, owner withdraws 50, total reads 150; view-only sees no controls.

Closes #165