### PR TITLE
feat(frontend): mobile-responsive sidebar drawer (closes #179)

### DIFF
--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -5,6 +5,7 @@ import {
   Landmark,
   LayoutDashboard,
   LogOut,
+  Menu,
   PiggyBank,
   Receipt,
   Settings,
@@ -13,6 +14,7 @@ import {
   TrendingUp,
   Users,
   Wallet,
+  X,
 } from 'lucide-react'
 import { useEffect, useState } from 'react'
 import { NavLink, Outlet, useNavigate } from 'react-router-dom'
@@ -65,52 +67,118 @@ export function AppShell() {
   const canSwitch = available.includes(SCOPE_HOUSEHOLD)
   const [joinOpen, setJoinOpen] = useState(false)
 
+  // Mobile drawer: below md (768px) the sidebar lives behind a hamburger
+  // toggle. md+ ignores this entirely — the sidebar stays in the static
+  // layout. The drawer closes itself when the user taps a nav link (each
+  // NavLink calls closeDrawer onClick) so we don't need a route-change
+  // effect — those are flagged by react-hooks/set-state-in-effect anyway.
+  const [drawerOpen, setDrawerOpen] = useState(false)
+  const closeDrawer = () => setDrawerOpen(false)
+
   const handleSignout = async () => {
     await signout()
     navigate('/signin', { replace: true })
   }
 
+  const sidebar = (
+    <>
+      <div className="flex items-center justify-between px-6 py-5">
+        <span className="text-lg font-semibold text-gray-900">offbook</span>
+        {/* Close button only visible inside the mobile drawer. */}
+        <button
+          type="button"
+          onClick={() => setDrawerOpen(false)}
+          aria-label="Close menu"
+          className="-mr-2 inline-flex h-11 w-11 items-center justify-center rounded-md text-gray-500 hover:bg-gray-100 hover:text-gray-900 md:hidden"
+        >
+          <X size={20} />
+        </button>
+      </div>
+      {canSwitch ? (
+        <ScopePicker active={active} onChange={setScope} />
+      ) : (
+        hydrated && <JoinCTA onClick={() => setJoinOpen(true)} />
+      )}
+      <nav className="flex-1 space-y-1 px-3 pb-4 overflow-y-auto">
+        {items.map(({ to, label, icon: Icon }) => (
+          <NavLink
+            key={to}
+            to={to}
+            onClick={closeDrawer}
+            className={({ isActive }) =>
+              [
+                // min-h-[44px] enforces the iOS HIG tap-target on mobile.
+                // md:min-h-0 hands the height back to py-2 on desktop so
+                // the sidebar isn't extra tall.
+                'flex min-h-[44px] items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition md:min-h-0',
+                isActive
+                  ? 'bg-indigo-50 text-indigo-700'
+                  : 'text-gray-600 hover:bg-gray-100 hover:text-gray-900',
+              ].join(' ')
+            }
+          >
+            <Icon size={18} />
+            {label}
+          </NavLink>
+        ))}
+      </nav>
+      <div className="border-t border-gray-200 p-3">
+        <button
+          type="button"
+          onClick={() => void handleSignout()}
+          className="flex min-h-[44px] w-full items-center gap-2 rounded-md px-3 py-2 text-sm font-medium text-gray-600 hover:bg-gray-100 hover:text-gray-900 md:min-h-0"
+        >
+          <LogOut size={16} />
+          Sign out
+        </button>
+      </div>
+    </>
+  )
+
   return (
     <div className="flex h-screen w-screen bg-gray-50">
-      <aside className="flex w-60 flex-col border-r border-gray-200 bg-white">
-        <div className="px-6 py-5 text-lg font-semibold text-gray-900">offbook</div>
-        {canSwitch ? (
-          <ScopePicker active={active} onChange={setScope} />
-        ) : (
-          hydrated && <JoinCTA onClick={() => setJoinOpen(true)} />
-        )}
-        <nav className="flex-1 space-y-1 px-3 pb-4 overflow-y-auto">
-          {items.map(({ to, label, icon: Icon }) => (
-            <NavLink
-              key={to}
-              to={to}
-              className={({ isActive }) =>
-                [
-                  'flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition',
-                  isActive
-                    ? 'bg-indigo-50 text-indigo-700'
-                    : 'text-gray-600 hover:bg-gray-100 hover:text-gray-900',
-                ].join(' ')
-              }
-            >
-              <Icon size={18} />
-              {label}
-            </NavLink>
-          ))}
-        </nav>
-        <div className="border-t border-gray-200 p-3">
+      {/* Desktop sidebar (md+). Always visible, takes its slot in the flex row. */}
+      <aside className="hidden w-60 flex-col border-r border-gray-200 bg-white md:flex">
+        {sidebar}
+      </aside>
+
+      {/* Mobile drawer (< md). Conditionally rendered overlay + slide-in panel. */}
+      {drawerOpen && (
+        <>
+          <div
+            onClick={() => setDrawerOpen(false)}
+            aria-hidden="true"
+            className="fixed inset-0 z-40 bg-black/40 md:hidden"
+          />
+          <aside
+            role="dialog"
+            aria-modal="true"
+            aria-label="Navigation"
+            className="fixed inset-y-0 left-0 z-50 flex w-64 max-w-[80vw] flex-col border-r border-gray-200 bg-white shadow-xl md:hidden"
+          >
+            {sidebar}
+          </aside>
+        </>
+      )}
+
+      <main className="flex-1 overflow-auto">
+        {/* Mobile top bar with hamburger + brand. Hidden md+ since the
+            sidebar already shows the brand. */}
+        <div className="sticky top-0 z-30 flex items-center gap-2 border-b border-gray-200 bg-white px-3 py-2 md:hidden">
           <button
             type="button"
-            onClick={() => void handleSignout()}
-            className="flex w-full items-center gap-2 rounded-md px-3 py-2 text-sm font-medium text-gray-600 hover:bg-gray-100 hover:text-gray-900"
+            onClick={() => setDrawerOpen(true)}
+            aria-label="Open menu"
+            aria-expanded={drawerOpen}
+            className="inline-flex h-11 w-11 items-center justify-center rounded-md text-gray-700 hover:bg-gray-100"
           >
-            <LogOut size={16} />
-            Sign out
+            <Menu size={22} />
           </button>
+          <span className="text-base font-semibold text-gray-900">offbook</span>
         </div>
-      </aside>
-      <main className="flex-1 overflow-auto">
-        <div className="mx-auto max-w-6xl px-8 py-8">
+        {/* Tighter horizontal padding on mobile so narrow viewports actually
+            get usable width. The mx-auto + max-w-6xl still caps wide layouts. */}
+        <div className="mx-auto max-w-6xl px-4 py-4 md:px-8 md:py-8">
           <Outlet />
         </div>
       </main>
@@ -154,7 +222,7 @@ function ScopePicker({ active, onChange }: { active: Scope; onChange: (s: Scope)
           onClick={() => onChange(o.key)}
           aria-pressed={active === o.key}
           className={[
-            'flex-1 rounded px-2 py-1 text-xs font-medium transition',
+            'min-h-[44px] flex-1 rounded px-2 py-1 text-xs font-medium transition md:min-h-0',
             active === o.key
               ? 'bg-white text-gray-900 shadow-sm'
               : 'text-gray-500 hover:text-gray-700',

--- a/frontend/src/pages/AccountsPage.tsx
+++ b/frontend/src/pages/AccountsPage.tsx
@@ -50,7 +50,7 @@ export function AccountsPage() {
         </div>
       )}
 
-      <div className="mt-6 overflow-hidden rounded-lg border border-gray-200 bg-white">
+      <div className="mt-6 overflow-x-auto rounded-lg border border-gray-200 bg-white">
         <table className="min-w-full divide-y divide-gray-200 text-sm">
           <thead className="bg-gray-50 text-xs font-medium uppercase tracking-wider text-gray-500">
             <tr>

--- a/frontend/src/pages/TransactionsPage.tsx
+++ b/frontend/src/pages/TransactionsPage.tsx
@@ -136,7 +136,7 @@ export function TransactionsPage() {
         </Field>
       </div>
 
-      <div className="mt-4 overflow-hidden rounded-lg border border-gray-200 bg-white">
+      <div className="mt-4 overflow-x-auto rounded-lg border border-gray-200 bg-white">
         <table className="min-w-full divide-y divide-gray-200 text-sm">
           <thead className="bg-gray-50 text-xs font-medium uppercase tracking-wider text-gray-500">
             <tr>


### PR DESCRIPTION
## Summary
Below the Tailwind \`md\` breakpoint (768px) the sidebar collapses behind a hamburger toggle in a sticky top bar. Tapping the hamburger opens an overlay drawer with a click-anywhere backdrop; tapping any NavLink closes the drawer (handled via per-link \`onClick\` so we don't trip \`react-hooks/set-state-in-effect\`). \`md+\` layout is untouched.

- Tap targets bumped to \`min-h-[44px]\` on nav links, sign-out button, and the scope-picker pills (iOS HIG). Reverts to natural height on \`md+\` so desktop spacing doesn't grow.
- Main content padding tightens to \`px-4 py-4\` on mobile (was \`px-8 py-8\`) so a 390px iPhone viewport actually gets usable width.
- Wrapped Accounts and Transactions tables in \`overflow-x-auto\` so wide tables scroll horizontally on mobile instead of pushing the layout off-screen. Investments + the household-side tables already had \`overflow-x-auto\` wrappers.
- Tile grids on Dashboard / Accounts / Transactions / Investments were already \`grid-cols-1\` mobile-first, no changes needed.

Closes #179.

## Test plan
- [x] \`pnpm lint\` + \`pnpm build\` green.
- [ ] CI green on PR.
- [ ] iPhone 15 Pro Safari over Tailscale:
  - Sidebar hidden by default, hamburger reveals drawer.
  - Tapping a nav link navigates AND auto-closes the drawer.
  - Backdrop click closes drawer.
  - Tap targets feel ≥44pt.
  - Tables (Accounts, Transactions) scroll horizontally; tiles stack vertically.
- [ ] iPad landscape: static sidebar visible (md+ breakpoint).
- [ ] Desktop unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)