### PR TITLE
docs: clear stale M2.5 deferrals + flag SESSION_SECRET dual-use

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,8 +6,16 @@ PORT=8000
 FRONTEND_URL=http://localhost:5173
 MIGRATIONS_PATH=migrations
 
-# Auth (required from M2.5+)
-# Generate with: openssl rand -hex 32
+# Auth (required from M2.5+). Generate with: openssl rand -hex 32
+#
+# DUAL PURPOSE — read before rotating:
+#   1. HMAC key for session-cookie tokens (auth/session.go).
+#   2. Source for the AES-256 key (via SHA-256) that encrypts per-user
+#      Claude API keys in user_settings.claude_api_key_enc (ADR-0010,
+#      ADR-0012). Rotating SESSION_SECRET invalidates every session AND
+#      makes every stored Claude key unrecoverable — users must re-paste
+#      their keys on /settings. Keep this in mind for any "secret
+#      rotation" runbook.
 SESSION_SECRET=
 
 # Plaid (optional — get keys at https://dashboard.plaid.com)

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -72,9 +72,9 @@ See [ADR-0006](ADR/0006-multi-tenant-model.md), [ADR-0007](ADR/0007-member-lifec
 - [x] `GET/PATCH /me/scope` — defaults to `household` when member, else `personal`
 - [x] Frontend: zustand `scopeStore` + scope picker in sidebar + 6 household routes (`/h/dashboard`, `/h/budgets`, `/h/goals`, `/h/members`, `/h/ai`, `/h/settings`) as PageStubs
 
-**Done criteria:** First boot → `/setup/admin` creates admin + picks `invite_only`. Invite a second user, both create households or join one. Account-level visibility toggles per account. Scope picker swaps the sidebar route list. Aggregator privacy tests green. Existing single-user flows still work for the bootstrap user. Members page UI, Household Dashboard layout, visibility-chip rendering, and Household AI Advisor wait for hi-fi.
+**Done criteria:** First boot → `/setup/admin` creates admin + picks `invite_only`. Invite a second user, both create households or join one. Account-level visibility toggles per account. Scope picker swaps the sidebar route list. Aggregator privacy tests green. Existing single-user flows still work for the bootstrap user.
 
-**Out of scope (deferred):** Members table UI, Household Dashboard layout, visibility-chip visuals, Household AI Advisor UI, `shared_budgets`/`shared_goals` CRUD, `cmd/household-purge` runner.
+**Originally deferred — all shipped post-M8:** Members table UI (#140), Household Dashboard layout (#141), visibility-chip rendering (#142), Household AI Advisor UI (#167), `shared_budgets` CRUD (#163), `shared_goals` CRUD (#165), `cmd/household-purge` runner (#161).
 
 ---
 
@@ -135,7 +135,7 @@ See [ADR-0006](ADR/0006-multi-tenant-model.md), [ADR-0007](ADR/0007-member-lifec
 
 **Done criteria:** Enter 0.05123456789012345 BTC, see value without precision loss; enter VTSAX, see allocation chart.
 
-**Backlog filed:** today's P&L tile (#122) — requires daily snapshots or a price feed.
+**Backlog landed:** today's P&L tile (#122) — shipped as the snapshot-pair "Recent change" tile (between the two most recent snapshot dates per holding, no external price feed needed).
 
 ---
 
@@ -169,16 +169,16 @@ goal through the UI, not just that the endpoint exists.
 
 - [x] First-boot `/setup/admin` page (admin creation + signup_mode picker)
 - [x] `/signin` page + session cookie handling + redirect logic
-- [x] `/signup` page (gated by `signup_mode`; invite-token form in invite_only deferred to #145)
-- [x] `/h/members` — list members, roles, owner-mint invite (in-grace badges + owner-side moderation deferred to #147)
-- [x] `/h/dashboard` — household-aggregate dashboard layout (consumes `aggregator.Dashboard`; per-member tiles deferred to #149)
+- [x] `/signup` page (gated by `signup_mode`; invite-token form in invite_only landed in #145)
+- [x] `/h/members` — list members, roles, owner-mint invite; in-grace badges + owner-side moderation landed in #147
+- [x] `/h/dashboard` — household-aggregate dashboard layout (consumes `aggregator.Dashboard`); per-member tiles landed in #149
 - [x] Account visibility chips on `/accounts` (per-household: private / balance-only / balance-and-txns)
-- [x] `/h/settings` — household name, grace period, leave button (owner transfer deferred to #152)
+- [x] `/h/settings` — household name, grace period, leave button; owner transfer landed in #152
 - [x] Scope-switcher polish: empty-state when not in a household, "create or join" CTA
 
 **Done criteria:** Fresh `docker compose up` → admin signup → invite a second user → second user joins → both see members page + household dashboard with real aggregate data → second user leaves → admin sees them in-grace → admin sets grace to 0 → purge runs. Every step clickable in the UI.
 
-**Backlog filed:** signup-with-invite endpoint (#145), owner-side member moderation (#147), per-member dashboard tiles (#149), owner-transfer endpoint (#152).
+**Backlog landed post-M8:** signup-with-invite endpoint (#145), owner-side member moderation (#147), per-member dashboard tiles (#149), owner-transfer endpoint (#152).
 
 ### M9+ — Frontend Hi-Fi: Per-Feature [DEFERRED]
 


### PR DESCRIPTION
## Summary
Two stale-claim cleanups that came up while reviewing the roadmap end-to-end.

**docs/ROADMAP.md**
- M2.5 "Out of scope (deferred)" section listed Members UI / Household Dashboard / visibility chips / Household AI / shared_budgets / shared_goals / household-purge as deferred. All seven have shipped (#140, #141, #142, #167, #163, #165, #161). Rewords the list to "Originally deferred — all shipped post-M8" with the closing-PR refs so the history reads cleanly.
- M2.5 Done-criteria sentence dropped the trailing "...wait for hi-fi" clause that hasn't been true for ~24 PRs.
- M8 "Backlog filed" lines flipped to "Backlog landed" since #145/#147/#149/#152 all merged.
- M6 backlog flipped similarly (#122 shipped as the snapshot-pair "Recent change" tile).

**.env.example**
- `SESSION_SECRET` comment now flags its second responsibility per ADR-0012: it's also the source (via SHA-256) for the AES-256 key that encrypts per-user Claude keys in `user_settings.claude_api_key_enc`. Rotating `SESSION_SECRET` invalidates sessions AND makes every stored Claude key unrecoverable. Future runbook hazard worth flagging in the file the operator actually reads.

Pure docs / config-comment change.