### PR TITLE
chore: gitignore air build dir and Claude scheduled-tasks lock (#177)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ frontend/node_modules/
 
 # Build output
 backend/bin/
+backend/tmp/
 frontend/dist/
 
 # Environment
@@ -38,6 +39,7 @@ go.work.sum
 
 # Claude Code local settings
 .claude/settings.local.json
+.claude/scheduled_tasks.lock
 
 # Test coverage
 coverage/


### PR DESCRIPTION
## Summary
Two runtime artifacts were dirtying \`git status\` after a dev-compose run:
- \`backend/tmp/server\` — air's build output
- \`.claude/scheduled_tasks.lock\` — Claude Code scheduled-tasks lock

Both added to \`.gitignore\`.

Closes #177