### PR TITLE
Codify QA acceptance workflow fixes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,6 +38,11 @@ PLAID_ENV=sandbox
 # Required when PLAID_CLIENT_ID is set. Generate with: openssl rand -hex 32
 PLAID_TOKEN_KEY=
 
+# QA-only persona password derivation. Production and development code do not
+# read this value; acceptance bootstrap uses it to derive reproducible persona
+# passwords without committing plaintext credentials.
+QA_SECRET=
+
 # AI Providers (optional)
 CLAUDE_API_KEY=
 OLLAMA_BASE_URL=http://localhost:11434

--- a/.env.qa.example
+++ b/.env.qa.example
@@ -1,0 +1,21 @@
+# Copy to .env.qa for the isolated offbook-qa compose stack.
+APP_ENV=dev
+DATABASE_URL=postgres://offbook:offbook@postgres:5432/offbook_dev?sslmode=disable
+PORT=8000
+FRONTEND_URL=http://localhost:15173
+MIGRATIONS_PATH=/app/migrations
+
+# QA-only backend secret. Generate a fresh value for real QA runs:
+#   openssl rand -hex 32
+SESSION_SECRET=replace-with-qa-session-secret
+
+# QA persona password derivation. If omitted, acceptance bootstrap writes a
+# generated value to gitignored .env.qa.local.
+QA_SECRET=
+
+# QA-only Plaid sandbox credentials. Do not reuse dev/prod Plaid identities.
+PLAID_CLIENT_ID=
+PLAID_SECRET=
+PLAID_ENV=sandbox
+# Generate with: openssl rand -hex 32
+PLAID_TOKEN_KEY=

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Dependencies
 backend/vendor/
 frontend/node_modules/
+acceptance/node_modules/
+.pnpm-store/
+.cache/
 
 # Build output
 backend/bin/
@@ -9,6 +12,7 @@ frontend/dist/
 
 # Environment
 .env
+.env.qa
 .env.local
 .env.*.local
 
@@ -44,3 +48,6 @@ go.work.sum
 # Test coverage
 coverage/
 *.coverprofile
+
+# Acceptance test output
+acceptance/reports/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,9 +39,9 @@ When running via Claude's Bash tool, prefix `make` with `command` (`command make
 - QA is manually triggered only. Do not run a standalone QA pass unless the user explicitly asks for it.
 - The same agent session should not be both developer and QA for the same change. Developer agents may run targeted verification, but they do not QA-certify their own work.
 - QA should work from `main`, preferably in a separate worktree, and should start its own isolated compose stack with `docker-compose.qa.yml` instead of using the development agent's running environment.
-- QA may use headless Chrome for browser verification.
-- QA credentials are defined in @docs/QA.md and are for the isolated QA stack only.
-- Follow @docs/QA.md for QA runs: use GitHub Discussion #199 as the QA Ledger, compare against the last QAed commit recorded there, and include the "found at" commit when filing or commenting on bugs.
+- QA browser automation uses Playwright headless Chromium. Run from a `*-qa` worktree or set `OFFBOOK_ROLE=qa` so QA helper scripts can tell the role apart from development.
+- QA persona emails and credential derivation are defined in @docs/QA.md and are for the isolated QA stack only.
+- Follow @docs/QA.md for QA runs: use GitHub Discussion #199 as the QA Ledger, compare against the last QAed commit with `scripts/qa-last-reviewed.sh`, and include the "found at" commit when filing or commenting on bugs.
 - Acceptance tests live outside unit tests. They start as optional, manually run suites and are not merge-required until the owner explicitly promotes them.
 
 ## Git Discipline

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,17 @@
+.PHONY: acceptance qa-smoke
+
+ACCEPTANCE_DIR := acceptance
+ACCEPTANCE_BASE_URL ?= http://localhost:15173
+ACCEPTANCE_API_URL ?= http://localhost:18000/api/v1
+PLAYWRIGHT_BROWSERS_PATH ?= .cache/ms-playwright
+
+acceptance:
+	@./scripts/qa-assert-role.sh
+	@pnpm --dir $(ACCEPTANCE_DIR) install --frozen-lockfile
+	@PLAYWRIGHT_BROWSERS_PATH="$(PLAYWRIGHT_BROWSERS_PATH)" pnpm --dir $(ACCEPTANCE_DIR) exec playwright install chromium
+	@node $(ACCEPTANCE_DIR)/fixtures/bootstrap.mjs
+	@ACCEPTANCE_BASE_URL="$(ACCEPTANCE_BASE_URL)" ACCEPTANCE_API_URL="$(ACCEPTANCE_API_URL)" PLAYWRIGHT_BROWSERS_PATH="$(PLAYWRIGHT_BROWSERS_PATH)" pnpm --dir $(ACCEPTANCE_DIR) exec playwright test
+
+qa-smoke:
+	@./scripts/qa-assert-role.sh
+	@ACCEPTANCE_BASE_URL="$(ACCEPTANCE_BASE_URL)" ACCEPTANCE_API_URL="$(ACCEPTANCE_API_URL)" PLAYWRIGHT_BROWSERS_PATH="$(PLAYWRIGHT_BROWSERS_PATH)" pnpm --dir $(ACCEPTANCE_DIR) exec playwright test smoke

--- a/acceptance/README.md
+++ b/acceptance/README.md
@@ -1,0 +1,24 @@
+# Offbook Acceptance Tests
+
+Acceptance tests are manual QA suites that run against the isolated `offbook-qa`
+compose stack. They are separate from unit tests and `backend/ make verify`.
+
+## Layout
+
+- `fixtures/` provisions reusable QA personas and shared helpers.
+- `smoke/` contains the canonical baseline browser smoke suite.
+- `plaid/` contains Plaid sandbox acceptance helpers and tests.
+- `reports/` is generated output for HTML reports, screenshots, traces, and
+  other run artifacts. It is gitignored.
+
+## Driver
+
+Browser acceptance tests use Playwright with headless Chromium. Playwright is
+installed through `pnpm --dir acceptance install`; no system browser or `brew`
+install is required.
+
+Run from the QA worktree or set `OFFBOOK_ROLE=qa`:
+
+```sh
+command make acceptance
+```

