### PR TITLE
feat(frontend): TimeAgo + DateDisplay components (closes #182)

### DIFF
--- a/frontend/src/components/AIChatSurface.tsx
+++ b/frontend/src/components/AIChatSurface.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useRef, useState, type ComponentType } from 'react'
 import { Plus, Send, Square, Sparkles } from 'lucide-react'
 import type { UseBoundStore, StoreApi } from 'zustand'
 import type { AIMessage, AIModel, AIThread } from '../types/ai'
+import { TimeAgo } from './TimeAgo'
 
 type State = {
   threads: AIThread[]
@@ -155,7 +156,7 @@ export function AIChatSurface({
             >
               <div className="truncate">{t.title || `Thread ${t.id}`}</div>
               <div className="text-[11px] text-gray-400">
-                {new Date(t.updated_at).toLocaleString()}
+                <TimeAgo when={t.updated_at} />
               </div>
             </button>
           ))}

--- a/frontend/src/components/DateDisplay.tsx
+++ b/frontend/src/components/DateDisplay.tsx
@@ -1,0 +1,64 @@
+// DateDisplay renders a pure DATE string ("YYYY-MM-DD") in the user's locale,
+// without any timezone interpretation. Use this for any column backed by a
+// SQL DATE — `transaction_date`, `posted_date`, `snapshot_date`,
+// `target_date`, etc. — never new Date(iso).toLocaleDateString(), which
+// re-interprets the date in the local timezone and can shift a "2026-05-19"
+// row to May 18 for negative-UTC users.
+
+import type { ReactElement } from 'react'
+
+type Props = {
+  value: string | null | undefined
+  className?: string
+  /** Hide the year when it matches the current calendar year. Default true. */
+  hideYearWhenCurrent?: boolean
+  /** Override "now" — only used by tests. */
+  now?: () => Date
+}
+
+export function DateDisplay({
+  value,
+  className,
+  hideYearWhenCurrent = true,
+  now,
+}: Props): ReactElement {
+  if (!value) return <span className={className}>—</span>
+
+  const parts = value.split('-')
+  if (parts.length !== 3) return <span className={className}>{value}</span>
+
+  const year = Number(parts[0])
+  const month = Number(parts[1])
+  const day = Number(parts[2])
+  if (
+    !Number.isFinite(year) ||
+    !Number.isFinite(month) ||
+    !Number.isFinite(day) ||
+    month < 1 ||
+    month > 12 ||
+    day < 1 ||
+    day > 31
+  ) {
+    return <span className={className}>{value}</span>
+  }
+
+  // Construct the Date at noon UTC to avoid any DST/offset edge causing the
+  // local-time conversion to round down to the previous day. The fields we
+  // pull out below use UTC accessors so this is timezone-stable.
+  const dt = new Date(Date.UTC(year, month - 1, day, 12, 0, 0))
+  const currentYear = (now ?? (() => new Date()))().getFullYear()
+  const showYear = !hideYearWhenCurrent || year !== currentYear
+
+  const label = new Intl.DateTimeFormat(undefined, {
+    month: 'short',
+    day: 'numeric',
+    year: showYear ? 'numeric' : undefined,
+    timeZone: 'UTC',
+  }).format(dt)
+
+  return (
+    <time dateTime={value} title={value} className={className}>
+      {label}
+    </time>
+  )
+}

--- a/frontend/src/components/SyncStatusPill.tsx
+++ b/frontend/src/components/SyncStatusPill.tsx
@@ -1,5 +1,6 @@
-import { useState } from 'react'
+import { useState, type ReactNode } from 'react'
 import type { Account } from '../types/account'
+import { TimeAgo } from './TimeAgo'
 
 // SyncStatusPill renders a compact traffic-light indicator for a Plaid-linked
 // account. Manual accounts (last_sync_status === null) render nothing — the
@@ -37,7 +38,7 @@ export function SyncStatusPill({ account }: { account: Account }) {
   )
 }
 
