### PR TITLE
Add QA acceptance fixtures and Plaid flow

### DIFF
--- a/acceptance/README.md
+++ b/acceptance/README.md
@@ -6,6 +6,7 @@ compose stack. They are separate from unit tests and `backend/ make verify`.
 ## Layout
 
 - `fixtures/` provisions reusable QA personas and shared helpers.
+- `auth/` contains opt-in cold-start setup and invite acceptance checks.
 - `smoke/` contains the canonical baseline browser smoke suite.
 - `plaid/` contains Plaid sandbox acceptance helpers and tests.
 - `reports/` is generated output for HTML reports, screenshots, traces, and
@@ -38,6 +39,13 @@ pnpm --dir acceptance exec playwright test plaid
 OFFBOOK_ROLE=qa pnpm --dir acceptance exec playwright test smoke/baseline.spec.ts:19
 ```
 
+Cold-start auth/setup checks intentionally reset the QA database to the state
+before `/setup/admin`. They are opt-in and ignored by default:
+
+```sh
+OFFBOOK_ROLE=qa QA_COLD_START=1 pnpm --dir acceptance exec playwright test auth/setup.cold-start.spec.ts
+```
+
 ## Environment Loading
 
 Acceptance helpers read `.env.qa` first and `.env.qa.local` second. Helpers that
@@ -45,3 +53,35 @@ call `personaPassword()` get that loading for free through `ensureQASecret()`.
 Helpers that do not need persona passwords must call `loadQAEnv()` explicitly
 before reading `process.env`; `plaid/helper.mjs` does this so Plaid credentials
 set only in `.env.qa.local` are visible without manual `export`.
+
+## Persona State Contract
+
+`bootstrap.mjs` creates four shared personas by direct SQL insert. That is fast
+and idempotent, but it bypasses `/setup/admin`, `/auth/signup`,
+`/auth/signup-with-invite`, and invite acceptance. Do not treat a successful
+persona bootstrap as proof that signup works; use the opt-in cold-start suite
+for those product paths.
+
+Default acceptance tests must not mutate the four shared personas:
+
+- `qa-admin@offbook.local`
+- `qa-contributor@offbook.local`
+- `qa-viewer@offbook.local`
+- `qa-solo@offbook.local`
+
+Write-heavy suites must create throwaway users with
+`createThrowawayUser({ suite })` from `fixtures/state.mjs` and clean them up
+with `deleteThrowawayUsers(suite)` in `finally` or `afterEach`. Throwaway emails
+use `qa+<suite>-<timestamp>@offbook.local`.
+
+If a suite needs a pristine shared-persona baseline, run:
+
+```sh
+OFFBOOK_ROLE=qa node acceptance/fixtures/bootstrap.mjs --reset
+```
+
+If a suite needs true first-boot state, run:
+
+```sh
+OFFBOOK_ROLE=qa node acceptance/fixtures/cold-start.mjs
+```

--- a/acceptance/auth/setup.cold-start.spec.ts
+++ b/acceptance/auth/setup.cold-start.spec.ts
@@ -1,0 +1,73 @@
+import { expect, test } from '@playwright/test'
+import { personaPassword } from '../fixtures/env.mjs'
+import { request, resetToColdStart, waitForBackend } from '../fixtures/state.mjs'
+
+test.describe('auth and setup cold-start acceptance', () => {
+  test.beforeAll(async () => {
+    await waitForBackend()
+    await resetToColdStart()
+  })
+
+  test('setup admin, invite-only signup, and household invite flow work through API product paths', async () => {
+    const adminEmail = 'qa+cold-admin@offbook.local'
+    const memberEmail = 'qa+cold-member@offbook.local'
+
+    const statusBefore = await request('/setup/status')
+    expect(statusBefore.res.status()).toBe(200)
+    expect(statusBefore.json.data.bootstrapped).toBe(false)
+
+    const setup = await request('/setup/admin', {
+      method: 'POST',
+      body: {
+        email: adminEmail,
+        password: personaPassword(adminEmail),
+        signup_mode: 'invite_only',
+      },
+    })
+    expect(setup.res.status()).toBe(201)
+    expect(setup.cookie).toBeTruthy()
+
+    const closedSignup = await request('/auth/signup', {
+      method: 'POST',
+      body: {
+        email: 'qa+cold-closed@offbook.local',
+        password: personaPassword('qa+cold-closed@offbook.local'),
+      },
+    })
+    expect(closedSignup.res.status()).toBe(403)
+    expect(closedSignup.json.code).toBe('SIGNUP_CLOSED')
+
+    const household = await request('/households', {
+      method: 'POST',
+      cookie: setup.cookie,
+      body: { name: 'Cold Start Household' },
+    })
+    expect(household.res.status()).toBe(201)
+    const householdID = household.json.data.id
+
+    const invite = await request(`/households/${householdID}/invites`, {
+      method: 'POST',
+      cookie: setup.cookie,
+      body: { role: 'contributor' },
+    })
+    expect(invite.res.status()).toBe(201)
+    expect(invite.json.data.token).toBeTruthy()
+
+    const signup = await request('/auth/signup-with-invite', {
+      method: 'POST',
+      body: {
+        email: memberEmail,
+        password: personaPassword(memberEmail),
+        invite_token: invite.json.data.token,
+      },
+    })
+    expect(signup.res.status()).toBe(201)
+    expect(signup.cookie).toBeTruthy()
+
+    const members = await request(`/households/${householdID}/members`, {
+      cookie: setup.cookie,
+    })
+    expect(members.res.status()).toBe(200)
+    expect(members.json.data.active.map((member: { user_id: number }) => member.user_id)).toContain(signup.json.data.id)
+  })
+})

--- a/acceptance/fixtures/bootstrap.mjs
+++ b/acceptance/fixtures/bootstrap.mjs
@@ -2,54 +2,10 @@
 import bcrypt from 'bcryptjs'
 import pg from 'pg'
 import { acceptanceAPIURL, personaPassword, personas, qaDatabaseURL } from './env.mjs'
+import { assertQARole, resetToColdStart, signin, waitForBackend } from './state.mjs'
 
 const { Client } = pg
 const apiURL = acceptanceAPIURL()
-
-function assertQARole() {
-  const cwd = process.cwd().split('/').pop() ?? ''
-  if (process.env.OFFBOOK_ROLE === 'qa' || cwd === 'offbook-qa' || cwd.endsWith('-qa')) return
-  throw new Error('QA bootstrap requires a QA signal: run from a *-qa worktree or set OFFBOOK_ROLE=qa')
-}
-
-async function waitForBackend() {
-  for (let i = 0; i < 30; i += 1) {
-    try {
-      const res = await fetch(`${apiURL}/health`)
-      if (res.ok) return
-    } catch {
-      // keep polling
-    }
-    await new Promise((resolve) => setTimeout(resolve, 1000))
-  }
-  throw new Error(`backend health did not become ready at ${apiURL}/health`)
-}
-
-async function request(path, { method = 'GET', body, cookie } = {}) {
-  const res = await fetch(`${apiURL}${path}`, {
-    method,
-    headers: {
-      'content-type': 'application/json',
-      ...(cookie ? { cookie } : {}),
-    },
-    body: body ? JSON.stringify(body) : undefined,
-    redirect: 'manual',
-  })
-  const setCookie = res.headers.get('set-cookie')?.split(';')[0]
-  const text = await res.text()
-  let json = null
-  if (text) json = JSON.parse(text)
-  return { res, json, cookie: setCookie }
-}
-
-async function signin(email) {
-  const out = await request('/auth/signin', {
-    method: 'POST',
-    body: { email, password: personaPassword(email) },
-  })
-  if (!out.res.ok) throw new Error(`signin failed for ${email}: HTTP ${out.res.status} ${JSON.stringify(out.json)}`)
-  return out.cookie
-}
 
 async function upsertUser(client, persona) {
   const hash = await bcrypt.hash(personaPassword(persona.email), 12)
@@ -161,7 +117,10 @@ async function provisionPersonas() {
 }
 
 assertQARole()
-await waitForBackend()
+await waitForBackend(apiURL)
+if (process.argv.includes('--reset')) {
+  await resetToColdStart()
+}
 await provisionPersonas()
 for (const persona of personas) {
   await signin(persona.email)

--- a/acceptance/fixtures/cold-start.mjs
+++ b/acceptance/fixtures/cold-start.mjs
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+import { acceptanceAPIURL } from './env.mjs'
+import { assertQARole, resetToColdStart, waitForBackend } from './state.mjs'
+
+assertQARole()
+await waitForBackend(acceptanceAPIURL())
+await resetToColdStart()
+
+console.log('QA database reset to pre-/setup/admin cold-start state')

--- a/acceptance/fixtures/state.mjs
+++ b/acceptance/fixtures/state.mjs
@@ -1,0 +1,174 @@
+import bcrypt from 'bcryptjs'
+import pg from 'pg'
+import { randomBytes } from 'node:crypto'
+import { acceptanceAPIURL, personaPassword, qaDatabaseURL } from './env.mjs'
+
+const { Client } = pg
+
+export function assertQARole() {
+  const cwd = process.cwd().split('/').pop() ?? ''
+  if (process.env.OFFBOOK_ROLE === 'qa' || cwd === 'offbook-qa' || cwd.endsWith('-qa')) return
+  throw new Error('QA helpers require a QA signal: run from a *-qa worktree or set OFFBOOK_ROLE=qa')
+}
+
+export async function withQAClient(fn) {
+  const client = new Client({ connectionString: qaDatabaseURL() })
+  await client.connect()
+  try {
+    return await fn(client)
+  } finally {
+    await client.end()
+  }
+}
+
+export async function waitForBackend(apiURL = acceptanceAPIURL()) {
+  for (let i = 0; i < 30; i += 1) {
+    try {
+      const res = await fetch(`${apiURL}/health`)
+      if (res.ok) return
+    } catch {
+      // keep polling
+    }
+    await new Promise((resolve) => setTimeout(resolve, 1000))
+  }
+  throw new Error(`backend health did not become ready at ${apiURL}/health`)
+}
+
+export async function request(path, { method = 'GET', body, cookie } = {}) {
+  const res = await fetch(`${acceptanceAPIURL()}${path}`, {
+    method,
+    headers: {
+      'content-type': 'application/json',
+      ...(cookie ? { cookie } : {}),
+    },
+    body: body ? JSON.stringify(body) : undefined,
+    redirect: 'manual',
+  })
+  const setCookie = res.headers.get('set-cookie')?.split(';')[0]
+  const text = await res.text()
+  let json = null
+  if (text) json = JSON.parse(text)
+  return { res, json, cookie: setCookie }
+}
+
+export async function signin(email, password = personaPassword(email)) {
+  const out = await request('/auth/signin', {
+    method: 'POST',
+    body: { email, password },
+  })
+  if (!out.res.ok) throw new Error(`signin failed for ${email}: HTTP ${out.res.status} ${JSON.stringify(out.json)}`)
+  return out.cookie
+}
+
+export async function resetToColdStart() {
+  assertQARole()
+  await withQAClient(async (client) => {
+    await client.query('BEGIN')
+    try {
+      await client.query('TRUNCATE TABLE instance_config RESTART IDENTITY')
+      await client.query('TRUNCATE TABLE pii_store, users RESTART IDENTITY CASCADE')
+      await client.query('COMMIT')
+    } catch (err) {
+      await client.query('ROLLBACK')
+      throw err
+    }
+  })
+}
+
+export async function createThrowawayUser({ suite, householdID, role = 'contributor' } = {}) {
+  assertQARole()
+  if (!suite) throw new Error('createThrowawayUser requires a suite name')
+
+  const suffix = `${Date.now()}-${randomBytes(4).toString('hex')}`
+  const email = `qa+${suite}-${suffix}@offbook.local`
+  const password = personaPassword(email)
+  const hash = await bcrypt.hash(password, 12)
+
+  const user = await withQAClient(async (client) => {
+    await client.query('BEGIN')
+    try {
+      const result = await client.query(
+        `
+          INSERT INTO users (email, password_hash, is_admin, last_scope, default_scope, created_at, updated_at)
+          VALUES ($1, $2, FALSE, 'personal', 'personal', NOW(), NOW())
+          RETURNING id, email
+        `,
+        [email, hash],
+      )
+      if (householdID) {
+        await client.query(
+          `
+            INSERT INTO household_members (household_id, user_id, role, joined_at)
+            VALUES ($1, $2, $3, NOW())
+          `,
+          [householdID, result.rows[0].id, role],
+        )
+        await client.query(
+          "UPDATE users SET last_scope = 'household', default_scope = 'household' WHERE id = $1",
+          [result.rows[0].id],
+        )
+      }
+      await client.query('COMMIT')
+      return result.rows[0]
+    } catch (err) {
+      await client.query('ROLLBACK')
+      throw err
+    }
+  })
+
+  return { id: Number(user.id), email, password }
+}
+
+export async function deleteThrowawayUsers(suite) {
+  assertQARole()
+  const prefix = `qa+${suite}-%@offbook.local`
+  await withQAClient(async (client) => {
+    await client.query('BEGIN')
+    try {
+      const users = await client.query('SELECT id FROM users WHERE email LIKE $1', [prefix])
+      if (users.rowCount > 0) {
+        const ids = users.rows.map((row) => row.id)
+        const accounts = await client.query('SELECT id FROM accounts WHERE user_id = ANY($1::bigint[])', [ids])
+        const accountIDs = accounts.rows.map((row) => row.id)
+        const households = await client.query('SELECT id FROM households WHERE owner_id = ANY($1::bigint[])', [ids])
+        const householdIDs = households.rows.map((row) => row.id)
+        await client.query('DELETE FROM sessions WHERE user_id = ANY($1::bigint[])', [ids])
+        await client.query('DELETE FROM plaid_sync_errors WHERE user_id = ANY($1::bigint[])', [ids])
+        await client.query('DELETE FROM plaid_items WHERE user_id = ANY($1::bigint[])', [ids])
+        await client.query('DELETE FROM ai_messages WHERE user_id = ANY($1::bigint[])', [ids])
+        await client.query('DELETE FROM ai_messages WHERE thread_id IN (SELECT id FROM ai_threads WHERE user_id = ANY($1::bigint[]))', [ids])
+        await client.query('DELETE FROM ai_threads WHERE user_id = ANY($1::bigint[])', [ids])
+        await client.query('DELETE FROM investments WHERE user_id = ANY($1::bigint[])', [ids])
+        await client.query('DELETE FROM savings_goals WHERE user_id = ANY($1::bigint[])', [ids])
+        await client.query('DELETE FROM budgets WHERE user_id = ANY($1::bigint[])', [ids])
+        await client.query('DELETE FROM categorization_rules WHERE user_id = ANY($1::bigint[])', [ids])
+        await client.query('UPDATE transactions SET transfer_pair_id = NULL WHERE user_id = ANY($1::bigint[])', [ids])
+        await client.query('DELETE FROM transactions WHERE user_id = ANY($1::bigint[])', [ids])
+        if (accountIDs.length > 0) {
+          await client.query('DELETE FROM account_shares WHERE account_id = ANY($1::bigint[])', [accountIDs])
+          await client.query('DELETE FROM ingestion_jobs WHERE account_id = ANY($1::bigint[])', [accountIDs])
+          await client.query('DELETE FROM pii_store WHERE entity_type = $1 AND entity_id = ANY($2::bigint[])', ['account', accountIDs])
+        }
+        await client.query('DELETE FROM accounts WHERE user_id = ANY($1::bigint[])', [ids])
+        if (householdIDs.length > 0) {
+          await client.query('DELETE FROM account_shares WHERE household_id = ANY($1::bigint[])', [householdIDs])
+          await client.query('DELETE FROM ai_messages WHERE thread_id IN (SELECT id FROM ai_threads WHERE household_id = ANY($1::bigint[]))', [householdIDs])
+          await client.query('DELETE FROM ai_threads WHERE household_id = ANY($1::bigint[])', [householdIDs])
+          await client.query('DELETE FROM shared_budgets WHERE household_id = ANY($1::bigint[])', [householdIDs])
+          await client.query('DELETE FROM shared_goals WHERE household_id = ANY($1::bigint[])', [householdIDs])
+          await client.query('DELETE FROM household_invites WHERE household_id = ANY($1::bigint[])', [householdIDs])
+          await client.query('DELETE FROM household_members WHERE household_id = ANY($1::bigint[])', [householdIDs])
+          await client.query('DELETE FROM households WHERE id = ANY($1::bigint[])', [householdIDs])
+        }
+        await client.query('DELETE FROM household_invites WHERE created_by = ANY($1::bigint[]) OR accepted_by = ANY($1::bigint[])', [ids])
+        await client.query('DELETE FROM household_members WHERE user_id = ANY($1::bigint[])', [ids])
+        await client.query('DELETE FROM user_settings WHERE user_id = ANY($1::bigint[])', [ids])
+        await client.query('DELETE FROM users WHERE id = ANY($1::bigint[])', [ids])
+      }
+      await client.query('COMMIT')
+    } catch (err) {
+      await client.query('ROLLBACK')
+      throw err
+    }
+  })
+}

--- a/acceptance/plaid/helper.mjs
+++ b/acceptance/plaid/helper.mjs
@@ -36,3 +36,37 @@ export async function exchangePublicToken(cookie, publicToken) {
   if (!res.ok) throw new Error(`Offbook Plaid exchange failed: HTTP ${res.status} ${await res.text()}`)
   return res.json()
 }
+
+export async function syncPlaidAccounts(cookie, plaidItemID) {
+  const res = await fetch(`${acceptanceAPIURL()}/plaid/items/${encodeURIComponent(plaidItemID)}/sync-accounts`, {
+    method: 'POST',
+    headers: { cookie },
+  })
+  if (!res.ok) throw new Error(`Offbook Plaid account sync failed: HTTP ${res.status} ${await res.text()}`)
+  return res.json()
+}
+
+export async function syncPlaidTransactions(cookie, plaidItemID) {
+  const res = await fetch(`${acceptanceAPIURL()}/plaid/items/${encodeURIComponent(plaidItemID)}/sync-transactions`, {
+    method: 'POST',
+    headers: { cookie },
+  })
+  if (!res.ok) throw new Error(`Offbook Plaid transaction sync failed: HTTP ${res.status} ${await res.text()}`)
+  return res.json()
+}
+
+export async function listAccounts(cookie) {
+  const res = await fetch(`${acceptanceAPIURL()}/accounts?limit=200`, {
+    headers: { cookie },
+  })
+  if (!res.ok) throw new Error(`Offbook accounts list failed: HTTP ${res.status} ${await res.text()}`)
+  return res.json()
+}
+
+export async function listTransactions(cookie) {
+  const res = await fetch(`${acceptanceAPIURL()}/transactions?limit=500`, {
+    headers: { cookie },
+  })
+  if (!res.ok) throw new Error(`Offbook transactions list failed: HTTP ${res.status} ${await res.text()}`)
+  return res.json()
+}

--- a/acceptance/plaid/sandbox.spec.ts
+++ b/acceptance/plaid/sandbox.spec.ts
@@ -1,9 +1,57 @@
 import { expect, test } from '@playwright/test'
-import { plaidSandboxPublicToken } from './helper.mjs'
+import { createThrowawayUser, deleteThrowawayUsers, signin } from '../fixtures/state.mjs'
+import {
+  exchangePublicToken,
+  listAccounts,
+  listTransactions,
+  plaidSandboxPublicToken,
+  syncPlaidAccounts,
+  syncPlaidTransactions,
+} from './helper.mjs'
+
+const plaidConfigured = Boolean(process.env.PLAID_CLIENT_ID && process.env.PLAID_SECRET)
 
 test.describe('Plaid sandbox acceptance', () => {
   test('public-token helper mints a sandbox token without Plaid Link', async () => {
-    test.skip(!process.env.PLAID_CLIENT_ID || !process.env.PLAID_SECRET, 'Plaid sandbox credentials are not configured')
+    test.skip(!plaidConfigured, 'Plaid sandbox credentials are not configured')
     await expect(plaidSandboxPublicToken()).resolves.toMatch(/^public-/)
+  })
+
+  test('exchange, sync, and re-sync produce accounts and no duplicate transactions', async () => {
+    test.skip(!plaidConfigured, 'Plaid sandbox credentials are not configured')
+
+    await deleteThrowawayUsers('plaid')
+    const user = await createThrowawayUser({ suite: 'plaid' })
+    const cookie = await signin(user.email, user.password)
+
+    try {
+      const publicToken = await plaidSandboxPublicToken()
+      const exchange = await exchangePublicToken(cookie, publicToken)
+      const plaidItemID = exchange.data.item_id
+      expect(plaidItemID).toBeTruthy()
+
+      const accountSync = await syncPlaidAccounts(cookie, plaidItemID)
+      expect(accountSync.data.created + accountSync.data.updated).toBeGreaterThan(0)
+
+      const accounts = await listAccounts(cookie)
+      expect(accounts.total).toBeGreaterThan(0)
+      expect(accounts.data.some((account: { plaid_item_id?: string }) => account.plaid_item_id === plaidItemID)).toBe(true)
+
+      const firstTxnSync = await syncPlaidTransactions(cookie, plaidItemID)
+      expect(firstTxnSync.data.inserted).toBeGreaterThan(0)
+      expect(firstTxnSync.data.failed).toBe(0)
+
+      const transactionsAfterFirstSync = await listTransactions(cookie)
+      expect(transactionsAfterFirstSync.total).toBeGreaterThan(0)
+
+      const secondTxnSync = await syncPlaidTransactions(cookie, plaidItemID)
+      expect(secondTxnSync.data.inserted).toBe(0)
+      expect(secondTxnSync.data.failed).toBe(0)
+
+      const transactionsAfterSecondSync = await listTransactions(cookie)
+      expect(transactionsAfterSecondSync.total).toBe(transactionsAfterFirstSync.total)
+    } finally {
+      await deleteThrowawayUsers('plaid')
+    }
   })
 })

--- a/acceptance/playwright.config.ts
+++ b/acceptance/playwright.config.ts
@@ -1,9 +1,11 @@
 import { defineConfig, devices } from '@playwright/test'
 
 const baseURL = process.env.ACCEPTANCE_BASE_URL ?? 'http://localhost:15173'
+const coldStartProjects = process.env.QA_COLD_START === '1'
 
 export default defineConfig({
   testDir: '.',
+  testIgnore: coldStartProjects ? [] : ['**/*.cold-start.spec.ts'],
   timeout: 30_000,
   fullyParallel: false,
   reporter: [
@@ -17,7 +19,15 @@ export default defineConfig({
     screenshot: 'only-on-failure',
     video: 'off',
   },
-  projects: [
+  projects: coldStartProjects ? [
+    {
+      name: 'desktop-chromium',
+      use: {
+        ...devices['Desktop Chrome'],
+        viewport: { width: 1280, height: 900 },
+      },
+    },
+  ] : [
     {
       name: 'desktop-chromium',
       use: {

--- a/docs/QA.md
+++ b/docs/QA.md
@@ -305,7 +305,25 @@ OFFBOOK_ROLE=qa pnpm --dir acceptance exec playwright test smoke/baseline.spec.t
 
 Acceptance helpers that call `personaPassword()` load `.env.qa` and `.env.qa.local` as a side effect. Helpers that do not need persona passwords must call `loadQAEnv()` explicitly before reading `process.env`; the Plaid helper does this because Plaid credentials normally live in `.env.qa.local`.
 
-Plaid sandbox acceptance must not drive the Plaid Link iframe. Use `acceptance/plaid/helper.mjs` to mint a public token through `/sandbox/public_token/create`, exchange it through `/api/v1/plaid/link/exchange`, then sync accounts and transactions through Offbook. A smaller browser smoke should still assert `/connect` renders and the Plaid Link button mounts.
+The direct SQL persona bootstrap is only a fixture loader. It does not test `/setup/admin`, `/auth/signup`, `/auth/signup-with-invite`, or invite acceptance. Those first-boot product paths live in the opt-in cold-start suite, which is ignored by default because it resets QA data:
+
+```sh
+OFFBOOK_ROLE=qa QA_COLD_START=1 pnpm --dir acceptance exec playwright test auth/setup.cold-start.spec.ts
+```
+
+Default suites must not mutate the four shared personas. Write-heavy suites use `createThrowawayUser({ suite })` from `acceptance/fixtures/state.mjs` and clean up with `deleteThrowawayUsers(suite)`. If a run needs to scrub all mutable QA state and rebuild the shared personas, use:
+
+```sh
+OFFBOOK_ROLE=qa node acceptance/fixtures/bootstrap.mjs --reset
+```
+
+If a run needs true first-boot state without personas, use:
+
+```sh
+OFFBOOK_ROLE=qa node acceptance/fixtures/cold-start.mjs
+```
+
+Plaid sandbox acceptance must not drive the Plaid Link iframe. Use `acceptance/plaid/helper.mjs` to mint a public token through `/sandbox/public_token/create`, exchange it through `/api/v1/plaid/link/exchange`, then sync accounts and transactions through Offbook. The suite must assert accounts and transactions land for the signed-in QA user, and a second transaction sync inserts zero new rows. A smaller browser smoke should still assert `/connect` renders and the Plaid Link button mounts.
 
 Initial suites to build:
 


### PR DESCRIPTION
## Summary
- add shared QA fixture helpers for role checks, API requests, cold-start resets, and throwaway users
- add an opt-in cold-start auth/setup acceptance suite for /setup/admin, invite-only signup closure, household invite creation, and signup-with-invite
- extend Plaid sandbox acceptance from token minting to exchange -> sync accounts -> sync transactions -> re-sync no duplicates
- document the shared persona mutation contract and cold-start limitations

Closes #214
Closes #216
Closes #219

## Verification
- git diff --check
- node module import check for acceptance fixtures and Plaid helper
- pnpm --dir acceptance exec playwright test --list confirms cold-start suite is excluded by default
- QA_COLD_START=1 pnpm --dir acceptance exec playwright test auth/setup.cold-start.spec.ts --list confirms the opt-in suite runs as one desktop project
- pnpm --dir acceptance exec playwright test plaid/sandbox.spec.ts confirms Plaid tests skip cleanly without sandbox creds
- docker compose -p offbook-qa -f docker-compose.yml -f docker-compose.qa.yml config
- isolated Docker Postgres/backend project: migrations applied, cold-start TRUNCATE SQL succeeds against offbook_qa
- isolated curl product-path check: /setup/admin -> /households -> /invites -> /auth/signup-with-invite -> member listed in household

## Notes
- Full browser smoke is still limited by this sandbox's Chromium MachPort permission issue; this PR's changed Plaid/API tests do not require launching a page when creds are absent.
- Running the deep Plaid exchange/sync assertions requires PLAID_CLIENT_ID and PLAID_SECRET in .env.qa/.env.qa.local.