--- a/acceptance/fixtures/bootstrap.mjs
+++ b/acceptance/fixtures/bootstrap.mjs
@@ -1,0 +1,170 @@
+#!/usr/bin/env node
+import bcrypt from 'bcryptjs'
+import pg from 'pg'
+import { acceptanceAPIURL, personaPassword, personas, qaDatabaseURL } from './env.mjs'
+
+const { Client } = pg
+const apiURL = acceptanceAPIURL()
+
+function assertQARole() {
+  const cwd = process.cwd().split('/').pop() ?? ''
+  if (process.env.OFFBOOK_ROLE === 'qa' || cwd === 'offbook-qa' || cwd.endsWith('-qa')) return
+  throw new Error('QA bootstrap requires a QA signal: run from a *-qa worktree or set OFFBOOK_ROLE=qa')
+}
+
+async function waitForBackend() {
+  for (let i = 0; i < 30; i += 1) {
+    try {
+      const res = await fetch(`${apiURL}/health`)
+      if (res.ok) return
+    } catch {
+      // keep polling
+    }
+    await new Promise((resolve) => setTimeout(resolve, 1000))
+  }
+  throw new Error(`backend health did not become ready at ${apiURL}/health`)
+}
+
+async function request(path, { method = 'GET', body, cookie } = {}) {
+  const res = await fetch(`${apiURL}${path}`, {
+    method,
+    headers: {
+      'content-type': 'application/json',
+      ...(cookie ? { cookie } : {}),
+    },
+    body: body ? JSON.stringify(body) : undefined,
+    redirect: 'manual',
+  })
+  const setCookie = res.headers.get('set-cookie')?.split(';')[0]
+  const text = await res.text()
+  let json = null
+  if (text) json = JSON.parse(text)
+  return { res, json, cookie: setCookie }
+}
+
+async function signin(email) {
+  const out = await request('/auth/signin', {
+    method: 'POST',
+    body: { email, password: personaPassword(email) },
+  })
+  if (!out.res.ok) throw new Error(`signin failed for ${email}: HTTP ${out.res.status} ${JSON.stringify(out.json)}`)
+  return out.cookie
+}
+
+async function upsertUser(client, persona) {
+  const hash = await bcrypt.hash(personaPassword(persona.email), 12)
+  const isAdmin = persona.key === 'admin'
+  const scope = persona.role === 'solo' ? 'personal' : 'household'
+
+  const existing = await client.query(
+    'SELECT id FROM users WHERE LOWER(email) = LOWER($1) AND deleted_at IS NULL LIMIT 1',
+    [persona.email],
+  )
+  if (existing.rowCount > 0) {
+    const result = await client.query(
+      `
+        UPDATE users
+        SET password_hash = $2,
+            is_admin = is_admin OR $3,
+            last_scope = $4,
+            default_scope = $4,
+            updated_at = NOW()
+        WHERE id = $1
+        RETURNING id
+      `,
+      [existing.rows[0].id, hash, isAdmin, scope],
+    )
+    return result.rows[0].id
+  }
+
+  const result = await client.query(
+    `
+      INSERT INTO users (email, password_hash, is_admin, last_scope, default_scope, created_at, updated_at)
+      VALUES ($1, $2, $3, $4, $4, NOW(), NOW())
+      RETURNING id
+    `,
+    [persona.email, hash, isAdmin, scope],
+  )
+  return result.rows[0].id
+}
+
+async function ensureMembership(client, householdID, userID, role) {
+  const existing = await client.query(
+    'SELECT id FROM household_members WHERE household_id = $1 AND user_id = $2 AND purged_at IS NULL LIMIT 1',
+    [householdID, userID],
+  )
+  if (existing.rowCount > 0) {
+    await client.query(
+      'UPDATE household_members SET role = $1, left_at = NULL WHERE id = $2',
+      [role, existing.rows[0].id],
+    )
+    return
+  }
+  await client.query(
+    'INSERT INTO household_members (household_id, user_id, role, joined_at) VALUES ($1, $2, $3, NOW())',
+    [householdID, userID, role],
+  )
+}
+
+async function provisionPersonas() {
+  const client = new Client({ connectionString: qaDatabaseURL() })
+  await client.connect()
+  try {
+    await client.query('BEGIN')
+    await client.query(
+      `
+        INSERT INTO instance_config (id, signup_mode, created_at, updated_at)
+        VALUES (1, 'invite_only', NOW(), NOW())
+        ON CONFLICT (id) DO UPDATE SET signup_mode = 'invite_only', updated_at = NOW()
+      `,
+    )
+
+    const ids = new Map()
+    for (const persona of personas) {
+      ids.set(persona.key, await upsertUser(client, persona))
+    }
+
+    const adminID = ids.get('admin')
+    const existingHousehold = await client.query(
+      "SELECT id FROM households WHERE owner_id = $1 AND name = 'QA Household' AND deleted_at IS NULL ORDER BY id LIMIT 1",
+      [adminID],
+    )
+    let householdID = existingHousehold.rows[0]?.id
+    if (!householdID) {
+      const household = await client.query(
+        `
+          INSERT INTO households (name, owner_id, grace_period_days, created_at, updated_at)
+          VALUES ('QA Household', $1, 30, NOW(), NOW())
+          RETURNING id
+        `,
+        [adminID],
+      )
+      householdID = household.rows[0]?.id
+    }
+    if (!householdID) throw new Error('could not create or find QA Household')
+
+    await ensureMembership(client, householdID, adminID, 'owner')
+    await ensureMembership(client, householdID, ids.get('contributor'), 'contributor')
+    await ensureMembership(client, householdID, ids.get('viewer'), 'view_only')
+    await client.query(
+      'UPDATE household_members SET left_at = COALESCE(left_at, NOW()) WHERE user_id = $1 AND left_at IS NULL AND purged_at IS NULL',
+      [ids.get('solo')],
+    )
+    await client.query('UPDATE users SET last_scope = $1, default_scope = $1 WHERE id = $2', ['personal', ids.get('solo')])
+    await client.query('COMMIT')
+  } catch (err) {
+    await client.query('ROLLBACK')
+    throw err
+  } finally {
+    await client.end()
+  }
+}
+
+assertQARole()
+await waitForBackend()
+await provisionPersonas()
+for (const persona of personas) {
+  await signin(persona.email)
+}
+
+console.log(`QA personas ready against ${apiURL}`)

