### PR TITLE
fix(investments): return [] not null for empty list (closes #180)

### DIFF
--- a/backend/internal/repository/investment_repo.go
+++ b/backend/internal/repository/investment_repo.go
@@ -66,7 +66,11 @@ func (r *investmentRepo) ListLatestPerHolding(ctx context.Context, userID int64)
 	// SELECT so the final result can be ordered however we like (here:
 	// stable by account_id, then ticker) without breaking the DISTINCT ON
 	// requirement that its ORDER BY start with the same columns.
-	var out []model.Investment
+	//
+	// `out` is initialized non-nil so the JSON handler serializes an empty
+	// result as `[]` rather than `null` (#180). encoding/json renders nil
+	// slices as `null`, which crashed the frontend's `holdings.length` read.
+	out := make([]model.Investment, 0)
 	err := r.db.WithContext(ctx).Raw(`
 		SELECT * FROM (
 			SELECT DISTINCT ON (account_id, ticker) *
@@ -86,7 +90,7 @@ func (r *investmentRepo) ListLatestPairPerHolding(ctx context.Context, userID in
 	// Window function picks the two newest snapshots per holding.
 	// Single query — paired-rows pattern via ROW_NUMBER beats two
 	// separate DISTINCT ON queries that would have to be zipped in Go.
-	var out []model.Investment
+	out := make([]model.Investment, 0)
 	err := r.db.WithContext(ctx).Raw(`
 		SELECT id, user_id, account_id, ticker, name, asset_class,
 		       quantity, cost_basis, market_value,
@@ -111,7 +115,7 @@ func (r *investmentRepo) ListLatestPairPerHolding(ctx context.Context, userID in
 
 func (r *investmentRepo) ListSnapshotsByHolding(ctx context.Context, userID, accountID int64, ticker string) ([]model.Investment, error) {
 	tk := strings.ToUpper(strings.TrimSpace(ticker))
-	var out []model.Investment
+	out := make([]model.Investment, 0)
 	err := r.db.WithContext(ctx).
 		Where("user_id = ? AND account_id = ? AND UPPER(ticker) = ?", userID, accountID, tk).
 		Order("snapshot_date ASC, id ASC").

--- a/backend/internal/service/investment_service_test.go
+++ b/backend/internal/service/investment_service_test.go
@@ -270,6 +270,26 @@ func portfolioCreate(
 func intPtr(v int64) *int64   { return &v }
 func strPtr(s string) *string { return &s }
 
+// TestInvestmentService_ListLatest_EmptyReturnsNonNilSlice guards against
+// #180: an empty result was a nil slice, which encoding/json serialized as
+// `null`. The frontend read `holdings.length` on that null and the page
+// crashed before the empty state could render. The fix is in
+// investment_repo.go (init with make([]…, 0)); this test pins the contract.
+func TestInvestmentService_ListLatest_EmptyReturnsNonNilSlice(t *testing.T) {
+	svc, userID, _, _ := newInvestmentSvc(t)
+
+	rows, err := svc.ListLatest(context.Background(), userID)
+	if err != nil {
+		t.Fatalf("ListLatest: %v", err)
+	}
+	if rows == nil {
+		t.Fatal("ListLatest returned nil slice; must be non-nil so JSON renders [] not null")
+	}
+	if len(rows) != 0 {
+		t.Errorf("len(rows) = %d, want 0 for a user with no investments", len(rows))
+	}
+}
+
 func TestInvestmentService_PortfolioSummary_EmptyReturnsZeros(t *testing.T) {
 	svc, userID, _, _ := newInvestmentSvc(t)
 

--- a/frontend/src/api/investments.ts
+++ b/frontend/src/api/investments.ts
@@ -7,7 +7,10 @@ import type {
 
 export async function listLatestHoldings(): Promise<Investment[]> {
   const res = await apiClient.get<ApiList<Investment>>('/investments')
-  return res.data.data
+  // The backend fix in #180 returns `[]` for the empty case, but normalize
+  // here too so stale containers or future regressions don't crash the page
+  // (`holdings.length` reads further down the call stack).
+  return res.data.data ?? []
 }
 
 export async function listSnapshotHistory(
@@ -17,7 +20,7 @@ export async function listSnapshotHistory(
   const res = await apiClient.get<ApiList<Investment>>('/investments', {
     params: { account_id: accountID, ticker },
   })
-  return res.data.data
+  return res.data.data ?? []
 }
 
 export async function createInvestment(


### PR DESCRIPTION
## Summary
Empty-portfolio sandbox accounts crashed \`/investments\` with \`TypeError: Cannot read properties of null (reading 'length')\` at \`InvestmentsPage.tsx:184\`. Root cause is a backend/frontend contract gap surfaced by Codex's diagnostic (issue comments):

- \`backend/internal/repository/investment_repo.go\` returned a nil \`[]model.Investment\` for zero rows.
- \`encoding/json\` renders nil slices as JSON \`null\`.
- \`frontend/src/store/investmentsStore.ts\` wrote that null straight into \`holdings\`.
- \`InvestmentsPage\` read \`holdings.length\` before the empty state could render.

## Fix
- **Backend (root cause):** initialize each list-return slice in \`investment_repo.go\` with \`make([]model.Investment, 0)\`. Result: \`GET /investments\` for a user with no investments returns \`{\"data\": [], \"total\": 0}\` (not \`null\`). Applied to \`ListLatestPerHolding\`, \`ListLatestPairPerHolding\`, and \`ListSnapshotsByHolding\` for consistency.
- **Frontend (defense in depth):** normalize \`res.data.data\` to \`?? []\` in \`frontend/src/api/investments.ts\` for \`listLatestHoldings\` and \`listSnapshotHistory\`. Keeps the UI resilient if a stale container ships old JSON or a future regression sneaks the null back in.
- **Regression test:** new \`TestInvestmentService_ListLatest_EmptyReturnsNonNilSlice\` asserts non-nil, len=0.

Closes #180.

## Test plan
- [x] \`make verify\` green locally (regression test included).
- [ ] CI green on PR.
- [ ] After merge, repro on mobile Safari over Tailscale: \`/investments\` renders the empty state instead of crashing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)