### PR TITLE
fix(plaid): request personal_finance_category on /transactions/sync (closes #181)

### DIFF
--- a/backend/internal/service/plaid/client.go
+++ b/backend/internal/service/plaid/client.go
@@ -270,6 +270,12 @@ func (c *SDKClient) SyncTransactions(ctx context.Context, accessToken, cursor st
 	if cursor != "" {
 		req.SetCursor(cursor)
 	}
+	// Opt in to personal_finance_category on every row. Without this flag
+	// Plaid omits PFC for new items, so MapPlaidCategory("","") returns
+	// (0, false) and the row stays uncategorized — #181.
+	opts := plaid.NewTransactionsSyncRequestOptions()
+	opts.SetIncludePersonalFinanceCategory(true)
+	req.SetOptions(*opts)
 	resp, _, err := c.api.PlaidApi.TransactionsSync(ctx).TransactionsSyncRequest(*req).Execute()
 	if err != nil {
 		return SyncTransactionsPage{}, fmt.Errorf("plaid: transactions/sync: %w", err)

--- a/backend/internal/service/plaid/client_sync_options_test.go
+++ b/backend/internal/service/plaid/client_sync_options_test.go
@@ -1,0 +1,65 @@
+package plaid_test
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	plaidsvc "github.com/gregwym/offbook/backend/internal/service/plaid"
+)
+
+// TestSyncTransactions_RequestsPersonalFinanceCategory asserts the wire-level
+// request body sent to /transactions/sync includes
+// `options.include_personal_finance_category: true`. Without this flag Plaid
+// omits PFC for new items, leaving every transaction uncategorized — see #181.
+func TestSyncTransactions_RequestsPersonalFinanceCategory(t *testing.T) {
+	var captured map[string]any
+	mux := http.NewServeMux()
+	mux.HandleFunc("/transactions/sync", func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("read body: %v", err)
+		}
+		if err := json.Unmarshal(body, &captured); err != nil {
+			t.Errorf("decode body: %v (body=%q)", err, string(body))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"added": []any{}, "modified": []any{}, "removed": []any{},
+			"next_cursor": "", "has_more": false, "request_id": "req-pfc",
+		})
+	})
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		t.Errorf("unexpected Plaid call: %s %s", r.Method, r.URL.Path)
+		http.Error(w, "unexpected", http.StatusInternalServerError)
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	client, err := plaidsvc.NewSDKClient(plaidsvc.Config{
+		ClientID: "cid",
+		Secret:   "csec",
+		Env:      srv.URL,
+	})
+	if err != nil {
+		t.Fatalf("client: %v", err)
+	}
+	if _, err := client.SyncTransactions(context.Background(), "access-sandbox-x", ""); err != nil {
+		t.Fatalf("SyncTransactions: %v", err)
+	}
+
+	opts, ok := captured["options"].(map[string]any)
+	if !ok {
+		t.Fatalf("request body missing `options` block (captured=%v)", captured)
+	}
+	got, ok := opts["include_personal_finance_category"].(bool)
+	if !ok {
+		t.Fatalf("options.include_personal_finance_category missing or wrong type (options=%v)", opts)
+	}
+	if !got {
+		t.Errorf("include_personal_finance_category = false, want true")
+	}
+}


### PR DESCRIPTION
## Summary
- Set \`options.include_personal_finance_category=true\` on every \`/transactions/sync\` call. Without it Plaid omits PFC for new items, so \`PFCPrimary\`/\`PFCDetailed\` stay empty, \`MapPlaidCategory(\"\",\"\")\` returns \`(0, false)\`, and every synced row ends up with \`category_id=NULL\` and \`categorization_method=NULL\` — observed: 42/42 sandbox txns uncategorized despite a fully-seeded \`plaid_category_map\`.
- New wire-level test stands up a stub Plaid server and asserts the JSON request body contains \`options.include_personal_finance_category: true\`.

Closes #181.

## Backfill for existing rows
After this lands, \`POST /api/v1/transactions/recategorize\` (M4) walks existing rows through the rule + Plaid-default resolution again — so old uncategorized Plaid imports pick up a category once a fresh sync repopulates \`PFCPrimary\`/\`PFCDetailed\`. (Sandbox routinely leaves a few rows PFC-empty, so 100% coverage isn't expected; the issue calls for ≥80%.)

## Test plan
- [x] \`go test ./internal/service/plaid/ -run TestSyncTransactions_RequestsPersonalFinanceCategory\` passes.
- [x] \`make verify\` green locally.
- [ ] CI green on PR.
- [ ] Manual sandbox sync after merge — confirm ≥80% of new sandbox txns get \`categorization_method='plaid_default'\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)