### PR TITLE
fix(plaid): prefix plaid_detailed with primary (refs #181)

### DIFF
--- a/backend/internal/service/plaid/category_mapping_integration_test.go
+++ b/backend/internal/service/plaid/category_mapping_integration_test.go
@@ -34,9 +34,13 @@ func fakeServerPFC(t *testing.T, plaidAcctID, plaidTxnID string) (*httptest.Serv
 			"merchant_name":     "Whole Foods",
 			"date":              "2026-05-10",
 			"pending":           false,
+			// detailed is the wire form Plaid actually returns: the
+			// primary token is repeated as a prefix
+			// ("FOOD_AND_DRINK_GROCERIES", not "GROCERIES"). #181 fallout —
+			// 000005 seeded the un-prefixed legacy form, 000012 normalized.
 			"personal_finance_category": map[string]any{
 				"primary":  "FOOD_AND_DRINK",
-				"detailed": "GROCERIES",
+				"detailed": "FOOD_AND_DRINK_GROCERIES",
 			},
 		}
 		var added, modified []map[string]any

--- a/backend/internal/service/plaid/rule_application_integration_test.go
+++ b/backend/internal/service/plaid/rule_application_integration_test.go
@@ -70,7 +70,7 @@ func TestPlaidSync_RuleWinsOverPlaidDefault(t *testing.T) {
 					"pending":           false,
 					"personal_finance_category": map[string]any{
 						"primary":  "FOOD_AND_DRINK",
-						"detailed": "GROCERIES",
+						"detailed": "FOOD_AND_DRINK_GROCERIES",
 					},
 				},
 			},
@@ -179,7 +179,7 @@ func TestPlaidSync_OtherUsersRuleDoesNotApply(t *testing.T) {
 					"pending":           false,
 					"personal_finance_category": map[string]any{
 						"primary":  "FOOD_AND_DRINK",
-						"detailed": "GROCERIES",
+						"detailed": "FOOD_AND_DRINK_GROCERIES",
 					},
 				},
 			},

--- a/backend/migrations/000012_plaid_category_map_prefixed.down.sql
+++ b/backend/migrations/000012_plaid_category_map_prefixed.down.sql
@@ -1,0 +1,6 @@
+-- Reverse of 000012: strip the leading "<primary>_" from plaid_detailed for
+-- any row where it was added. Only touches rows that begin with the
+-- exact prefix so manually-added rows in another shape are untouched.
+UPDATE plaid_category_map
+   SET plaid_detailed = substr(plaid_detailed, length(plaid_primary) + 2)
+ WHERE position(plaid_primary || '_' IN plaid_detailed) = 1;

--- a/backend/migrations/000012_plaid_category_map_prefixed.up.sql
+++ b/backend/migrations/000012_plaid_category_map_prefixed.up.sql
@@ -1,0 +1,14 @@
+-- #181 follow-up: Plaid's /transactions/sync returns personal_finance_category
+-- with the *detailed* field prefixed by the *primary*, e.g.
+--   primary  = FOOD_AND_DRINK
+--   detailed = FOOD_AND_DRINK_FAST_FOOD
+-- The 000005 seed used the un-prefixed legacy form (FAST_FOOD), so every
+-- lookup in MapPlaidCategory missed and transactions stayed uncategorized
+-- despite the PFC flag being correctly requested. Normalize the existing
+-- rows to match the wire format.
+--
+-- The WHERE guard makes this idempotent and safe in case a future seed
+-- already lands in the canonical prefixed form.
+UPDATE plaid_category_map
+   SET plaid_detailed = plaid_primary || '_' || plaid_detailed
+ WHERE position(plaid_primary || '_' IN plaid_detailed) <> 1;


### PR DESCRIPTION
## Summary
Follow-up to #181. The PFC flag is requested now, but live sandbox testing showed every txn was still uncategorized. Direct \`/transactions/sync\` debug against Plaid revealed the wire format:

\`\`\`
(\"FOOD_AND_DRINK\", \"FOOD_AND_DRINK_GROCERIES\")
\`\`\`

…not the un-prefixed legacy form (\`GROCERIES\`) that migration 000005 seeded. Every lookup in \`MapPlaidCategory\` missed because the in-memory table was keyed on the wrong shape.

## Fix
- New migration **000012** prepends \`<primary>_\` to every \`plaid_detailed\` value where it isn't already prefixed. Guarded by \`position(primary || '_' IN detailed) <> 1\` so it's idempotent and safe on re-run. Down migration strips the prefix.
- Updated integration tests that previously asserted on the old un-prefixed form (they were green because the test seed matched the test-time map, not what Plaid actually sends).

The \`MapPlaidCategory\` lookup contract is unchanged — same key shape, just fed canonical values.

Refs #181.

## Local recovery
For an existing DB with already-imported uncategorized Plaid txns: after this lands, the backend mapper still has the OLD un-prefixed values cached in memory until restart. Path forward:
1. Rebuild + restart backend (picks up the new migration + reloads mapper from the now-prefixed table).
2. Reset the cursor + delete the existing plaid-sourced txns, then re-trigger sync from \`/connect\`.

(Or wait for a future PR to add Plaid-default backfill to the bulk re-categorize endpoint — currently it only re-applies user rules.)

## Test plan
- [x] \`make verify\` green locally — both updated integration tests now use the canonical wire form and pass.
- [ ] CI green on PR.
- [ ] After merge: rebuild backend image, restart, reset cursor + re-sync, confirm ≥80% of new sandbox txns get \`categorization_method='plaid_default'\` (the #181 acceptance bar).

🤖 Generated with [Claude Code](https://claude.com/claude-code)