-function pillLabel(status: NonNullable<Account['last_sync_status']>, lastSyncedAt: string | null): string {
+function pillLabel(status: NonNullable<Account['last_sync_status']>, lastSyncedAt: string | null): ReactNode {
   switch (status) {
     case 'syncing':
       return 'Syncing…'
@@ -46,7 +47,9 @@ function pillLabel(status: NonNullable<Account['last_sync_status']>, lastSyncedA
     case 'never':
       return 'Not synced'
     case 'ok':
-      return lastSyncedAt ? `Synced ${formatRelative(lastSyncedAt)}` : 'Synced'
+      return lastSyncedAt ? (
+        <>Synced <TimeAgo when={lastSyncedAt} /></>
+      ) : 'Synced'
   }
 }
 
@@ -76,19 +79,3 @@ function dotTone(status: NonNullable<Account['last_sync_status']>): string {
   }
 }
 
-// formatRelative renders a coarse "Xm/h/d ago" — enough resolution for a
-// sync indicator. Anything older than 30 days falls back to a calendar date
-// so the pill doesn't claim "1y ago" forever.
-function formatRelative(iso: string): string {
-  const then = new Date(iso).getTime()
-  if (Number.isNaN(then)) return 'recently'
-  const diffSec = Math.max(0, Math.floor((Date.now() - then) / 1000))
-  if (diffSec < 60) return 'just now'
-  const mins = Math.floor(diffSec / 60)
-  if (mins < 60) return `${mins}m ago`
-  const hours = Math.floor(mins / 60)
-  if (hours < 24) return `${hours}h ago`
-  const days = Math.floor(hours / 24)
-  if (days < 30) return `${days}d ago`
-  return new Date(iso).toLocaleDateString()
-}

--- a/frontend/src/components/TimeAgo.tsx
+++ b/frontend/src/components/TimeAgo.tsx
@@ -1,0 +1,77 @@
+// TimeAgo renders a relative time string for an ISO/RFC3339 timestamp with
+// the exact value available as a tooltip and (for screen readers) on the
+// underlying <time> element. Use this anywhere a TIMESTAMPTZ field reaches
+// the UI — sync chips, audit logs, "Joined / Updated" labels, etc.
+//
+// Buckets:
+//   < 60s   → "just now"
+//   < 60m   → "Xm ago"
+//   < 24h   → "Xh ago"
+//   < 7d    → weekday name ("Tuesday")
+//   < same year → "Mar 14"
+//   otherwise   → "Mar 14, 2025"
+//
+// Future times bucket symmetrically ("in Xm"). Anything older than ~6 months
+// falls into the dated branch — bucketed "5mo ago" labels stop being useful
+// once you can just show a calendar date.
+
+import type { ReactElement } from 'react'
+
+type Props = {
+  when: string | null | undefined
+  className?: string
+  /** Override Date.now() — only used by tests. */
+  now?: () => number
+}
+
+export function TimeAgo({ when, className, now }: Props): ReactElement {
+  if (!when) {
+    return <span className={className}>—</span>
+  }
+  const t = Date.parse(when)
+  if (Number.isNaN(t)) {
+    return <span className={className}>—</span>
+  }
+  const nowMs = (now ?? Date.now)()
+  const label = formatRelativeTime(t, nowMs)
+  return (
+    <time dateTime={when} title={when} className={className}>
+      {label}
+    </time>
+  )
+}
+
+function formatRelativeTime(targetMs: number, nowMs: number): string {
+  const diffSec = Math.round((targetMs - nowMs) / 1000)
+  const absSec = Math.abs(diffSec)
+
+  if (absSec < 60) return diffSec >= 0 ? 'just now' : 'just now'
+
+  const absMin = Math.round(absSec / 60)
+  if (absMin < 60) {
+    return diffSec < 0 ? `${absMin}m ago` : `in ${absMin}m`
+  }
+
+  const absHr = Math.round(absMin / 60)
+  if (absHr < 24) {
+    return diffSec < 0 ? `${absHr}h ago` : `in ${absHr}h`
+  }
+
+  const target = new Date(targetMs)
+  const now = new Date(nowMs)
+  const absDays = Math.round(absHr / 24)
+
+  if (absDays < 7) {
+    // Within a week: weekday name reads more naturally than "3d ago".
+    // Past days say "Tuesday"; future days say "Tuesday" too — the year
+    // and tooltip disambiguate.
+    return new Intl.DateTimeFormat(undefined, { weekday: 'long' }).format(target)
+  }
+
+  const sameYear = target.getFullYear() === now.getFullYear()
+  return new Intl.DateTimeFormat(undefined, {
+    month: 'short',
+    day: 'numeric',
+    year: sameYear ? undefined : 'numeric',
+  }).format(target)
+}

--- a/frontend/src/pages/HouseholdGoalsPage.tsx
+++ b/frontend/src/pages/HouseholdGoalsPage.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { Coins, Pencil, PiggyBank, Plus, Trash2 } from 'lucide-react'
 import { AmountDisplay } from '../components/AmountDisplay'
+import { DateDisplay } from '../components/DateDisplay'
 import {
   contributeToSharedGoal,
   createSharedGoal,
@@ -202,7 +203,7 @@ function GoalCard({
         <div className="min-w-0">
           <div className="truncate font-medium text-gray-900">{goal.name}</div>
           <div className="mt-0.5 text-xs text-gray-500">
-            {goal.target_date ? `By ${new Date(goal.target_date).toLocaleDateString()}` : 'No deadline'}
+            {goal.target_date ? <>By <DateDisplay value={goal.target_date} /></> : 'No deadline'}
           </div>
         </div>
         {canMutate && (

--- a/frontend/src/pages/HouseholdMembersPage.tsx
+++ b/frontend/src/pages/HouseholdMembersPage.tsx
@@ -1,5 +1,7 @@
 import { useCallback, useEffect, useState } from 'react'
 import { Check, Copy, Mail, Trash2, Users } from 'lucide-react'
+import { DateDisplay } from '../components/DateDisplay'
+import { TimeAgo } from '../components/TimeAgo'
 import {
   createInvite,
   listMembers,
@@ -185,7 +187,7 @@ export function HouseholdMembersPage() {
                 <div className="min-w-0">
                   <div className="font-medium text-gray-900">User #{m.user_id}</div>
                   <div className="text-xs text-gray-500">
-                    Left {m.left_at ? new Date(m.left_at).toLocaleDateString() : 'recently'} ·
+                    Left {m.left_at ? <DateDisplay value={m.left_at.slice(0, 10)} /> : 'recently'} ·
                     can rejoin via a fresh invite within {detail.household.grace_period_days} days
                   </div>
                 </div>
@@ -239,7 +241,7 @@ function MemberRow({
           )}
         </div>
         <div className="mt-0.5 text-xs text-gray-500">
-          Joined {new Date(member.joined_at).toLocaleDateString()}
+          Joined <DateDisplay value={member.joined_at.slice(0, 10)} />
         </div>
       </div>
       {showControls ? (
@@ -388,7 +390,7 @@ function InviteModal({
                 </button>
               </div>
               <div className="text-[11px] text-gray-400">
-                Expires {new Date(lastInvite.invite.expires_at).toLocaleString()}.
+                Expires <TimeAgo when={lastInvite.invite.expires_at} />.
               </div>
             </div>
           )}

--- a/frontend/src/pages/InvestmentsPage.tsx
+++ b/frontend/src/pages/InvestmentsPage.tsx
@@ -9,6 +9,7 @@
 import { useEffect, useMemo, useState, type ReactNode } from 'react'
 import { LineChart, Plus, TrendingUp } from 'lucide-react'
 import { AmountDisplay } from '../components/AmountDisplay'
+import { DateDisplay } from '../components/DateDisplay'
 import { AllocationDonut } from '../components/InvestmentsCharts'
 import { useAccountsStore } from '../store/accountsStore'
 import { useInvestmentsStore } from '../store/investmentsStore'
@@ -476,7 +477,7 @@ function SnapshotHistoryModal({ inv, account, fetchHistory, onClose }: HistoryPr
                   const gl = computeGainLoss(r)
                   return (
                     <tr key={r.id}>
-                      <Td>{r.snapshot_date}</Td>
+                      <Td><DateDisplay value={r.snapshot_date} /></Td>
                       <Td align="right" className="tabular-nums">{formatQuantity(r.quantity)}</Td>
                       <Td align="right" className="tabular-nums"><AmountDisplay amount={r.cost_basis} currency="USD" /></Td>
                       <Td align="right" className="tabular-nums"><AmountDisplay amount={r.market_value} currency="USD" /></Td>

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -1,6 +1,7 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useState, type ReactNode } from 'react'
 import { Link } from 'react-router-dom'
 import { AlertTriangle, Bot, Check, Landmark, Plug, Trash2, X } from 'lucide-react'
+import { TimeAgo } from '../components/TimeAgo'
 import {
   disconnectItem,
   dismissSyncError,
@@ -427,7 +428,7 @@ function SyncErrorsModal({ item, onClose }: { item: PlaidItem; onClose: () => vo
                       {row.error_code}
                     </span>
                     <span className="text-xs text-gray-500">
-                      {new Date(row.occurred_at).toLocaleString()}
+                      <TimeAgo when={row.occurred_at} />
                     </span>
                   </div>
                   <p className="mt-1 text-sm text-gray-900">{row.error_message}</p>
@@ -467,14 +468,14 @@ function SyncErrorsModal({ item, onClose }: { item: PlaidItem; onClose: () => vo
   )
 }
 
-function statusSummary(it: PlaidItem): string {
+function statusSummary(it: PlaidItem): ReactNode {
   const status = it.last_sync_status
   switch (status) {
     case 'ok':
-      return it.last_synced_at ? `Synced ${formatRelative(it.last_synced_at)}` : 'Synced'
+      return it.last_synced_at ? <>Synced <TimeAgo when={it.last_synced_at} /></> : 'Synced'
     case 'ok_with_errors':
       return it.last_synced_at
-        ? `Synced ${formatRelative(it.last_synced_at)} (with errors)`
+        ? <>Synced <TimeAgo when={it.last_synced_at} /> (with errors)</>
         : 'Synced (with errors)'
     case 'syncing':
       return 'Syncing…'
@@ -485,20 +486,6 @@ function statusSummary(it: PlaidItem): string {
     default:
       return status
   }
-}
-
-function formatRelative(iso: string): string {
-  const t = new Date(iso).getTime()
-  if (Number.isNaN(t)) return 'recently'
-  const diff = Math.max(0, Math.floor((Date.now() - t) / 1000))
-  if (diff < 60) return 'just now'
-  const mins = Math.floor(diff / 60)
-  if (mins < 60) return `${mins}m ago`
-  const hours = Math.floor(mins / 60)
-  if (hours < 24) return `${hours}h ago`
-  const days = Math.floor(hours / 24)
-  if (days < 30) return `${days}d ago`
-  return new Date(iso).toLocaleDateString()
 }
 
 function errMsg(err: unknown): string {

--- a/frontend/src/pages/TransactionsPage.tsx
+++ b/frontend/src/pages/TransactionsPage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState, type ReactNode } from 'react'
 import { Plus, Sparkles, Trash2 } from 'lucide-react'
 import { Link } from 'react-router-dom'
 import { AmountDisplay } from '../components/AmountDisplay'
+import { DateDisplay } from '../components/DateDisplay'
 import { RuleFormModal, type RuleFormDefaults } from '../components/RuleFormModal'
 import { useAccountsStore } from '../store/accountsStore'
 import { useCategoriesStore } from '../store/categoriesStore'
@@ -280,7 +281,7 @@ type RowProps = {
 function TransactionRow({ tx, account, categories, currentCategory, onCategoryChange, onCreateRule, onDelete }: RowProps) {
   return (
     <tr className="hover:bg-gray-50">
-      <td className="px-3 py-2 text-gray-700">{tx.transaction_date}</td>
+      <td className="px-3 py-2 text-gray-700"><DateDisplay value={tx.transaction_date} /></td>
       <td className="px-3 py-2 text-gray-900">{tx.description ?? '—'}</td>
       <td className="px-3 py-2 text-gray-700">{tx.merchant_name ?? '—'}</td>
       <td className="px-3 py-2 text-right">


### PR DESCRIPTION
## Summary
- New \`<TimeAgo when={iso} />\` for any TIMESTAMPTZ field. Buckets: \`<60s\` → \"just now\", \`<60m\` → \"Xm ago\", \`<24h\` → \"Xh ago\", \`<7d\` → weekday name, this calendar year → \"Mar 14\", older → \"Mar 14, 2025\". Future times bucket symmetrically (\"in 5m\"). Rendered as \`<time dateTime={iso} title={iso}>\` so the exact RFC3339 is on the tooltip + accessible to screen readers.
- New \`<DateDisplay value={\"YYYY-MM-DD\"} />\` for SQL DATE columns. Parses the date by component (no \`new Date(iso)\`) and renders via \`Intl.DateTimeFormat({timeZone: 'UTC'})\` so a 2026-05-19 row doesn't shift to May 18 in negative-UTC zones. Drops the year for current-year dates.
- Replaced ad-hoc formatters at the surfaces listed in the issue + the obvious adjacent ones:
  - Transactions table — \`transaction_date\`
  - Investments holdings table — \`snapshot_date\`
  - \`SyncStatusPill\` — \`last_synced_at\` (deletes the local \`formatRelative\`)
  - Settings → Linked Institutions + ingestion-error rows (deletes the local \`formatRelative\`)
  - AI Chat thread list — \`updated_at\`
  - Household Members — joined/left + invite expiry
  - Household Goals — \`target_date\`

Closes #182.

## Out of scope
- Sessions / signin log — backend surfaces don't render those yet (issue called this out).
- Custom relative-time strings per language (uses \`Intl.RelativeTimeFormat\`-style buckets but with English labels; full i18n is a separate concern).
- A frontend test framework — no vitest/jest exists in this repo today; the components are pure enough to add coverage when one lands.

## Test plan
- [x] \`pnpm lint\` + \`pnpm build\` green.
- [x] All call sites typecheck.
- [ ] Spot-check in browser: transaction dates, sync chip, settings sync row, household member row.
- [ ] CI green on PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)