### PR TITLE
feat(config): APP_ENV-driven per-env DB isolation (closes #183)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,17 @@
-# PostgreSQL
-DATABASE_URL=postgres://offbook:offbook@localhost:5432/offbook?sslmode=disable
+# Environment selector (#183). Drives the default DB URL. The Makefile
+# sets this for you (`make dev` → dev, `make test` → test); only set it
+# manually if you're running `go run ./cmd/server` by hand.
+#
+#   dev   → postgres://offbook:offbook@localhost:5432/offbook_dev (default)
+#   test  → postgres://offbook:offbook@localhost:5432/offbook_test
+#   prod  → DATABASE_URL is REQUIRED (no default; refuses to start otherwise)
+APP_ENV=dev
+
+# PostgreSQL — optional override. When unset, APP_ENV selects the URL.
+# Set this only if you need to point at a non-default host (remote DB,
+# alternate port). docker-compose injects this internally so the container
+# uses the in-network `postgres` hostname rather than localhost.
+# DATABASE_URL=
 
 # Backend
 PORT=8000

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
         env:
           POSTGRES_USER: offbook
           POSTGRES_PASSWORD: offbook
-          POSTGRES_DB: offbook
+          POSTGRES_DB: offbook_test
         ports:
           - 5432:5432
         options: >-
@@ -44,7 +44,8 @@ jobs:
           --health-timeout 5s
           --health-retries 10
     env:
-      DATABASE_URL: postgres://offbook:offbook@localhost:5432/offbook?sslmode=disable
+      APP_ENV: test
+      DATABASE_URL: postgres://offbook:offbook@localhost:5432/offbook_test?sslmode=disable
     defaults:
       run:
         working-directory: backend

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,8 +50,10 @@ When running via Claude's Bash tool, prefix `make` with `command` (`command make
 
 ## Environment Isolation
 - **Every environment gets its own database.** Dev, test, prod (and any future staging) never share a DB. Sharing leaks fixtures between them — `make test` running against the dev DB has corrupted dev data in the past (test-fixture `categories` showing up in the user's category dropdown; see #183).
-- DB selection routes through `APP_ENV` (or equivalent), not a single shared `DATABASE_URL`. Each env resolves its own URL; prod refuses to start without an explicit one.
-- When adding a new entry point (CLI, cron, worker), make it env-aware too — it picks up the right DB automatically.
+- DB selection routes through `APP_ENV`, resolved by `internal/config.ResolveDatabaseURL`. Defaults: `dev` → `offbook_dev`, `test` → `offbook_test`, `prod` → no default (refuses to start without explicit `DATABASE_URL`). Explicit `DATABASE_URL` always wins (docker-compose and prod inject one).
+- When adding a new entry point (CLI, cron, worker), call `config.Load()` so it picks up the right DB automatically. Don't re-read `DATABASE_URL` from `os.Getenv` directly.
+- `make dev` / `make smoke` set `APP_ENV=dev`. `make test` sets `APP_ENV=test` and points at `offbook_test`, migrating it first.
+- One-shot cleanup of a polluted pre-#183 DB: `cd backend && go run ./cmd/db-clean-fixtures --apply` (dry-run by default; refuses to run against `offbook_test`).
 - "Just use a `TEST_DATABASE_URL` env var" is not enough — the structural fix is config-layer isolation across all envs, not a Makefile flag.
 
 ## Plaid Sandbox

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -13,6 +13,12 @@ PIDFILE    ?= /tmp/offbook-server.pid
 LOGFILE    ?= /tmp/offbook-server.log
 HEALTH_URL  = http://localhost:$(PORT)/api/v1/health
 
+# Env isolation (#183): dev / test / prod each resolve their own DB through
+# internal/config. `make dev` runs against APP_ENV=dev (offbook_dev DB);
+# `make test` runs against APP_ENV=test (offbook_test DB). Override with
+# DATABASE_URL on either if you need to point at a non-local Postgres.
+TEST_DATABASE_URL ?= postgres://offbook:offbook@localhost:5432/offbook_test?sslmode=disable
+
 .PHONY: help dev stop restart smoke test test-v test-fast lint vet build verify clean routes logs
 
 help:
@@ -39,7 +45,7 @@ stop:
 	@echo "stopped (port $(PORT) free)"
 
 dev: stop
-	@go run ./cmd/server > $(LOGFILE) 2>&1 & echo $$! > $(PIDFILE)
+	@APP_ENV=dev go run ./cmd/server > $(LOGFILE) 2>&1 & echo $$! > $(PIDFILE)
 	@echo "started (pid $$(cat $(PIDFILE)), log $(LOGFILE))"
 
 restart: stop dev
@@ -62,14 +68,19 @@ smoke: dev
 # -race -p 1 mirrors CI exactly. Integration tests share one DATABASE_URL,
 # so parallel packages step on each other's rows. Use `make test-fast` for
 # tight dev loops on a single package, but `make test` is what CI sees.
+#
+# APP_ENV=test + DATABASE_URL=offbook_test guarantees the test suite cannot
+# touch the dev DB (#183). Migrations run first so a fresh checkout works
+# without manual setup.
 test:
-	@go test -race -p 1 ./...
+	@APP_ENV=test DATABASE_URL='$(TEST_DATABASE_URL)' go run ./cmd/migrate up >/dev/null
+	@APP_ENV=test DATABASE_URL='$(TEST_DATABASE_URL)' go test -race -p 1 ./...
 
 test-fast:
-	@go test ./...
+	@APP_ENV=test DATABASE_URL='$(TEST_DATABASE_URL)' go test ./...
 
 test-v:
-	@go test -race -p 1 -v ./...
+	@APP_ENV=test DATABASE_URL='$(TEST_DATABASE_URL)' go test -race -p 1 -v ./...
 
 lint:
 	@docker run --rm -v "$$PWD":/app -w /app golangci/golangci-lint:latest-alpine golangci-lint run ./...

--- a/backend/cmd/db-clean-fixtures/main.go
+++ b/backend/cmd/db-clean-fixtures/main.go
@@ -1,0 +1,257 @@
+// One-shot cleanup of integration-test fixture rows from a DB that was
+// polluted before env isolation (#183) split dev and test into separate
+// databases.
+//
+// Targets:
+//   - users with `@example.test` emails (the standard test-fixture marker)
+//     and every owned row that hangs off them
+//   - non-system categories whose names match the timestamp-suffix pattern
+//     `XX-NNNNNN.NNNNNN` produced by the integration suite (AlertCat-*,
+//     IsoAlert-*, EdgeCat-*, CtxGroc-*, Inactive-*, …)
+//
+// Usage (against the dev DB):
+//
+//	cd backend && go run ./cmd/db-clean-fixtures            # dry run
+//	cd backend && go run ./cmd/db-clean-fixtures --apply    # actually delete
+//
+// Safe to run repeatedly. Refuses to run against a URL whose database name
+// is `offbook_test` — that DB is supposed to be full of fixtures.
+package main
+
+import (
+	"context"
+	"database/sql"
+	"flag"
+	"fmt"
+	"log"
+	"net/url"
+	"strings"
+
+	_ "github.com/lib/pq"
+
+	"github.com/gregwym/offbook/backend/internal/config"
+)
+
+func main() {
+	apply := flag.Bool("apply", false, "actually delete (default is dry-run)")
+	flag.Parse()
+
+	cfg := config.MustLoad()
+	if cfg.DatabaseURL == "" {
+		log.Fatal("DATABASE_URL is empty after config.Load — refusing to run")
+	}
+	dbName, err := databaseName(cfg.DatabaseURL)
+	if err != nil {
+		log.Fatalf("parse DATABASE_URL: %v", err)
+	}
+	if dbName == "offbook_test" {
+		log.Fatal("refusing to run against offbook_test — that DB is meant to hold fixtures")
+	}
+
+	db, err := sql.Open("postgres", cfg.DatabaseURL)
+	if err != nil {
+		log.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+	if err := db.Ping(); err != nil {
+		log.Fatalf("ping db: %v", err)
+	}
+	ctx := context.Background()
+
+	fmt.Printf("connected to %s (apply=%v)\n\n", dbName, *apply)
+
+	// Each step prints its row count regardless of mode. In dry-run we use
+	// SELECT-style counts; in apply mode we use DELETE … RETURNING-style
+	// counts via RowsAffected so the numbers report what really happened.
+	steps := []cleanupStep{
+		// Fixture user emails follow `*-<unix-nanos>-…@example.test` and
+		// adjacent patterns. The @example.test suffix is the reliable marker.
+		{
+			label: "household_invites for fixture users",
+			countSQL: `SELECT COUNT(*) FROM household_invites WHERE created_by IN
+				(SELECT id FROM users WHERE email LIKE '%@example.test')`,
+			deleteSQL: `DELETE FROM household_invites WHERE created_by IN
+				(SELECT id FROM users WHERE email LIKE '%@example.test')`,
+		},
+		{
+			label: "household_members for fixture users",
+			countSQL: `SELECT COUNT(*) FROM household_members WHERE user_id IN
+				(SELECT id FROM users WHERE email LIKE '%@example.test')`,
+			deleteSQL: `DELETE FROM household_members WHERE user_id IN
+				(SELECT id FROM users WHERE email LIKE '%@example.test')`,
+		},
+		{
+			label: "account_shares for fixture-owned accounts",
+			countSQL: `SELECT COUNT(*) FROM account_shares WHERE account_id IN
+				(SELECT id FROM accounts WHERE user_id IN
+					(SELECT id FROM users WHERE email LIKE '%@example.test'))`,
+			deleteSQL: `DELETE FROM account_shares WHERE account_id IN
+				(SELECT id FROM accounts WHERE user_id IN
+					(SELECT id FROM users WHERE email LIKE '%@example.test'))`,
+		},
+		{
+			label: "ai_messages for fixture users (via thread)",
+			countSQL: `SELECT COUNT(*) FROM ai_messages WHERE thread_id IN
+				(SELECT id FROM ai_threads WHERE user_id IN
+					(SELECT id FROM users WHERE email LIKE '%@example.test'))`,
+			deleteSQL: `DELETE FROM ai_messages WHERE thread_id IN
+				(SELECT id FROM ai_threads WHERE user_id IN
+					(SELECT id FROM users WHERE email LIKE '%@example.test'))`,
+		},
+		{
+			label: "ai_threads for fixture users",
+			countSQL: `SELECT COUNT(*) FROM ai_threads WHERE user_id IN
+				(SELECT id FROM users WHERE email LIKE '%@example.test')`,
+			deleteSQL: `DELETE FROM ai_threads WHERE user_id IN
+				(SELECT id FROM users WHERE email LIKE '%@example.test')`,
+		},
+		{
+			label: "pii_store for fixture-owned accounts/transactions",
+			countSQL: `SELECT COUNT(*) FROM pii_store WHERE
+				(entity_type = 'account' AND entity_id IN
+					(SELECT id FROM accounts WHERE user_id IN
+						(SELECT id FROM users WHERE email LIKE '%@example.test')))
+				OR (entity_type = 'transaction' AND entity_id IN
+					(SELECT id FROM transactions WHERE user_id IN
+						(SELECT id FROM users WHERE email LIKE '%@example.test')))`,
+			deleteSQL: `DELETE FROM pii_store WHERE
+				(entity_type = 'account' AND entity_id IN
+					(SELECT id FROM accounts WHERE user_id IN
+						(SELECT id FROM users WHERE email LIKE '%@example.test')))
+				OR (entity_type = 'transaction' AND entity_id IN
+					(SELECT id FROM transactions WHERE user_id IN
+						(SELECT id FROM users WHERE email LIKE '%@example.test')))`,
+		},
+		{
+			label: "transactions for fixture users",
+			countSQL: `SELECT COUNT(*) FROM transactions WHERE user_id IN
+				(SELECT id FROM users WHERE email LIKE '%@example.test')`,
+			deleteSQL: `DELETE FROM transactions WHERE user_id IN
+				(SELECT id FROM users WHERE email LIKE '%@example.test')`,
+		},
+		{
+			label: "savings_goals for fixture users",
+			countSQL: `SELECT COUNT(*) FROM savings_goals WHERE user_id IN
+				(SELECT id FROM users WHERE email LIKE '%@example.test')`,
+			deleteSQL: `DELETE FROM savings_goals WHERE user_id IN
+				(SELECT id FROM users WHERE email LIKE '%@example.test')`,
+		},
+		{
+			label: "investments for fixture users",
+			countSQL: `SELECT COUNT(*) FROM investments WHERE user_id IN
+				(SELECT id FROM users WHERE email LIKE '%@example.test')`,
+			deleteSQL: `DELETE FROM investments WHERE user_id IN
+				(SELECT id FROM users WHERE email LIKE '%@example.test')`,
+		},
+		{
+			label: "budgets for fixture users",
+			countSQL: `SELECT COUNT(*) FROM budgets WHERE user_id IN
+				(SELECT id FROM users WHERE email LIKE '%@example.test')`,
+			deleteSQL: `DELETE FROM budgets WHERE user_id IN
+				(SELECT id FROM users WHERE email LIKE '%@example.test')`,
+		},
+		{
+			label: "categorization_rules for fixture users",
+			countSQL: `SELECT COUNT(*) FROM categorization_rules WHERE user_id IN
+				(SELECT id FROM users WHERE email LIKE '%@example.test')`,
+			deleteSQL: `DELETE FROM categorization_rules WHERE user_id IN
+				(SELECT id FROM users WHERE email LIKE '%@example.test')`,
+		},
+		{
+			label: "plaid_items for fixture users",
+			countSQL: `SELECT COUNT(*) FROM plaid_items WHERE user_id IN
+				(SELECT id FROM users WHERE email LIKE '%@example.test')`,
+			deleteSQL: `DELETE FROM plaid_items WHERE user_id IN
+				(SELECT id FROM users WHERE email LIKE '%@example.test')`,
+		},
+		{
+			label: "accounts for fixture users",
+			countSQL: `SELECT COUNT(*) FROM accounts WHERE user_id IN
+				(SELECT id FROM users WHERE email LIKE '%@example.test')`,
+			deleteSQL: `DELETE FROM accounts WHERE user_id IN
+				(SELECT id FROM users WHERE email LIKE '%@example.test')`,
+		},
+		{
+			label: "households owned by fixture users",
+			countSQL: `SELECT COUNT(*) FROM households WHERE owner_id IN
+				(SELECT id FROM users WHERE email LIKE '%@example.test')`,
+			deleteSQL: `DELETE FROM households WHERE owner_id IN
+				(SELECT id FROM users WHERE email LIKE '%@example.test')`,
+		},
+		{
+			label: "sessions for fixture users",
+			countSQL: `SELECT COUNT(*) FROM sessions WHERE user_id IN
+				(SELECT id FROM users WHERE email LIKE '%@example.test')`,
+			deleteSQL: `DELETE FROM sessions WHERE user_id IN
+				(SELECT id FROM users WHERE email LIKE '%@example.test')`,
+		},
+		{
+			label:     "fixture users (@example.test)",
+			countSQL:  `SELECT COUNT(*) FROM users WHERE email LIKE '%@example.test'`,
+			deleteSQL: `DELETE FROM users WHERE email LIKE '%@example.test'`,
+		},
+		// Non-system categories whose names carry the integration-suite
+		// timestamp suffix (`HHMMSS.NNNNNN` or `NN-HHMMSS.NNNNNN`). Using
+		// SIMILAR TO keeps the match tight so a legitimately-named category
+		// like "AlertCat" without a numeric tail is left alone.
+		{
+			label: "fixture categories (timestamp-suffix, non-system)",
+			countSQL: `SELECT COUNT(*) FROM categories
+				WHERE is_system = false
+				  AND name SIMILAR TO '%[0-9]{6}\.[0-9]{6,}'`,
+			deleteSQL: `DELETE FROM categories
+				WHERE is_system = false
+				  AND name SIMILAR TO '%[0-9]{6}\.[0-9]{6,}'`,
+		},
+	}
+
+	for _, s := range steps {
+		n, err := s.run(ctx, db, *apply)
+		if err != nil {
+			log.Fatalf("%s: %v", s.label, err)
+		}
+		verb := "would delete"
+		if *apply {
+			verb = "deleted"
+		}
+		fmt.Printf("%6d  %s  — %s\n", n, verb, s.label)
+	}
+
+	if !*apply {
+		fmt.Println("\n(dry run — re-run with --apply to actually delete)")
+	}
+}
+
+type cleanupStep struct {
+	label     string
+	countSQL  string
+	deleteSQL string
+}
+
+func (s cleanupStep) run(ctx context.Context, db *sql.DB, apply bool) (int64, error) {
+	if !apply {
+		var n int64
+		if err := db.QueryRowContext(ctx, s.countSQL).Scan(&n); err != nil {
+			return 0, err
+		}
+		return n, nil
+	}
+	res, err := db.ExecContext(ctx, s.deleteSQL)
+	if err != nil {
+		return 0, err
+	}
+	return res.RowsAffected()
+}
+
+// databaseName extracts the database name from a Postgres URL.
+func databaseName(rawURL string) (string, error) {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return "", err
+	}
+	name := strings.TrimPrefix(u.Path, "/")
+	if name == "" {
+		return "", fmt.Errorf("no database name in URL")
+	}
+	return name, nil
+}

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -10,7 +10,16 @@ import (
 	"github.com/joho/godotenv"
 )
 
+// AppEnv is the environment label that drives DB selection and any other
+// per-env behavior. See ResolveDatabaseURL.
+const (
+	AppEnvDev  = "dev"
+	AppEnvTest = "test"
+	AppEnvProd = "prod"
+)
+
 type Config struct {
+	AppEnv         string // dev | test | prod (see Resolve* helpers)
 	Port           string
 	DatabaseURL    string
 	FrontendURL    string
@@ -42,6 +51,46 @@ func (c Config) ClaudeConfigured() bool {
 	return c.ClaudeAPIKey != ""
 }
 
+// ResolveAppEnv normalizes and validates APP_ENV. Empty → "dev" (the default
+// for a fresh local checkout).
+func ResolveAppEnv(raw string) (string, error) {
+	if raw == "" {
+		return AppEnvDev, nil
+	}
+	switch raw {
+	case AppEnvDev, AppEnvTest, AppEnvProd:
+		return raw, nil
+	default:
+		return "", fmt.Errorf("APP_ENV must be %s|%s|%s, got %q",
+			AppEnvDev, AppEnvTest, AppEnvProd, raw)
+	}
+}
+
+// ResolveDatabaseURL picks the DB URL for the given app env. Explicit
+// DATABASE_URL always wins (this is how docker-compose and prod inject the
+// connection string). When unset:
+//   - dev → local Postgres, database "offbook_dev"
+//   - test → local Postgres, database "offbook_test"
+//   - prod → no default; returns an error (force operators to be explicit)
+//
+// This is the structural fix for #183: every env resolves its own URL through
+// one place, so the dev DB and the test DB can never accidentally collide.
+func ResolveDatabaseURL(appEnv, explicitURL string) (string, error) {
+	if explicitURL != "" {
+		return explicitURL, nil
+	}
+	switch appEnv {
+	case AppEnvDev:
+		return "postgres://offbook:offbook@localhost:5432/offbook_dev?sslmode=disable", nil
+	case AppEnvTest:
+		return "postgres://offbook:offbook@localhost:5432/offbook_test?sslmode=disable", nil
+	case AppEnvProd:
+		return "", errors.New("APP_ENV=prod requires DATABASE_URL to be set explicitly (no default)")
+	default:
+		return "", fmt.Errorf("unknown APP_ENV %q", appEnv)
+	}
+}
+
 // Load reads env vars (with .env support) and validates required combinations.
 // Fails fast on misconfiguration so the server never starts with broken
 // invariants (e.g. PLAID_CLIENT_ID set but no encryption key — would silently
@@ -53,9 +102,19 @@ func Load() (Config, error) {
 	loadDotenv(".env")
 	loadDotenv("../.env")
 
+	appEnv, err := ResolveAppEnv(os.Getenv("APP_ENV"))
+	if err != nil {
+		return Config{}, err
+	}
+	dbURL, err := ResolveDatabaseURL(appEnv, os.Getenv("DATABASE_URL"))
+	if err != nil {
+		return Config{}, err
+	}
+
 	cfg := Config{
+		AppEnv:         appEnv,
 		Port:           getenv("PORT", "8000"),
-		DatabaseURL:    os.Getenv("DATABASE_URL"),
+		DatabaseURL:    dbURL,
 		FrontendURL:    getenv("FRONTEND_URL", "http://localhost:5173"),
 		MigrationsPath: getenv("MIGRATIONS_PATH", "migrations"),
 		SessionSecret:  os.Getenv("SESSION_SECRET"),

--- a/backend/internal/config/config_test.go
+++ b/backend/internal/config/config_test.go
@@ -1,0 +1,150 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestResolveAppEnv(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      string
+		want    string
+		wantErr bool
+	}{
+		{name: "empty defaults to dev", in: "", want: AppEnvDev},
+		{name: "dev", in: AppEnvDev, want: AppEnvDev},
+		{name: "test", in: AppEnvTest, want: AppEnvTest},
+		{name: "prod", in: AppEnvProd, want: AppEnvProd},
+		{name: "garbage rejected", in: "staging", wantErr: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ResolveAppEnv(tc.in)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("want error, got nil (returned %q)", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestResolveDatabaseURL(t *testing.T) {
+	tests := []struct {
+		name        string
+		appEnv      string
+		explicit    string
+		wantSubstr  string // expected substring in successful URL
+		wantErrLike string // expected substring in error message
+	}{
+		{
+			name:       "explicit wins for dev",
+			appEnv:     AppEnvDev,
+			explicit:   "postgres://x:y@h:1/custom?sslmode=disable",
+			wantSubstr: "/custom?",
+		},
+		{
+			name:       "explicit wins for prod (the production path)",
+			appEnv:     AppEnvProd,
+			explicit:   "postgres://prod:prod@db.internal/offbook?sslmode=require",
+			wantSubstr: "db.internal",
+		},
+		{
+			name:       "dev default",
+			appEnv:     AppEnvDev,
+			wantSubstr: "/offbook_dev?",
+		},
+		{
+			name:       "test default",
+			appEnv:     AppEnvTest,
+			wantSubstr: "/offbook_test?",
+		},
+		{
+			name:        "prod with no explicit URL is an error",
+			appEnv:      AppEnvProd,
+			wantErrLike: "DATABASE_URL",
+		},
+		{
+			name:        "unknown env is an error",
+			appEnv:      "staging",
+			wantErrLike: "unknown",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ResolveDatabaseURL(tc.appEnv, tc.explicit)
+			if tc.wantErrLike != "" {
+				if err == nil {
+					t.Fatalf("want error containing %q, got nil (URL=%q)", tc.wantErrLike, got)
+				}
+				if !strings.Contains(err.Error(), tc.wantErrLike) {
+					t.Fatalf("error %q does not contain %q", err.Error(), tc.wantErrLike)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !strings.Contains(got, tc.wantSubstr) {
+				t.Fatalf("URL %q does not contain %q", got, tc.wantSubstr)
+			}
+		})
+	}
+}
+
+// TestLoad_DefaultsToDevDB verifies the integrated path: empty APP_ENV +
+// empty DATABASE_URL → resolves to the dev DB. This is the structural fix
+// for #183 — the dev path can't accidentally use whatever DATABASE_URL the
+// shell happened to inherit from a test run.
+func TestLoad_DefaultsToDevDB(t *testing.T) {
+	t.Setenv("APP_ENV", "")
+	t.Setenv("DATABASE_URL", "")
+	// Strip secrets that would otherwise fail Plaid validation.
+	t.Setenv("PLAID_CLIENT_ID", "")
+	t.Setenv("PLAID_SECRET", "")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.AppEnv != AppEnvDev {
+		t.Errorf("AppEnv = %q, want %q", cfg.AppEnv, AppEnvDev)
+	}
+	if !strings.Contains(cfg.DatabaseURL, "/offbook_dev?") {
+		t.Errorf("DatabaseURL = %q, want it to point at offbook_dev", cfg.DatabaseURL)
+	}
+}
+
+func TestLoad_TestEnvUsesTestDB(t *testing.T) {
+	t.Setenv("APP_ENV", AppEnvTest)
+	t.Setenv("DATABASE_URL", "")
+	t.Setenv("PLAID_CLIENT_ID", "")
+	t.Setenv("PLAID_SECRET", "")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if !strings.Contains(cfg.DatabaseURL, "/offbook_test?") {
+		t.Errorf("DatabaseURL = %q, want it to point at offbook_test", cfg.DatabaseURL)
+	}
+}
+
+func TestLoad_ProdRequiresExplicitDatabaseURL(t *testing.T) {
+	t.Setenv("APP_ENV", AppEnvProd)
+	t.Setenv("DATABASE_URL", "")
+	t.Setenv("PLAID_CLIENT_ID", "")
+	t.Setenv("PLAID_SECRET", "")
+
+	if _, err := Load(); err == nil {
+		t.Fatal("want error when APP_ENV=prod and DATABASE_URL is empty; got nil")
+	}
+}

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -10,7 +10,8 @@ services:
       - ./backend:/app
       - backend_go_mod:/go/pkg/mod
     environment:
-      DATABASE_URL: postgres://offbook:offbook@postgres:5432/offbook?sslmode=disable
+      APP_ENV: dev
+      DATABASE_URL: postgres://offbook:offbook@postgres:5432/offbook_dev?sslmode=disable
       PORT: "8000"
       FRONTEND_URL: http://localhost:5173
       MIGRATIONS_PATH: /app/migrations

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,13 +4,17 @@ services:
     environment:
       POSTGRES_USER: offbook
       POSTGRES_PASSWORD: offbook
-      POSTGRES_DB: offbook
+      POSTGRES_DB: offbook_dev
     ports:
       - "5432:5432"
     volumes:
       - ./data/postgres:/var/lib/postgresql/data
+      # Init scripts run only on first volume creation (when the data dir is
+      # empty). They provision the test DB alongside the dev DB so `make test`
+      # never touches dev rows. See #183 + infra/postgres/init/.
+      - ./infra/postgres/init:/docker-entrypoint-initdb.d:ro
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U offbook -d offbook"]
+      test: ["CMD-SHELL", "pg_isready -U offbook -d offbook_dev"]
       interval: 5s
       timeout: 5s
       retries: 10
@@ -22,7 +26,8 @@ services:
     ports:
       - "8000:8000"
     environment:
-      DATABASE_URL: postgres://offbook:offbook@postgres:5432/offbook?sslmode=disable
+      APP_ENV: dev
+      DATABASE_URL: postgres://offbook:offbook@postgres:5432/offbook_dev?sslmode=disable
       PORT: "8000"
       FRONTEND_URL: http://localhost:5173
       MIGRATIONS_PATH: /app/migrations

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -287,7 +287,8 @@ func (h *AccountHandler) Create(c *gin.Context) {
 
 | Variable | Required | Description |
 |---|---|---|
-| `DATABASE_URL` | Yes | PostgreSQL connection string |
+| `APP_ENV` | No | `dev` \| `test` \| `prod`. Default `dev`. Selects the default DB when `DATABASE_URL` is unset: `dev` → `offbook_dev`, `test` → `offbook_test`, `prod` → no default (refuses to start). See #183. |
+| `DATABASE_URL` | Yes in prod, optional elsewhere | PostgreSQL connection string. Overrides the `APP_ENV`-derived default. docker-compose injects this internally so the container uses the in-network `postgres` hostname. |
 | `PORT` | No | Backend port (default: 8000) |
 | `FRONTEND_URL` | No | CORS origin (default: http://localhost:5173) |
 | `MIGRATIONS_PATH` | No | Path to golang-migrate SQL dir (default: `migrations`) |

--- a/infra/postgres/init/01-create-test-db.sh
+++ b/infra/postgres/init/01-create-test-db.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Provision a sibling test database alongside the dev database on first
+# Postgres-volume creation. Docker's official `postgres` image runs every
+# *.sh / *.sql file in /docker-entrypoint-initdb.d once, only when the data
+# directory is empty.
+#
+# Why this exists: see #183. Sharing one DB between `docker compose up`
+# and `make test` lets test fixtures bleed into the dev UI (e.g. categories
+# named `AlertCat-50-102333.896245` showing up in the user's dropdown).
+# Each env gets its own database; the dev one is created by Postgres from
+# POSTGRES_DB, and this script adds the test one.
+set -euo pipefail
+
+psql -v ON_ERROR_STOP=1 --username "${POSTGRES_USER}" --dbname "${POSTGRES_DB}" <<-EOSQL
+	CREATE DATABASE offbook_test;
+	GRANT ALL PRIVILEGES ON DATABASE offbook_test TO ${POSTGRES_USER};
+EOSQL


### PR DESCRIPTION
## Summary
- Splits dev and test into separate Postgres databases so the test suite cannot pollute the dev DB (which is what produced the leaked `AlertCat-*` / `IsoAlert-*` / `EdgeCat-*` categories the user saw in the UI).
- `internal/config.ResolveDatabaseURL` is the single resolver: `dev → offbook_dev`, `test → offbook_test`, `prod` requires an explicit `DATABASE_URL` (refuses to start otherwise). Explicit `DATABASE_URL` always wins, so docker-compose and prod can still inject one.
- `docker-compose` now creates `offbook_dev` by default and provisions `offbook_test` alongside via `infra/postgres/init/01-create-test-db.sh` (Postgres entrypoint init scripts run only on first volume create).
- `make dev`/`make smoke` set `APP_ENV=dev`. `make test`/`test-fast`/`test-v` set `APP_ENV=test`, point `DATABASE_URL` at `offbook_test`, and migrate the test DB first so a fresh checkout works.
- CI workflow flipped to `POSTGRES_DB=offbook_test` and `APP_ENV=test`.
- New `backend/cmd/db-clean-fixtures` (dry-run by default; `--apply` to delete) to wipe `@example.test` fixture users + timestamp-suffix categories from a polluted pre-#183 DB. Refuses to run against `offbook_test`.
- Config unit tests cover `ResolveAppEnv`, `ResolveDatabaseURL`, and `Load`'s default behavior per env.

Closes #183.

## Upgrading an existing checkout
Existing `./data/postgres` volumes have only the old `offbook` DB. Pick one:

**Easy:** drop the volume and re-up.
```
docker compose down
rm -rf data/postgres
docker compose up
```

**Preserve data:** create the new DBs manually.
```
docker exec offbook-postgres-1 psql -U offbook -d postgres -c 'CREATE DATABASE offbook_dev;'
docker exec offbook-postgres-1 psql -U offbook -d postgres -c 'CREATE DATABASE offbook_test;'
# Optional: rename your existing offbook → offbook_dev, or pg_dump/restore.
```

Then optionally run the fixture cleanup against your polluted dev DB:
```
cd backend && go run ./cmd/db-clean-fixtures             # dry run
cd backend && go run ./cmd/db-clean-fixtures --apply     # delete
```

## Test plan
- [x] `make verify` green locally (full CI mirror — vet, lint, race tests, frontend lint + build).
- [x] `make test` runs against `offbook_test` (created on the fly during testing); whole backend suite passes.
- [x] New `config_test.go` covers defaults, explicit-URL override, prod-without-URL error.
- [x] `cmd/db-clean-fixtures` dry-run against `offbook` works; refuses `offbook_test`.
- [ ] CI green on PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)