--- a/acceptance/fixtures/env.mjs
+++ b/acceptance/fixtures/env.mjs
@@ -1,0 +1,54 @@
+import { createHmac, randomBytes } from 'node:crypto'
+import { existsSync, readFileSync, appendFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+const repoRoot = resolve(import.meta.dirname, '../..')
+
+export const personas = [
+  { key: 'admin', email: 'qa-admin@offbook.local', role: 'owner' },
+  { key: 'contributor', email: 'qa-contributor@offbook.local', role: 'contributor' },
+  { key: 'viewer', email: 'qa-viewer@offbook.local', role: 'view_only' },
+  { key: 'solo', email: 'qa-solo@offbook.local', role: 'solo' },
+]
+
+export function loadQAEnv() {
+  for (const name of ['.env.qa', '.env.qa.local']) {
+    const path = resolve(repoRoot, name)
+    if (!existsSync(path)) continue
+    const text = readFileSync(path, 'utf8')
+    for (const line of text.split(/\r?\n/)) {
+      const trimmed = line.trim()
+      if (!trimmed || trimmed.startsWith('#') || !trimmed.includes('=')) continue
+      const [key, ...rest] = trimmed.split('=')
+      if (!process.env[key]) process.env[key] = rest.join('=').trim()
+    }
+  }
+}
+
+export function ensureQASecret() {
+  loadQAEnv()
+  if (process.env.QA_SECRET) return process.env.QA_SECRET
+
+  const secret = randomBytes(32).toString('hex')
+  const path = resolve(repoRoot, '.env.qa.local')
+  appendFileSync(path, `${existsSync(path) ? '\n' : ''}QA_SECRET=${secret}\n`, { mode: 0o600 })
+  process.env.QA_SECRET = secret
+  return secret
+}
+
+export function personaPassword(email) {
+  const secret = ensureQASecret()
+  return createHmac('sha256', secret).update(`offbook-qa:${email}`).digest('base64url').slice(0, 28)
+}
+
+export function acceptanceAPIURL() {
+  return process.env.ACCEPTANCE_API_URL ?? 'http://localhost:18000/api/v1'
+}
+
+export function acceptanceBaseURL() {
+  return process.env.ACCEPTANCE_BASE_URL ?? 'http://localhost:15173'
+}
+
+export function qaDatabaseURL() {
+  return process.env.QA_DATABASE_URL ?? 'postgres://offbook:offbook@localhost:15432/offbook_dev?sslmode=disable'
+}

--- a/acceptance/package.json
+++ b/acceptance/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "offbook-acceptance",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "test": "playwright test"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.57.0",
+    "@types/pg": "^8.20.0",
+    "bcryptjs": "^3.0.3",
+    "pg": "^8.21.0"
+  }
+}

--- a/acceptance/plaid/helper.mjs
+++ b/acceptance/plaid/helper.mjs
@@ -1,0 +1,36 @@
+import { acceptanceAPIURL } from '../fixtures/env.mjs'
+
+export async function plaidSandboxPublicToken() {
+  const clientID = process.env.PLAID_CLIENT_ID
+  const secret = process.env.PLAID_SECRET
+  if (!clientID || !secret) {
+    throw new Error('PLAID_CLIENT_ID and PLAID_SECRET are required for Plaid sandbox acceptance tests')
+  }
+
+  const res = await fetch('https://sandbox.plaid.com/sandbox/public_token/create', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      client_id: clientID,
+      secret,
+      institution_id: process.env.PLAID_SANDBOX_INSTITUTION_ID ?? 'ins_109508',
+      initial_products: ['transactions'],
+      options: {
+        webhook: process.env.PLAID_SANDBOX_WEBHOOK,
+      },
+    }),
+  })
+  if (!res.ok) throw new Error(`Plaid sandbox token create failed: HTTP ${res.status} ${await res.text()}`)
+  const body = await res.json()
+  return body.public_token
+}
+
+export async function exchangePublicToken(cookie, publicToken) {
+  const res = await fetch(`${acceptanceAPIURL()}/plaid/link/exchange`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', cookie },
+    body: JSON.stringify({ public_token: publicToken }),
+  })
+  if (!res.ok) throw new Error(`Offbook Plaid exchange failed: HTTP ${res.status} ${await res.text()}`)
+  return res.json()
+}

--- a/acceptance/plaid/sandbox.spec.ts
+++ b/acceptance/plaid/sandbox.spec.ts
@@ -1,0 +1,9 @@
+import { expect, test } from '@playwright/test'
+import { plaidSandboxPublicToken } from './helper.mjs'
+
+test.describe('Plaid sandbox acceptance', () => {
+  test('public-token helper mints a sandbox token without Plaid Link', async () => {
+    test.skip(!process.env.PLAID_CLIENT_ID || !process.env.PLAID_SECRET, 'Plaid sandbox credentials are not configured')
+    await expect(plaidSandboxPublicToken()).resolves.toMatch(/^public-/)
+  })
+})

