### PR TITLE
fix(dev): dev-compose accessible over LAN / Tailscale (#174)

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,65 @@ docker compose up
 
 Go + Gin | PostgreSQL | React + Vite + TypeScript | Docker Compose
 
+## Running the app
+
+Three supported ways to run, pick one:
+
+### 1. Full Docker (production-ish)
+
+Builds backend + frontend images, serves the static Vite bundle via nginx. No live reload.
+
+```bash
+docker compose up
+```
+
+Use this for: trying the app, demos, or self-hosting.
+
+### 2. Dev Docker (live reload)
+
+Backend runs under [air](https://github.com/cosmtrek/air), frontend runs Vite dev server, both inside containers. Source-mounted, so edits reload automatically.
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.dev.yml up
+```
+
+**Prerequisite (Colima/Podman/Docker Desktop):** the VM needs ≥4 GiB or the backend's first cold compile will be OOM-killed. For Colima:
+
+```bash
+colima stop
+colima start --memory 4 --save-config
+```
+
+See [docs/dev/colima.md](docs/dev/colima.md) for details. Docker Desktop / Podman Desktop users: bump the VM memory in the GUI.
+
+Use this for: most active development.
+
+### 3. Native dev (fastest iteration)
+
+Run backend and frontend directly on the host; only Postgres in Docker.
+
+```bash
+docker compose up -d postgres                  # Postgres only
+(cd backend && make dev)                       # Go server on :8000
+(cd frontend && pnpm install && pnpm dev)      # Vite on :5173
+```
+
+Backend helpers: `make smoke` (start + wait for /health), `make stop` (kill by port), `make test`, `make verify`. See [AGENTS.md](AGENTS.md) for the full list.
+
+Use this for: tight Go iteration loops where container rebuild latency hurts.
+
+### Accessing from another device on your LAN (phone, tablet)
+
+Options 1 and 2 already bind to all interfaces, so just point the device at your machine's LAN IP:
+
+```bash
+ipconfig getifaddr en0    # macOS: prints e.g. 192.168.x.x
+```
+
+Then open `http://<that-ip>:5173`. The first connection may trigger a macOS firewall allow prompt.
+
+Option 3 needs Vite told explicitly: `pnpm dev --host 0.0.0.0`.
+
 ## Development
 
-See [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for the full technical reference and [docs/ROADMAP.md](docs/ROADMAP.md) for current progress.
+See [AGENTS.md](AGENTS.md) for session conventions and commands, [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for the full technical reference, and [docs/ROADMAP.md](docs/ROADMAP.md) for current progress.

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -33,7 +33,9 @@ services:
       - ./frontend:/app
       - frontend_node_modules:/app/node_modules
     environment:
-      VITE_API_BASE_URL: ""
+      # VITE_API_BASE_URL intentionally unset — client.ts falls back to '/api/v1'
+      # (nullish coalescing doesn't fall back on ""), and Vite proxies /api/* to
+      # the backend container via VITE_PROXY_TARGET.
       VITE_PROXY_TARGET: http://backend:8000
 
 volumes:

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -12,6 +12,9 @@ export default defineConfig(({ mode }) => {
     plugins: [react(), tailwindcss()],
     server: {
       port: 5173,
+      // Allow Tailscale MagicDNS (*.ts.net) and Bonjour (*.local) so dev server
+      // is reachable from phones/tablets without disabling Vite's host check.
+      allowedHosts: ['.ts.net', '.local'],
       proxy: {
         '/api': {
           target: proxyTarget,


### PR DESCRIPTION
## Summary
- `frontend/vite.config.ts`: allow `.ts.net` and `.local` hosts so Tailscale MagicDNS and Bonjour names don't 403 on Vite's DNS-rebinding check.
- `docker-compose.dev.yml`: remove `VITE_API_BASE_URL: ""`. Empty string defeats `?? '/api/v1'` in `client.ts`; axios called `/setup/status` (no prefix), Vite served it as the SPA index.html, and auth hydrate hung forever. Reproduces on `http://localhost:5173`, not just over Tailscale.
- `README.md`: document all three run modes + Colima 4 GiB prerequisite + LAN-access notes.

## Test plan
- [x] `docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d` → load `http://localhost:5173` → auth hydrates, no infinite loading
- [x] curl `https://<host>.ts.net/api/v1/setup/status` via Tailscale Serve → 200 JSON
- [x] curl `Host: foo.example` → 403 (Vite still rejects unknown hosts)
- [x] curl `Host: test.ts.net` → 200
- [ ] Live load from phone over Tailscale once shields-up and ACLs allow inbound

Closes #174