### PR TITLE
perf(frontend): route-based code splitting (#169)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,28 +1,39 @@
-import { useEffect } from 'react'
+import { lazy, Suspense, useEffect } from 'react'
 import { Navigate, Outlet, Route, Routes, useNavigate } from 'react-router-dom'
 import { AppShell } from './components/AppShell'
 import { setUnauthorizedHandler } from './api/client'
 import { useAuthStore } from './store/authStore'
-import { AccountsPage } from './pages/AccountsPage'
-import { AIPage } from './pages/AIPage'
-import { BudgetsPage } from './pages/BudgetsPage'
-import { DashboardPage } from './pages/DashboardPage'
-import { HouseholdAIPage } from './pages/HouseholdAIPage'
-import { HouseholdBudgetsPage } from './pages/HouseholdBudgetsPage'
-import { HouseholdDashboardPage } from './pages/HouseholdDashboardPage'
-import { HouseholdGoalsPage } from './pages/HouseholdGoalsPage'
-import { HouseholdMembersPage } from './pages/HouseholdMembersPage'
-import { HouseholdSettingsPage } from './pages/HouseholdSettingsPage'
-import { ImportPage } from './pages/ImportPage'
-import { InvestmentsPage } from './pages/InvestmentsPage'
-import { PlaidConnectPage } from './pages/PlaidConnectPage'
-import { RulesPage } from './pages/RulesPage'
-import { SavingsGoalsPage } from './pages/SavingsGoalsPage'
-import { SettingsPage } from './pages/SettingsPage'
+// Auth-flow pages are eager — they're the front door before sign-in and
+// shouldn't incur a Suspense flash on the very first paint.
 import { SetupAdminPage } from './pages/SetupAdminPage'
 import { SigninPage } from './pages/SigninPage'
 import { SignupPage } from './pages/SignupPage'
-import { TransactionsPage } from './pages/TransactionsPage'
+
+// Authenticated routes lazy-load their page modules. This drops the
+// initial bundle below Vite's 500 kB warning threshold and means a user
+// who only ever visits /dashboard never downloads Recharts (Investments),
+// the AI chat surface, or the Plaid SDK shim.
+//
+// React.lazy wants default exports; our pages are named exports, so we
+// adapt each module inline. Keep the adaption shape identical so the
+// Suspense + chunk splits stay symmetric across pages.
+const DashboardPage = lazy(() => import('./pages/DashboardPage').then((m) => ({ default: m.DashboardPage })))
+const AccountsPage = lazy(() => import('./pages/AccountsPage').then((m) => ({ default: m.AccountsPage })))
+const PlaidConnectPage = lazy(() => import('./pages/PlaidConnectPage').then((m) => ({ default: m.PlaidConnectPage })))
+const TransactionsPage = lazy(() => import('./pages/TransactionsPage').then((m) => ({ default: m.TransactionsPage })))
+const RulesPage = lazy(() => import('./pages/RulesPage').then((m) => ({ default: m.RulesPage })))
+const BudgetsPage = lazy(() => import('./pages/BudgetsPage').then((m) => ({ default: m.BudgetsPage })))
+const SavingsGoalsPage = lazy(() => import('./pages/SavingsGoalsPage').then((m) => ({ default: m.SavingsGoalsPage })))
+const InvestmentsPage = lazy(() => import('./pages/InvestmentsPage').then((m) => ({ default: m.InvestmentsPage })))
+const ImportPage = lazy(() => import('./pages/ImportPage').then((m) => ({ default: m.ImportPage })))
+const AIPage = lazy(() => import('./pages/AIPage').then((m) => ({ default: m.AIPage })))
+const SettingsPage = lazy(() => import('./pages/SettingsPage').then((m) => ({ default: m.SettingsPage })))
+const HouseholdDashboardPage = lazy(() => import('./pages/HouseholdDashboardPage').then((m) => ({ default: m.HouseholdDashboardPage })))
+const HouseholdBudgetsPage = lazy(() => import('./pages/HouseholdBudgetsPage').then((m) => ({ default: m.HouseholdBudgetsPage })))
+const HouseholdGoalsPage = lazy(() => import('./pages/HouseholdGoalsPage').then((m) => ({ default: m.HouseholdGoalsPage })))
+const HouseholdMembersPage = lazy(() => import('./pages/HouseholdMembersPage').then((m) => ({ default: m.HouseholdMembersPage })))
+const HouseholdAIPage = lazy(() => import('./pages/HouseholdAIPage').then((m) => ({ default: m.HouseholdAIPage })))
+const HouseholdSettingsPage = lazy(() => import('./pages/HouseholdSettingsPage').then((m) => ({ default: m.HouseholdSettingsPage })))
 
 export default function App() {
   const { hydrated, hydrate, signout } = useAuthStore()
@@ -44,7 +55,7 @@ export default function App() {
 
   return (
     <Routes>
-      {/* Unauthenticated routes — no AppShell, no auth required. */}
+      {/* Unauthenticated routes — no AppShell, no auth required, eager-loaded. */}
       <Route path="/setup/admin" element={<SetupAdminPage />} />
       <Route path="/signin" element={<SigninPage />} />
       <Route path="/signup" element={<SignupPage />} />
@@ -53,27 +64,44 @@ export default function App() {
       <Route element={<RequireAuth />}>
         <Route element={<AppShell />}>
           <Route index element={<Navigate to="/dashboard" replace />} />
-          <Route path="/dashboard" element={<DashboardPage />} />
-          <Route path="/accounts" element={<AccountsPage />} />
-          <Route path="/connect" element={<PlaidConnectPage />} />
-          <Route path="/transactions" element={<TransactionsPage />} />
-          <Route path="/rules" element={<RulesPage />} />
-          <Route path="/budgets" element={<BudgetsPage />} />
-          <Route path="/savings-goals" element={<SavingsGoalsPage />} />
-          <Route path="/investments" element={<InvestmentsPage />} />
-          <Route path="/import" element={<ImportPage />} />
-          <Route path="/ai" element={<AIPage />} />
-          <Route path="/settings" element={<SettingsPage />} />
+          <Route path="/dashboard" element={<LazyRoute><DashboardPage /></LazyRoute>} />
+          <Route path="/accounts" element={<LazyRoute><AccountsPage /></LazyRoute>} />
+          <Route path="/connect" element={<LazyRoute><PlaidConnectPage /></LazyRoute>} />
+          <Route path="/transactions" element={<LazyRoute><TransactionsPage /></LazyRoute>} />
+          <Route path="/rules" element={<LazyRoute><RulesPage /></LazyRoute>} />
+          <Route path="/budgets" element={<LazyRoute><BudgetsPage /></LazyRoute>} />
+          <Route path="/savings-goals" element={<LazyRoute><SavingsGoalsPage /></LazyRoute>} />
+          <Route path="/investments" element={<LazyRoute><InvestmentsPage /></LazyRoute>} />
+          <Route path="/import" element={<LazyRoute><ImportPage /></LazyRoute>} />
+          <Route path="/ai" element={<LazyRoute><AIPage /></LazyRoute>} />
+          <Route path="/settings" element={<LazyRoute><SettingsPage /></LazyRoute>} />
 
-          <Route path="/h/dashboard" element={<HouseholdDashboardPage />} />
-          <Route path="/h/budgets"   element={<HouseholdBudgetsPage />} />
-          <Route path="/h/goals"     element={<HouseholdGoalsPage />} />
-          <Route path="/h/members"   element={<HouseholdMembersPage />} />
-          <Route path="/h/ai"        element={<HouseholdAIPage />} />
-          <Route path="/h/settings"  element={<HouseholdSettingsPage />} />
+          <Route path="/h/dashboard" element={<LazyRoute><HouseholdDashboardPage /></LazyRoute>} />
+          <Route path="/h/budgets"   element={<LazyRoute><HouseholdBudgetsPage /></LazyRoute>} />
+          <Route path="/h/goals"     element={<LazyRoute><HouseholdGoalsPage /></LazyRoute>} />
+          <Route path="/h/members"   element={<LazyRoute><HouseholdMembersPage /></LazyRoute>} />
+          <Route path="/h/ai"        element={<LazyRoute><HouseholdAIPage /></LazyRoute>} />
+          <Route path="/h/settings"  element={<LazyRoute><HouseholdSettingsPage /></LazyRoute>} />
         </Route>
       </Route>
     </Routes>
+  )
+}
+
+// LazyRoute wraps every code-split route with the same Suspense fallback
+// so the placeholder shape is uniform. Centered so the AppShell sidebar
+// stays visible while the chunk loads.
+function LazyRoute({ children }: { children: React.ReactNode }) {
+  return (
+    <Suspense
+      fallback={
+        <div className="flex h-full min-h-[60vh] items-center justify-center text-sm text-gray-400">
+          Loading…
+        </div>
+      }
+    >
+      {children}
+    </Suspense>
   )
 }
 


### PR DESCRIPTION
## Summary
Closes Vite's "chunks larger than 500 kB" warning that printed on every build.

- Auth-flow pages (`SetupAdminPage`, `SigninPage`, `SignupPage`) stay eager — they're the front door and shouldn't Suspense-flash on first paint.
- Every other page (`/dashboard`, `/accounts`, `/transactions`, …, `/h/*`) is imported via \`React.lazy\` + a tiny named-export adapter (each \`m => ({ default: m.PageName })\`). No page-file changes needed — they keep their named exports.
- A uniform \`<LazyRoute>\` Suspense wrapper renders an inline "Loading…" placeholder inside the AppShell, so the sidebar stays visible while a chunk loads.

## Bundle impact
| Chunk | Before | After |
|---|---|---|
| Initial JS (loaded from `index.html`) | ~800 kB / 230 kB gzip | **305 kB / 98 kB gzip** |
| Recharts + chart colors | bundled into initial | own 319 kB chunk, only loaded by Dashboard / Investments |
| DashboardPage | bundled into initial | own 76 kB chunk |
| Per-page chunks | n/a | 0.6 kB – 15 kB each |

A user who only visits /signin → /dashboard never downloads the AI chat surface, the Plaid SDK shim, or the household pages.

## Test plan
- [x] `pnpm lint && pnpm build` — clean, no chunk-size warning
- [x] Build output shows expected per-page chunks
- [ ] Manual: navigate every route once, watch the network panel show each page chunk loading on first visit

Closes #169