### PR TITLE
Harden QA acceptance workflow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,7 @@
 # manually if you're running `go run ./cmd/server` by hand.
 #
 #   dev   → postgres://offbook:offbook@localhost:5432/offbook_dev (default)
+#   qa    → postgres://offbook:offbook@localhost:5432/offbook_qa
 #   test  → postgres://offbook:offbook@localhost:5432/offbook_test
 #   prod  → DATABASE_URL is REQUIRED (no default; refuses to start otherwise)
 APP_ENV=dev

--- a/.env.qa.example
+++ b/.env.qa.example
@@ -1,13 +1,13 @@
 # Copy to .env.qa for the isolated offbook-qa compose stack.
-APP_ENV=dev
-DATABASE_URL=postgres://offbook:offbook@postgres:5432/offbook_dev?sslmode=disable
+APP_ENV=qa
+DATABASE_URL=postgres://offbook:offbook@postgres:5432/offbook_qa?sslmode=disable
 PORT=8000
 FRONTEND_URL=http://localhost:15173
 MIGRATIONS_PATH=/app/migrations
 
 # QA-only backend secret. Generate a fresh value for real QA runs:
 #   openssl rand -hex 32
-SESSION_SECRET=replace-with-qa-session-secret
+# SESSION_SECRET=
 
 # QA persona password derivation. If omitted, acceptance bootstrap writes a
 # generated value to gitignored .env.qa.local.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,9 +59,10 @@ When running via Claude's Bash tool, prefix `make` with `command` (`command make
 
 ## Environment Isolation
 - **Every environment gets its own database.** Dev, test, prod (and any future staging) never share a DB. Sharing leaks fixtures between them — `make test` running against the dev DB has corrupted dev data in the past (test-fixture `categories` showing up in the user's category dropdown; see #183).
-- DB selection routes through `APP_ENV`, resolved by `internal/config.ResolveDatabaseURL`. Defaults: `dev` → `offbook_dev`, `test` → `offbook_test`, `prod` → no default (refuses to start without explicit `DATABASE_URL`). Explicit `DATABASE_URL` always wins (docker-compose and prod inject one).
+- DB selection routes through `APP_ENV`, resolved by `internal/config.ResolveDatabaseURL`. Defaults: `dev` → `offbook_dev`, `qa` → `offbook_qa`, `test` → `offbook_test`, `prod` → no default (refuses to start without explicit `DATABASE_URL`). Explicit `DATABASE_URL` always wins (docker-compose and prod inject one).
 - When adding a new entry point (CLI, cron, worker), call `config.Load()` so it picks up the right DB automatically. Don't re-read `DATABASE_URL` from `os.Getenv` directly.
 - `make dev` / `make smoke` set `APP_ENV=dev`. `make test` sets `APP_ENV=test` and points at `offbook_test`, migrating it first.
+- The isolated QA compose stack sets `APP_ENV=qa` and points at `offbook_qa`.
 - One-shot cleanup of a polluted pre-#183 DB: `cd backend && go run ./cmd/db-clean-fixtures --apply` (dry-run by default; refuses to run against `offbook_test`).
 - "Just use a `TEST_DATABASE_URL` env var" is not enough — the structural fix is config-layer isolation across all envs, not a Makefile flag.
 

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,28 @@
-.PHONY: acceptance qa-smoke
+.DEFAULT_GOAL := help
+
+.PHONY: help verify acceptance qa-smoke qa-suite
 
 ACCEPTANCE_DIR := acceptance
 ACCEPTANCE_BASE_URL ?= http://localhost:15173
 ACCEPTANCE_API_URL ?= http://localhost:18000/api/v1
 PLAYWRIGHT_BROWSERS_PATH ?= .cache/ms-playwright
+QA_SUITE ?=
+
+help:
+	@printf '%s\n' 'Offbook root targets:'
+	@printf '%s\n' '  command make acceptance          Install browser deps, bootstrap QA personas, run all acceptance suites'
+	@printf '%s\n' '  command make qa-smoke            Run the baseline acceptance smoke suite'
+	@printf '%s\n' '  command make qa-suite QA_SUITE=plaid  Run one acceptance suite or spec pattern'
+	@printf '%s\n' '  command make verify              Run the backend CI mirror from backend/'
+	@printf '%s\n' ''
+	@printf '%s\n' 'Backend-only targets live in backend/Makefile; run them from backend/ with command make <target>.'
+
+verify:
+	@$(MAKE) -C backend verify
 
 acceptance:
 	@./scripts/qa-assert-role.sh
+	@./scripts/qa-preflight.sh
 	@pnpm --dir $(ACCEPTANCE_DIR) install --frozen-lockfile
 	@PLAYWRIGHT_BROWSERS_PATH="$(PLAYWRIGHT_BROWSERS_PATH)" pnpm --dir $(ACCEPTANCE_DIR) exec playwright install chromium
 	@node $(ACCEPTANCE_DIR)/fixtures/bootstrap.mjs
@@ -14,4 +30,11 @@ acceptance:
 
 qa-smoke:
 	@./scripts/qa-assert-role.sh
+	@./scripts/qa-preflight.sh
 	@ACCEPTANCE_BASE_URL="$(ACCEPTANCE_BASE_URL)" ACCEPTANCE_API_URL="$(ACCEPTANCE_API_URL)" PLAYWRIGHT_BROWSERS_PATH="$(PLAYWRIGHT_BROWSERS_PATH)" pnpm --dir $(ACCEPTANCE_DIR) exec playwright test smoke
+
+qa-suite:
+	@./scripts/qa-assert-role.sh
+	@./scripts/qa-preflight.sh
+	@test -n "$(QA_SUITE)" || (echo 'Set QA_SUITE, for example: command make qa-suite QA_SUITE=plaid' >&2; exit 2)
+	@ACCEPTANCE_BASE_URL="$(ACCEPTANCE_BASE_URL)" ACCEPTANCE_API_URL="$(ACCEPTANCE_API_URL)" PLAYWRIGHT_BROWSERS_PATH="$(PLAYWRIGHT_BROWSERS_PATH)" pnpm --dir $(ACCEPTANCE_DIR) exec playwright test "$(QA_SUITE)"

--- a/acceptance/README.md
+++ b/acceptance/README.md
@@ -22,3 +22,26 @@ Run from the QA worktree or set `OFFBOOK_ROLE=qa`:
 ```sh
 command make acceptance
 ```
+
+For discoverability, the repo root exposes:
+
+```sh
+command make help
+command make qa-smoke
+command make qa-suite QA_SUITE=plaid
+```
+
+Run a suite or spec directly when you need Playwright flags:
+
+```sh
+pnpm --dir acceptance exec playwright test plaid
+OFFBOOK_ROLE=qa pnpm --dir acceptance exec playwright test smoke/baseline.spec.ts:19
+```
+
+## Environment Loading
+
+Acceptance helpers read `.env.qa` first and `.env.qa.local` second. Helpers that
+call `personaPassword()` get that loading for free through `ensureQASecret()`.
+Helpers that do not need persona passwords must call `loadQAEnv()` explicitly
+before reading `process.env`; `plaid/helper.mjs` does this so Plaid credentials
+set only in `.env.qa.local` are visible without manual `export`.

--- a/acceptance/fixtures/env.mjs
+++ b/acceptance/fixtures/env.mjs
@@ -50,5 +50,5 @@ export function acceptanceBaseURL() {
 }
 
 export function qaDatabaseURL() {
-  return process.env.QA_DATABASE_URL ?? 'postgres://offbook:offbook@localhost:15432/offbook_dev?sslmode=disable'
+  return process.env.QA_DATABASE_URL ?? 'postgres://offbook:offbook@localhost:15432/offbook_qa?sslmode=disable'
 }

--- a/acceptance/plaid/helper.mjs
+++ b/acceptance/plaid/helper.mjs
@@ -1,4 +1,6 @@
-import { acceptanceAPIURL } from '../fixtures/env.mjs'
+import { acceptanceAPIURL, loadQAEnv } from '../fixtures/env.mjs'
+
+loadQAEnv()
 
 export async function plaidSandboxPublicToken() {
   const clientID = process.env.PLAID_CLIENT_ID

--- a/acceptance/smoke/baseline.spec.ts
+++ b/acceptance/smoke/baseline.spec.ts
@@ -18,6 +18,12 @@ const personalRoutes = [
 const householdRoutes = ['/h/dashboard', '/h/budgets', '/h/goals', '/h/members', '/h/ai', '/h/settings']
 
 test.describe('baseline route smoke', () => {
+  test('unexpected auth failures are reported', () => {
+    expect(isUnexpectedAuthFailure(401, 'http://localhost:18000/api/v1/dashboard/summary')).toBe(true)
+    expect(isUnexpectedAuthFailure(403, 'http://localhost:18000/api/v1/h/dashboard/summary')).toBe(true)
+    expect(isUnexpectedAuthFailure(401, 'http://localhost:18000/api/v1/me')).toBe(false)
+  })
+
   for (const route of publicRoutes) {
     test(`public route ${route}`, async ({ page }) => {
       const errors = collectRuntimeErrors(page)
@@ -47,13 +53,24 @@ function collectRuntimeErrors(page: Page) {
   })
   page.on('pageerror', (err) => errors.push(err.message))
   page.on('response', (response) => {
-    if (response.status() >= 500) errors.push(`${response.status()} ${response.url()}`)
+    if (response.status() >= 500 || isUnexpectedAuthFailure(response.status(), response.url())) {
+      errors.push(`${response.status()} ${response.url()}`)
+    }
   })
   return errors
 }
 
 function isExpectedBrowserNoise(message: string) {
+  // Chromium reports failed 401 fetches as console errors without a reliable URL.
+  // Response listeners do have the URL, so auth regressions are checked there.
   return message.includes('Failed to load resource: the server responded with a status of 401 (Unauthorized)')
+}
+
+function isUnexpectedAuthFailure(status: number, url: string) {
+  if (status !== 401 && status !== 403) return false
+
+  const expectedUnauthenticatedProbe = url.includes('/api/v1/me')
+  return !expectedUnauthenticatedProbe
 }
 
 async function login(page: Page) {

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io/fs"
 	"os"
+	"strings"
 
 	"github.com/joho/godotenv"
 )
@@ -14,12 +15,13 @@ import (
 // per-env behavior. See ResolveDatabaseURL.
 const (
 	AppEnvDev  = "dev"
+	AppEnvQA   = "qa"
 	AppEnvTest = "test"
 	AppEnvProd = "prod"
 )
 
 type Config struct {
-	AppEnv         string // dev | test | prod (see Resolve* helpers)
+	AppEnv         string // dev | qa | test | prod (see Resolve* helpers)
 	Port           string
 	DatabaseURL    string
 	FrontendURL    string
@@ -58,11 +60,11 @@ func ResolveAppEnv(raw string) (string, error) {
 		return AppEnvDev, nil
 	}
 	switch raw {
-	case AppEnvDev, AppEnvTest, AppEnvProd:
+	case AppEnvDev, AppEnvQA, AppEnvTest, AppEnvProd:
 		return raw, nil
 	default:
-		return "", fmt.Errorf("APP_ENV must be %s|%s|%s, got %q",
-			AppEnvDev, AppEnvTest, AppEnvProd, raw)
+		return "", fmt.Errorf("APP_ENV must be %s|%s|%s|%s, got %q",
+			AppEnvDev, AppEnvQA, AppEnvTest, AppEnvProd, raw)
 	}
 }
 
@@ -70,6 +72,7 @@ func ResolveAppEnv(raw string) (string, error) {
 // DATABASE_URL always wins (this is how docker-compose and prod inject the
 // connection string). When unset:
 //   - dev → local Postgres, database "offbook_dev"
+//   - qa → local Postgres, database "offbook_qa"
 //   - test → local Postgres, database "offbook_test"
 //   - prod → no default; returns an error (force operators to be explicit)
 //
@@ -82,6 +85,8 @@ func ResolveDatabaseURL(appEnv, explicitURL string) (string, error) {
 	switch appEnv {
 	case AppEnvDev:
 		return "postgres://offbook:offbook@localhost:5432/offbook_dev?sslmode=disable", nil
+	case AppEnvQA:
+		return "postgres://offbook:offbook@localhost:5432/offbook_qa?sslmode=disable", nil
 	case AppEnvTest:
 		return "postgres://offbook:offbook@localhost:5432/offbook_test?sslmode=disable", nil
 	case AppEnvProd:
@@ -125,6 +130,10 @@ func Load() (Config, error) {
 		OllamaBaseURL:  getenv("OLLAMA_BASE_URL", "http://localhost:11434"),
 	}
 
+	if isPlaceholderSecret(cfg.SessionSecret) {
+		return Config{}, errors.New("SESSION_SECRET is a placeholder; generate a real QA/dev secret with `openssl rand -hex 32`")
+	}
+
 	if cfg.PlaidClientID != "" {
 		if cfg.PlaidSecret == "" {
 			return Config{}, errors.New("PLAID_CLIENT_ID is set but PLAID_SECRET is empty")
@@ -149,6 +158,18 @@ func Load() (Config, error) {
 	}
 
 	return cfg, nil
+}
+
+func isPlaceholderSecret(secret string) bool {
+	if strings.HasPrefix(secret, "replace-with-") {
+		return true
+	}
+	switch secret {
+	case "change-me", "changeme":
+		return true
+	default:
+		return false
+	}
 }
 
 // MustLoad is a thin wrapper for main(), where any error is fatal.

--- a/backend/internal/config/config_test.go
+++ b/backend/internal/config/config_test.go
@@ -14,6 +14,7 @@ func TestResolveAppEnv(t *testing.T) {
 	}{
 		{name: "empty defaults to dev", in: "", want: AppEnvDev},
 		{name: "dev", in: AppEnvDev, want: AppEnvDev},
+		{name: "qa", in: AppEnvQA, want: AppEnvQA},
 		{name: "test", in: AppEnvTest, want: AppEnvTest},
 		{name: "prod", in: AppEnvProd, want: AppEnvProd},
 		{name: "garbage rejected", in: "staging", wantErr: true},
@@ -61,6 +62,11 @@ func TestResolveDatabaseURL(t *testing.T) {
 			name:       "dev default",
 			appEnv:     AppEnvDev,
 			wantSubstr: "/offbook_dev?",
+		},
+		{
+			name:       "qa default",
+			appEnv:     AppEnvQA,
+			wantSubstr: "/offbook_qa?",
 		},
 		{
 			name:       "test default",
@@ -135,6 +141,33 @@ func TestLoad_TestEnvUsesTestDB(t *testing.T) {
 	}
 	if !strings.Contains(cfg.DatabaseURL, "/offbook_test?") {
 		t.Errorf("DatabaseURL = %q, want it to point at offbook_test", cfg.DatabaseURL)
+	}
+}
+
+func TestLoad_QAEnvUsesQADB(t *testing.T) {
+	t.Setenv("APP_ENV", AppEnvQA)
+	t.Setenv("DATABASE_URL", "")
+	t.Setenv("PLAID_CLIENT_ID", "")
+	t.Setenv("PLAID_SECRET", "")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if !strings.Contains(cfg.DatabaseURL, "/offbook_qa?") {
+		t.Errorf("DatabaseURL = %q, want it to point at offbook_qa", cfg.DatabaseURL)
+	}
+}
+
+func TestLoad_RejectsPlaceholderSessionSecret(t *testing.T) {
+	t.Setenv("APP_ENV", AppEnvQA)
+	t.Setenv("DATABASE_URL", "")
+	t.Setenv("SESSION_SECRET", "replace-with-qa-session-secret")
+	t.Setenv("PLAID_CLIENT_ID", "")
+	t.Setenv("PLAID_SECRET", "")
+
+	if _, err := Load(); err == nil || !strings.Contains(err.Error(), "placeholder") {
+		t.Fatalf("Load error = %v, want placeholder SESSION_SECRET error", err)
 	}
 }
 

--- a/docker-compose.qa.yml
+++ b/docker-compose.qa.yml
@@ -15,8 +15,8 @@ services:
       - path: .env.qa.local
         required: false
     environment:
-      APP_ENV: dev
-      DATABASE_URL: postgres://offbook:offbook@postgres:5432/offbook_dev?sslmode=disable
+      APP_ENV: qa
+      DATABASE_URL: postgres://offbook:offbook@postgres:5432/offbook_qa?sslmode=disable
       PORT: "8000"
       FRONTEND_URL: http://localhost:15173
       MIGRATIONS_PATH: /app/migrations

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -287,7 +287,7 @@ func (h *AccountHandler) Create(c *gin.Context) {
 
 | Variable | Required | Description |
 |---|---|---|
-| `APP_ENV` | No | `dev` \| `test` \| `prod`. Default `dev`. Selects the default DB when `DATABASE_URL` is unset: `dev` → `offbook_dev`, `test` → `offbook_test`, `prod` → no default (refuses to start). See #183. |
+| `APP_ENV` | No | `dev` \| `qa` \| `test` \| `prod`. Default `dev`. Selects the default DB when `DATABASE_URL` is unset: `dev` → `offbook_dev`, `qa` → `offbook_qa`, `test` → `offbook_test`, `prod` → no default (refuses to start). See #183. |
 | `DATABASE_URL` | Yes in prod, optional elsewhere | PostgreSQL connection string. Overrides the `APP_ENV`-derived default. docker-compose injects this internally so the container uses the in-network `postgres` hostname. |
 | `PORT` | No | Backend port (default: 8000) |
 | `FRONTEND_URL` | No | CORS origin (default: http://localhost:5173) |

--- a/docs/QA.md
+++ b/docs/QA.md
@@ -93,6 +93,8 @@ QA service URLs:
 
 The QA compose project name (`offbook-qa`) gives QA separate containers and Docker-managed identity. The QA compose override gives QA separate host ports and a dedicated `qa_postgres_data` named volume, so the QA database is isolated even if someone accidentally runs the QA stack from the main development worktree. A separate worktree is still required to avoid file and branch conflicts with the development agent.
 
+The QA backend runs with `APP_ENV=qa` and defaults to the `offbook_qa` database. The init scripts create `offbook_qa` alongside `offbook_dev` and `offbook_test` on a fresh Postgres volume.
+
 The backend container runs migrations on boot when `MIGRATIONS_PATH=/app/migrations` is set. On a cold QA volume, `docker compose -p offbook-qa -f docker-compose.yml -f docker-compose.qa.yml up -d --build` should leave the DB migrated and `/setup/admin` renderable.
 
 Stop the QA stack when done:
@@ -112,6 +114,14 @@ Use a dedicated Chrome profile for QA, for example under `/private/tmp/offbook-q
 ## QA Environment And Credentials
 
 The QA compose override loads backend environment from `.env.qa` and `.env.qa.local`, not the repo-root `.env`. This keeps QA Plaid sandbox credentials and `PLAID_TOKEN_KEY` separate from development. `.env.qa.local` is generated or edited locally and is gitignored.
+
+`SESSION_SECRET` is intentionally blank in `.env.qa.example`. Set it to a QA-only value before booting the QA stack:
+
+```sh
+openssl rand -hex 32
+```
+
+Backend startup and `command make acceptance` refuse known placeholder values such as `replace-with-*`, `change-me`, and `changeme`.
 
 QA persona emails are fixed. Passwords are derived from `QA_SECRET` by the acceptance fixture loader, so they are reproducible without committing plaintext credentials. If `QA_SECRET` is absent, `command make acceptance` writes a generated value to `.env.qa.local`; use that file for manual login during the same QA run.
 
@@ -272,6 +282,28 @@ Command:
 ```sh
 command make acceptance
 ```
+
+Discover root-level QA commands with:
+
+```sh
+command make help
+```
+
+Run only the baseline suite:
+
+```sh
+command make qa-smoke
+```
+
+Run one suite or spec pattern:
+
+```sh
+command make qa-suite QA_SUITE=plaid
+pnpm --dir acceptance exec playwright test plaid
+OFFBOOK_ROLE=qa pnpm --dir acceptance exec playwright test smoke/baseline.spec.ts:19
+```
+
+Acceptance helpers that call `personaPassword()` load `.env.qa` and `.env.qa.local` as a side effect. Helpers that do not need persona passwords must call `loadQAEnv()` explicitly before reading `process.env`; the Plaid helper does this because Plaid credentials normally live in `.env.qa.local`.
 
 Plaid sandbox acceptance must not drive the Plaid Link iframe. Use `acceptance/plaid/helper.mjs` to mint a public token through `/sandbox/public_token/create`, exchange it through `/api/v1/plaid/link/exchange`, then sync accounts and transactions through Offbook. A smaller browser smoke should still assert `/connect` renders and the Plaid Link button mounts.
 

--- a/infra/postgres/init/01-create-test-db.sh
+++ b/infra/postgres/init/01-create-test-db.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Provision a sibling test database alongside the dev database on first
+# Provision sibling QA and test databases alongside the dev database on first
 # Postgres-volume creation. Docker's official `postgres` image runs every
 # *.sh / *.sql file in /docker-entrypoint-initdb.d once, only when the data
 # directory is empty.
@@ -8,10 +8,12 @@
 # and `make test` lets test fixtures bleed into the dev UI (e.g. categories
 # named `AlertCat-50-102333.896245` showing up in the user's dropdown).
 # Each env gets its own database; the dev one is created by Postgres from
-# POSTGRES_DB, and this script adds the test one.
+# POSTGRES_DB, and this script adds the QA and test databases.
 set -euo pipefail
 
 psql -v ON_ERROR_STOP=1 --username "${POSTGRES_USER}" --dbname "${POSTGRES_DB}" <<-EOSQL
+	CREATE DATABASE offbook_qa;
+	GRANT ALL PRIVILEGES ON DATABASE offbook_qa TO ${POSTGRES_USER};
 	CREATE DATABASE offbook_test;
 	GRANT ALL PRIVILEGES ON DATABASE offbook_test TO ${POSTGRES_USER};
 EOSQL

--- a/scripts/qa-preflight.sh
+++ b/scripts/qa-preflight.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env sh
+set -eu
+
+check_env_file() {
+  file="$1"
+  [ -f "$file" ] || return 0
+
+  secret="$(awk -F= '
+    /^[[:space:]]*#/ { next }
+    /^[[:space:]]*SESSION_SECRET[[:space:]]*=/ {
+      value=$0
+      sub(/^[^=]*=/, "", value)
+      gsub(/^[[:space:]]+|[[:space:]]+$/, "", value)
+      print value
+    }
+  ' "$file" | tail -n 1)"
+
+  case "$secret" in
+    replace-with-*|change-me|changeme)
+      cat >&2 <<EOF
+QA preflight refused placeholder SESSION_SECRET in $file.
+
+Generate a QA-only secret and set it in .env.qa or .env.qa.local:
+
+  openssl rand -hex 32
+EOF
+      exit 2
+      ;;
+  esac
+}
+
+check_env_file .env.qa
+check_env_file .env.qa.local


### PR DESCRIPTION
## Summary
- add APP_ENV=qa / offbook_qa defaults for the isolated QA stack
- load .env.qa/.env.qa.local in Plaid acceptance helpers and document single-suite commands
- reject placeholder QA session secrets via backend config and QA preflight
- tighten smoke auth failure detection so unexpected authenticated 401/403 responses fail

Closes #215
Closes #217
Closes #218
Closes #220
Closes #221

## Verification
- git diff --check
- GOCACHE=/Users/greg/src/offbook/.cache/go-build go test ./internal/config
- pnpm --dir acceptance exec playwright test smoke/baseline.spec.ts:21
- temporary .env.qa.local import check for acceptance/plaid/helper.mjs
- OFFBOOK_ROLE=qa scripts/qa-preflight.sh placeholder rejection check
- docker compose -p offbook-qa -f docker-compose.yml -f docker-compose.qa.yml config
- docker compose -p offbook-qa-fresh -f docker-compose.yml -f docker-compose.qa.yml up -d --build
- verified fresh Postgres has offbook_dev, offbook_qa, offbook_test
- curl -fsS http://localhost:18000/api/v1/health
- in-app browser: /setup/admin -> /dashboard, then /dashboard /connect /settings render without horizontal overflow

## Notes
- command make verify reached backend vet, then stopped at backend lint because this sandbox cannot access the Colima Docker socket.
- OFFBOOK_ROLE=qa command make qa-smoke also hit sandbox browser launch limits: Chromium failed with MachPortRendezvous permission denied. The non-browser Playwright regression test passed; real page checks were done with the in-app browser instead.
- Existing pre-change offbook-qa Docker volumes will not contain offbook_qa; fresh QA volumes do. This matches #218 out-of-scope guidance for backfilling old local volumes.