--- a/acceptance/playwright.config.ts
+++ b/acceptance/playwright.config.ts
@@ -1,0 +1,39 @@
+import { defineConfig, devices } from '@playwright/test'
+
+const baseURL = process.env.ACCEPTANCE_BASE_URL ?? 'http://localhost:15173'
+
+export default defineConfig({
+  testDir: '.',
+  timeout: 30_000,
+  fullyParallel: false,
+  reporter: [
+    ['list'],
+    ['html', { outputFolder: 'reports/html', open: 'never' }],
+  ],
+  outputDir: 'reports/artifacts',
+  use: {
+    baseURL,
+    trace: 'retain-on-failure',
+    screenshot: 'only-on-failure',
+    video: 'off',
+  },
+  projects: [
+    {
+      name: 'desktop-chromium',
+      use: {
+        ...devices['Desktop Chrome'],
+        viewport: { width: 1280, height: 900 },
+      },
+    },
+    {
+      name: 'mobile-chromium',
+      use: {
+        browserName: 'chromium',
+        isMobile: true,
+        hasTouch: true,
+        userAgent: devices['iPhone 14'].userAgent,
+        viewport: { width: 393, height: 852 },
+      },
+    },
+  ],
+})

--- a/acceptance/pnpm-lock.yaml
+++ b/acceptance/pnpm-lock.yaml
@@ -1,0 +1,195 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    devDependencies:
+      '@playwright/test':
+        specifier: ^1.57.0
+        version: 1.60.0
+      '@types/pg':
+        specifier: ^8.20.0
+        version: 8.20.0
+      bcryptjs:
+        specifier: ^3.0.3
+        version: 3.0.3
+      pg:
+        specifier: ^8.21.0
+        version: 8.21.0
+
+packages:
+
+  '@playwright/test@1.60.0':
+    resolution: {integrity: sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  '@types/node@25.9.0':
+    resolution: {integrity: sha512-AOQwYUNolgy3VosiRqXrACUXTN8nJUtPl7FJXMqZVyxiiCLhQuG3jXKvCS1ALr+Y2OmZhzzLVlYPEqJaiqkaJQ==}
+
+  '@types/pg@8.20.0':
+    resolution: {integrity: sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==}
+
+  bcryptjs@3.0.3:
+    resolution: {integrity: sha512-GlF5wPWnSa/X5LKM1o0wz0suXIINz1iHRLvTS+sLyi7XPbe5ycmYI3DlZqVGZZtDgl4DmasFg7gOB3JYbphV5g==}
+    hasBin: true
+
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  pg-cloudflare@1.4.0:
+    resolution: {integrity: sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A==}
+
+  pg-connection-string@2.13.0:
+    resolution: {integrity: sha512-EMnU9E2fSULdsbErBbMaXJvFeD9B4+nPcM3f+4lsiCR0BHLPrLVjv3DbyM2hgQQviKJaTWIRRTjKjWlHg3p2ig==}
+
+  pg-int8@1.0.1:
+    resolution: {integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==}
+    engines: {node: '>=4.0.0'}
+
+  pg-pool@3.14.0:
+    resolution: {integrity: sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw==}
+    peerDependencies:
+      pg: '>=8.0'
+
+  pg-protocol@1.14.0:
+    resolution: {integrity: sha512-n5taZ1kO3s9ngDTVxsEznOqCyToTgz0FLuPq0B33COy5pPpuWJpY3/2oRBVETuOgzdqRXfWpM9HIhp2LBBT1BA==}
+
+  pg-types@2.2.0:
+    resolution: {integrity: sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==}
+    engines: {node: '>=4'}
+
+  pg@8.21.0:
+    resolution: {integrity: sha512-AUP1EYJuHraQGsVoCQVIcM7TEJVGtDzxWtGFZd8rds9d+CCXlU5Js1rYgfLNvxy9iJrpHjGrRjoi/3BT9fRyiA==}
+    engines: {node: '>= 16.0.0'}
+    peerDependencies:
+      pg-native: '>=3.0.1'
+    peerDependenciesMeta:
+      pg-native:
+        optional: true
+
+  pgpass@1.0.5:
+    resolution: {integrity: sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==}
+
+  playwright-core@1.60.0:
+    resolution: {integrity: sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.60.0:
+    resolution: {integrity: sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  postgres-array@2.0.0:
+    resolution: {integrity: sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==}
+    engines: {node: '>=4'}
+
+  postgres-bytea@1.0.1:
+    resolution: {integrity: sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==}
+    engines: {node: '>=0.10.0'}
+
+  postgres-date@1.0.7:
+    resolution: {integrity: sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==}
+    engines: {node: '>=0.10.0'}
+
+  postgres-interval@1.2.0:
+    resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
+    engines: {node: '>=0.10.0'}
+
+  split2@4.2.0:
+    resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
+    engines: {node: '>= 10.x'}
+
+  undici-types@7.24.6:
+    resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
+
+  xtend@4.0.2:
+    resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
+    engines: {node: '>=0.4'}
+
+snapshots:
+
+  '@playwright/test@1.60.0':
+    dependencies:
+      playwright: 1.60.0
+
+  '@types/node@25.9.0':
+    dependencies:
+      undici-types: 7.24.6
+
+  '@types/pg@8.20.0':
+    dependencies:
+      '@types/node': 25.9.0
+      pg-protocol: 1.14.0
+      pg-types: 2.2.0
+
+  bcryptjs@3.0.3: {}
+
+  fsevents@2.3.2:
+    optional: true
+
+  pg-cloudflare@1.4.0:
+    optional: true
+
+  pg-connection-string@2.13.0: {}
+
+  pg-int8@1.0.1: {}
+
+  pg-pool@3.14.0(pg@8.21.0):
+    dependencies:
+      pg: 8.21.0
+
+  pg-protocol@1.14.0: {}
+
+  pg-types@2.2.0:
+    dependencies:
+      pg-int8: 1.0.1
+      postgres-array: 2.0.0
+      postgres-bytea: 1.0.1
+      postgres-date: 1.0.7
+      postgres-interval: 1.2.0
+
+  pg@8.21.0:
+    dependencies:
+      pg-connection-string: 2.13.0
+      pg-pool: 3.14.0(pg@8.21.0)
+      pg-protocol: 1.14.0
+      pg-types: 2.2.0
+      pgpass: 1.0.5
+    optionalDependencies:
+      pg-cloudflare: 1.4.0
+
+  pgpass@1.0.5:
+    dependencies:
+      split2: 4.2.0
+
+  playwright-core@1.60.0: {}
+
+  playwright@1.60.0:
+    dependencies:
+      playwright-core: 1.60.0
+    optionalDependencies:
+      fsevents: 2.3.2
+
+  postgres-array@2.0.0: {}
+
+  postgres-bytea@1.0.1: {}
+
+  postgres-date@1.0.7: {}
+
+  postgres-interval@1.2.0:
+    dependencies:
+      xtend: 4.0.2
+
+  split2@4.2.0: {}
+
+  undici-types@7.24.6: {}
+
+  xtend@4.0.2: {}

--- a/acceptance/smoke/baseline.spec.ts
+++ b/acceptance/smoke/baseline.spec.ts
@@ -1,0 +1,70 @@
+import { expect, test, type Page } from '@playwright/test'
+import { personaPassword } from '../fixtures/env.mjs'
+
+const publicRoutes = ['/setup/admin', '/signin', '/signup']
+const personalRoutes = [
+  '/dashboard',
+  '/accounts',
+  '/connect',
+  '/transactions',
+  '/rules',
+  '/budgets',
+  '/savings-goals',
+  '/investments',
+  '/import',
+  '/ai',
+  '/settings',
+]
+const householdRoutes = ['/h/dashboard', '/h/budgets', '/h/goals', '/h/members', '/h/ai', '/h/settings']
+
+test.describe('baseline route smoke', () => {
+  for (const route of publicRoutes) {
+    test(`public route ${route}`, async ({ page }) => {
+      const errors = collectRuntimeErrors(page)
+      await page.goto(route)
+      await expect(page.locator('body')).not.toBeEmpty()
+      await expectNoHorizontalOverflow(page)
+      expect(errors, 'console errors, uncaught exceptions, or 5xx responses').toEqual([])
+    })
+  }
+
+  for (const route of [...personalRoutes, ...householdRoutes]) {
+    test(`authenticated route ${route}`, async ({ page }) => {
+      const errors = collectRuntimeErrors(page)
+      await login(page)
+      await page.goto(route)
+      await expect(page.locator('body')).not.toBeEmpty()
+      await expectNoHorizontalOverflow(page)
+      expect(errors, 'console errors, uncaught exceptions, or 5xx responses').toEqual([])
+    })
+  }
+})
+
+function collectRuntimeErrors(page: Page) {
+  const errors: string[] = []
+  page.on('console', (msg) => {
+    if (msg.type() === 'error' && !isExpectedBrowserNoise(msg.text())) errors.push(msg.text())
+  })
+  page.on('pageerror', (err) => errors.push(err.message))
+  page.on('response', (response) => {
+    if (response.status() >= 500) errors.push(`${response.status()} ${response.url()}`)
+  })
+  return errors
+}
+
+function isExpectedBrowserNoise(message: string) {
+  return message.includes('Failed to load resource: the server responded with a status of 401 (Unauthorized)')
+}
+
+async function login(page: Page) {
+  await page.goto('/signin')
+  await page.getByLabel(/email/i).fill('qa-admin@offbook.local')
+  await page.getByLabel(/password/i).fill(personaPassword('qa-admin@offbook.local'))
+  await page.getByRole('button', { name: /sign in/i }).click()
+  await page.waitForURL(/\/dashboard|\/h\/dashboard/)
+}
+
+async function expectNoHorizontalOverflow(page: Page) {
+  const overflow = await page.evaluate(() => document.documentElement.scrollWidth > document.documentElement.clientWidth + 1)
+  expect(overflow, 'document must not horizontally overflow').toBe(false)
+}

--- a/docker-compose.qa.yml
+++ b/docker-compose.qa.yml
@@ -9,8 +9,17 @@ services:
   backend:
     ports: !override
       - "18000:8000"
+    env_file: !override
+      - path: .env.qa
+        required: false
+      - path: .env.qa.local
+        required: false
     environment:
+      APP_ENV: dev
+      DATABASE_URL: postgres://offbook:offbook@postgres:5432/offbook_dev?sslmode=disable
+      PORT: "8000"
       FRONTEND_URL: http://localhost:15173
+      MIGRATIONS_PATH: /app/migrations
 
   frontend:
     ports: !override

--- a/docs/QA.md
+++ b/docs/QA.md
@@ -2,7 +2,7 @@
 
 Offbook QA is a manually triggered role. The same agent session should not both implement a change and certify it as QA. A developer agent may run focused checks while building, but autonomous QA starts only when the user explicitly asks for it, for example: "be QA", "run QA", "QA issue #123", or "QA since the last reviewed commit."
 
-QA work is evidence gathering, issue filing, and acceptance-test development. It must not make product code changes unless the user explicitly switches the session from QA to development. QA should normally use headless Chrome for browser verification.
+QA work is evidence gathering, issue filing, and acceptance-test development. It must not make product code changes unless the user explicitly switches the session from QA to development. Browser automation uses Playwright with headless Chromium.
 
 ## Product Contract
 
@@ -50,7 +50,7 @@ QA agents:
 
 If the user asks the current agent to fix an issue found during QA, treat that as a role switch. Record the QA finding first, then stop calling the resulting work QA certification.
 
-## Worktree and Environment Isolation
+## Worktree And Environment Isolation
 
 QA should not share a working tree, containers, ports, browser profile, or database volume with an active development agent.
 
@@ -69,9 +69,19 @@ git -C ../offbook-qa pull --ff-only
 
 Run QA from the QA worktree. Use a branch or detached commit only when the user explicitly asks to QA that target. Do not switch the developer's active worktree.
 
+QA tooling requires a visible QA-mode signal. The default signal is running from a worktree whose directory name is `offbook-qa` or ends in `-qa`. If a scoped QA run must happen elsewhere, explicitly set:
+
+```sh
+export OFFBOOK_ROLE=qa
+```
+
+Helper scripts refuse to run without one of those signals, making accidental dev/QA role mixing visible.
+
 Default isolated QA stack:
 
 ```sh
+cp .env.qa.example .env.qa
+# Edit .env.qa with a QA-only SESSION_SECRET and optional QA-only Plaid sandbox keys.
 docker compose -p offbook-qa -f docker-compose.yml -f docker-compose.qa.yml up -d --build
 ```
 
@@ -82,6 +92,8 @@ QA service URLs:
 - Postgres host port: `15432`
 
 The QA compose project name (`offbook-qa`) gives QA separate containers and Docker-managed identity. The QA compose override gives QA separate host ports and a dedicated `qa_postgres_data` named volume, so the QA database is isolated even if someone accidentally runs the QA stack from the main development worktree. A separate worktree is still required to avoid file and branch conflicts with the development agent.
+
+The backend container runs migrations on boot when `MIGRATIONS_PATH=/app/migrations` is set. On a cold QA volume, `docker compose -p offbook-qa -f docker-compose.yml -f docker-compose.qa.yml up -d --build` should leave the DB migrated and `/setup/admin` renderable.
 
 Stop the QA stack when done:
 
@@ -97,22 +109,28 @@ docker volume rm offbook-qa_qa_postgres_data
 
 Use a dedicated Chrome profile for QA, for example under `/private/tmp/offbook-qa-chrome-profile`, so cookies and local storage do not bleed between development and QA.
 
-## QA Credentials
+## QA Environment And Credentials
 
-QA credentials are fixed test personas for the isolated QA stack only. They are not secrets and must not be used in development, production, or any shared real-data environment.
+The QA compose override loads backend environment from `.env.qa` and `.env.qa.local`, not the repo-root `.env`. This keeps QA Plaid sandbox credentials and `PLAID_TOKEN_KEY` separate from development. `.env.qa.local` is generated or edited locally and is gitignored.
+
+QA persona emails are fixed. Passwords are derived from `QA_SECRET` by the acceptance fixture loader, so they are reproducible without committing plaintext credentials. If `QA_SECRET` is absent, `command make acceptance` writes a generated value to `.env.qa.local`; use that file for manual login during the same QA run.
 
 Default personas:
 
-| Persona | Email | Password | Purpose |
-| --- | --- | --- | --- |
-| Primary admin | `qa-admin@offbook.local` | `qa-admin-password-2026!` | First `/setup/admin` user, owner-level household flows, settings, invites |
-| Contributor | `qa-contributor@offbook.local` | `qa-contributor-password-2026!` | Household member with own accounts and share settings |
-| Viewer | `qa-viewer@offbook.local` | `qa-viewer-password-2026!` | View-only/member lifecycle and aggregate visibility checks |
-| Solo user | `qa-solo@offbook.local` | `qa-solo-password-2026!` | Personal-only scope, no-household empty states |
+| Persona | Email | Purpose |
+| --- | --- | --- |
+| Primary admin | `qa-admin@offbook.local` | First `/setup/admin` user, owner-level household flows, settings, invites |
+| Contributor | `qa-contributor@offbook.local` | Household member with own accounts and share settings |
+| Viewer | `qa-viewer@offbook.local` | View-only/member lifecycle and aggregate visibility checks |
+| Solo user | `qa-solo@offbook.local` | Personal-only scope and no-household empty states |
 
-On a fresh QA database, create the primary admin through `/setup/admin` with `invite_only` mode unless the test specifically covers local multi-tenant signup. Create the remaining personas through invite flows so QA exercises the product path.
+The fixture loader provisions these personas idempotently:
 
-Acceptance tests should use these credentials by default and may recreate them after resetting the QA volume. If a test needs a one-off user, use a `qa+<suite>-<timestamp>@offbook.local` address and keep it inside the isolated QA stack.
+```sh
+node acceptance/fixtures/bootstrap.mjs
+```
+
+`command make acceptance` invokes the loader before running browser suites. If a test needs a one-off user, use a `qa+<suite>-<timestamp>@offbook.local` address and keep it inside the isolated QA stack.
 
 ## QA Ledger
 
@@ -120,7 +138,7 @@ Use GitHub Discussion #199 as the shared QA Ledger:
 
 - `https://github.com/gregwym/offbook/discussions/199`
 
-Do not record QA run history in committed repo files. A QA run should append a comment to Discussion #199 after filing or updating any issues. This keeps QA bookkeeping shared across agents without creating PRs only for operational state.
+Do not record QA run history in committed repo files. A QA run should append a comment to Discussion #199 after filing or updating any issues.
 
 Each full or scoped QA run gets a discussion comment:
 
@@ -141,7 +159,13 @@ Each full or scoped QA run gets a discussion comment:
 -- Codex QA
 ```
 
-The most recent QA run comment in Discussion #199 is the source of truth for the last QAed commit. At the start of a QA run, compare that commit to the target under review:
+The most recent QA run comment in Discussion #199 is the source of truth for the last QAed commit. Fetch it with:
+
+```sh
+scripts/qa-last-reviewed.sh
+```
+
+Then compare that commit to the target under review:
 
 ```sh
 git rev-parse HEAD
@@ -186,6 +210,20 @@ Required issue body fields:
 
 If a matching issue already exists, comment instead of creating a duplicate. The comment must still include `Found At: <sha>` if the failure is reproduced at a new commit.
 
+When a QA-filed bug is fixed, re-test it before closing. The close comment must include:
+
+```md
+## QA Re-Verification
+
+- Verified Fixed At: `<sha>`
+- Verified By: `<QA ledger comment URL or GitHub Actions run URL>`
+- Result: `<pass | still failing>`
+
+-- Codex QA
+```
+
+Apply `qa-verified` on verified close. Use `qa-needs-verify` for a merged fix that still needs a QA re-test.
+
 ## Severity
 
 - P0: privacy leak, auth bypass, cross-user data exposure, destructive action without confirmation.
@@ -197,35 +235,31 @@ If a matching issue already exists, comment instead of creating a duplicate. The
 
 1. Read the product contract files.
 2. Check worktree and branch.
-3. Read the latest QA Ledger comment in Discussion #199 and compute the delta from the last reviewed commit.
+3. Run `scripts/qa-last-reviewed.sh` and compute the delta from the last reviewed commit.
 4. Check open GitHub issues to avoid duplicates.
 5. Start or confirm the isolated QA compose stack and backend health.
 6. Log in with the test personas required for the run.
-7. Run browser smoke over changed routes and baseline critical routes.
+7. Run `command make acceptance`, or `command make qa-smoke` for a baseline-only run, then add changed-route checks as needed.
 8. Run targeted workflow checks from the design contract.
 9. Use API/database inspection to verify privacy and data-shape claims.
 10. File or update issues with evidence and `Found At`.
 11. Add or update acceptance tests when a core requirement is stable enough to automate.
-12. Append a QA Ledger comment to Discussion #199.
+12. Append a QA Ledger comment to Discussion #199, manually or with `scripts/qa-append-ledger.sh <markdown-file>`.
 
-Critical baseline routes:
-
-- Personal: `/dashboard`, `/accounts`, `/transactions`, `/rules`, `/budgets`, `/savings-goals`, `/investments`, `/import`, `/ai`, `/settings`.
-- Household: `/h/dashboard`, `/h/budgets`, `/h/goals`, `/h/members`, `/h/ai`, `/h/settings`.
-- Auth: `/setup/admin`, `/signin`, `/signup`.
+The canonical baseline route list lives in `acceptance/smoke/baseline.spec.ts`. It covers auth, personal, and household routes and asserts page load, no console/runtime errors, no 5xx responses, and no mobile horizontal overflow.
 
 Browser checks:
 
 - Desktop: `1280x900`.
 - Mobile: `393x852` with iPhone Safari user agent.
-- Use headless Chrome unless a bug specifically requires another browser.
+- Use Playwright headless Chromium unless a bug specifically requires another browser.
 - Use the isolated QA frontend URL, normally `http://localhost:15173`.
 - Capture uncaught exceptions, console errors, blank page state, network 5xx responses, and horizontal overflow.
 - For mobile, verify primary controls remain visible and usable.
 
 ## Acceptance Test Suites
 
-Acceptance tests are separate from unit tests and from `make verify`. They should exercise user-level product requirements through the running app and API. They start as optional, manually run checks and are not required for merging until the owner explicitly promotes them.
+Acceptance tests are separate from unit tests and from `make verify`. They exercise user-level product requirements through the running app and API. They start as optional, manually run checks and are not required for merging until the owner explicitly promotes them.
 
 Location:
 
@@ -233,93 +267,26 @@ Location:
 - Test fixtures and personas: `acceptance/fixtures/`.
 - Reports and screenshots: ignored output under `acceptance/reports/`.
 
-Expected command shape once implemented:
+Command:
 
 ```sh
 command make acceptance
 ```
 
-Acceptance tests should target the isolated QA stack by default, not the developer stack. If they need to start services themselves, they should use the `offbook-qa` compose project and `docker-compose.qa.yml` ports.
+Plaid sandbox acceptance must not drive the Plaid Link iframe. Use `acceptance/plaid/helper.mjs` to mint a public token through `/sandbox/public_token/create`, exchange it through `/api/v1/plaid/link/exchange`, then sync accounts and transactions through Offbook. A smaller browser smoke should still assert `/connect` renders and the Plaid Link button mounts.
 
 Initial suites to build:
 
-1. Auth and setup
-   - first admin setup
-   - invite-only signup
-   - signin/signout
-   - unauthorized redirects
+1. Auth and setup: first admin setup, invite-only signup, signin/signout, unauthorized redirects.
+2. Personal finance core: create account, PII masking/reveal, create/categorize transaction, dashboard totals.
+3. Plaid sandbox smoke: public-token helper, exchange, sync accounts, sync transactions, no duplicate rows on re-sync.
+4. Budgets and goals: create budget, spend calculation, over-budget warning, savings goal contribution.
+5. Investments: empty portfolio, crypto precision, allocation summary, CSV import happy path.
+6. Household privacy: invite member, private/balance-only/balance-and-transactions visibility, aggregate-only household UI/API.
+7. Household lifecycle: leave, grace, rejoin, last-owner protection, purge preserving historical aggregates.
+8. AI privacy: personal/household context exclusions and context-preview parity with provider-bound payload.
+9. Responsive contract: mobile overflow, scope switcher, AI composer, and primary tap targets.
 
-2. Personal finance core
-   - create account
-   - PII masked by default and revealable only from account PII surface
-   - create transaction
-   - categorize transaction
-   - dashboard totals update
+Each suite should write or link machine-readable run history. Today, manually link the local run output or note `not run` in the QA Ledger. When these suites are promoted into CI, GitHub Actions runs, checks, and artifacts become the durable acceptance-test run history. QA Ledger comments should then link the relevant Actions run/check/artifact instead of duplicating full logs in Discussion #199.
 
-3. Plaid sandbox smoke
-   - connect sandbox institution
-   - sync accounts
-   - sync transactions
-   - re-sync does not duplicate
-
-4. Budgets and goals
-   - create budget
-   - budget spend calculation
-   - over-budget warning
-   - create savings goal and contribution
-
-5. Investments
-   - empty portfolio renders
-   - crypto precision is preserved
-   - allocation summary renders
-   - CSV import happy path
-
-6. Household privacy
-   - create household
-   - invite member
-   - private account excluded
-   - balance-only account contributes balance but not transaction category detail
-   - balance-and-transactions account contributes allowed aggregates
-   - no raw other-member transactions appear in household UI or API responses
-
-7. Household lifecycle
-   - member leaves
-   - leaving member is excluded from live aggregates during grace
-   - rejoin auto-resumes preserved links
-   - last owner cannot leave without transfer
-   - purge removes expired links while preserving historical aggregates
-
-8. AI privacy
-   - personal AI context excludes PII
-   - household AI context excludes PII, private accounts, individual balances, raw other-member transactions, and other members' private chats
-   - context preview matches the API payload sent to the model provider boundary
-
-9. Responsive contract
-   - no route-level horizontal overflow on mobile except intentional local table scrollers
-   - scope switcher usable on mobile
-   - AI composer visible on mobile
-   - primary actions meet mobile tap-target expectations
-
-Acceptance test run history:
-
-- Manual QA narrative belongs in Discussion #199.
-- Automated acceptance test history should eventually live in GitHub Actions runs, non-required checks, logs, screenshots, and uploaded artifacts.
-- When acceptance suites are introduced, publish a GitHub Actions run or check result against the reviewed commit and link it from the Discussion #199 QA run comment.
-- Keep acceptance checks non-required until the owner explicitly promotes a stable subset.
-
-Promotion rule:
-
-- Optional at first: failures file bugs but do not block merges.
-- Required later only by explicit decision, after the suite is stable and fast enough for CI.
-- When promoted, document the required subset in `AGENTS.md` and CI config in the same PR.
-
-## QA Output
-
-End every QA run with:
-
-- commit reviewed
-- previous reviewed commit
-- changed surfaces tested
-- issues filed or updated
-- acceptance tests added or missing
-- blockers or residual risk
+End every QA run with the commit reviewed, previous reviewed commit, changed surfaces tested, issues filed or updated, acceptance tests added or missing, and blockers or residual risk.

--- a/scripts/qa-append-ledger.sh
+++ b/scripts/qa-append-ledger.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env sh
+set -eu
+
+./scripts/qa-assert-role.sh
+
+if [ "$#" -ne 1 ]; then
+  echo "usage: scripts/qa-append-ledger.sh <markdown-file>" >&2
+  exit 2
+fi
+
+owner="${GITHUB_REPOSITORY_OWNER:-gregwym}"
+repo="${GITHUB_REPOSITORY_NAME:-offbook}"
+discussion="${QA_LEDGER_DISCUSSION_NUMBER:-199}"
+
+discussion_id="$(gh api graphql \
+  -f owner="$owner" \
+  -f repo="$repo" \
+  -F number="$discussion" \
+  -f query='query($owner:String!, $repo:String!, $number:Int!) { repository(owner:$owner, name:$repo) { discussion(number:$number) { id } } }' \
+  --jq '.data.repository.discussion.id')"
+
+gh api graphql \
+  -f discussionId="$discussion_id" \
+  -f body="$(cat "$1")" \
+  -f query='mutation($discussionId:ID!, $body:String!) { addDiscussionComment(input:{discussionId:$discussionId, body:$body}) { comment { url } } }' \
+  --jq '.data.addDiscussionComment.comment.url'

--- a/scripts/qa-assert-role.sh
+++ b/scripts/qa-assert-role.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env sh
+set -eu
+
+base="$(basename "$PWD")"
+if [ "${OFFBOOK_ROLE:-}" = "qa" ] || [ "$base" = "offbook-qa" ] || [ "${base%*-qa}" != "$base" ]; then
+  exit 0
+fi
+
+cat >&2 <<'EOF'
+QA tooling requires a structural QA signal.
+
+Run from a QA worktree such as ../offbook-qa, or set:
+
+  export OFFBOOK_ROLE=qa
+EOF
+exit 2

--- a/scripts/qa-last-reviewed.sh
+++ b/scripts/qa-last-reviewed.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env sh
+set -eu
+
+./scripts/qa-assert-role.sh
+
+owner="${GITHUB_REPOSITORY_OWNER:-gregwym}"
+repo="${GITHUB_REPOSITORY_NAME:-offbook}"
+discussion="${QA_LEDGER_DISCUSSION_NUMBER:-199}"
+
+query='
+query($owner:String!, $repo:String!, $number:Int!) {
+  repository(owner:$owner, name:$repo) {
+    discussion(number:$number) {
+      comments(last:50) {
+        nodes {
+          body
+          createdAt
+        }
+      }
+    }
+  }
+}'
+
+body="$(gh api graphql -f owner="$owner" -f repo="$repo" -F number="$discussion" -f query="$query" --jq '.data.repository.discussion.comments.nodes | reverse | .[].body' | awk '
+  match($0, /Reviewed commit:[[:space:]]*`?[0-9a-f]{7,40}`?/) {
+    line = substr($0, RSTART, RLENGTH)
+    gsub(/Reviewed commit:[[:space:]]*`?/, "", line)
+    gsub(/`/, "", line)
+    print line
+    exit
+  }
+')"
+
+if [ -z "$body" ]; then
+  exit 1
+fi
+
+printf '%s\n' "$body"


### PR DESCRIPTION
Closes #202
Closes #203
Closes #204
Closes #205
Closes #206
Closes #207
Closes #208
Closes #209
Closes #210
Closes #211
Closes #212

## Summary
- Add root acceptance targets, Playwright acceptance scaffold, baseline smoke suite, Plaid sandbox helper, and idempotent QA persona bootstrap.
- Isolate QA env loading through .env.qa/.env.qa.local and document QA_SECRET-derived persona credentials.
- Add QA-mode guard scripts, GitHub Discussion ledger helpers, and re-verification lifecycle docs/labels.

## Verification
- docker compose -p offbook-qa -f docker-compose.yml -f docker-compose.qa.yml config
- OFFBOOK_ROLE=qa scripts/qa-last-reviewed.sh
- cold QA volume reset + docker compose up rendered /setup/admin and healthy backend
- OFFBOOK_ROLE=qa command make acceptance: 40 passed, 2 Plaid sandbox tests skipped because Plaid credentials are not configured