### PR TITLE
M9 roadmap: lock v6 personal-scope IA

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -180,8 +180,29 @@ goal through the UI, not just that the endpoint exists.
 
 **Backlog landed post-M8:** signup-with-invite endpoint (#145), owner-side member moderation (#147), per-member dashboard tiles (#149), owner-transfer endpoint (#152).
 
-### M9+ — Frontend Hi-Fi: Per-Feature [DEFERRED]
+### M9 — Frontend Hi-Fi: v6 Personal Scope
 
-Each future backend milestone (M4 categorization, M5 budgets, M6 investments, M7 AI) gets a paired frontend milestone filed when the backend milestone closes. Pattern:
-- File each FE issue with a one-sentence **Product Goal** (see issue template)
-- Done = a user can reach the product goal through the UI
+**Goal:** Restructure personal-scope IA to match `docs/designs/App Hierarchy v6.html`. Five durable surfaces, no wrapper: Sign up · Add account · Transactions · Insights · Settings. Household pages collapse onto the same components — scope swaps the data source, not the page.
+
+Locked v6 decisions (see design doc for full rationale):
+1. **Add account** — two tiles up front (Connect bank / Add manually). "Connect bank" hands off to the Plaid *native* picker; dismissing it falls back to manual within the same surface.
+2. **Auto-categorize** — silent on import. Surfaced only via a banner + "Needs review" filter on the Transactions page.
+3. **Manual import** — folded into Add Account and per-account "add more" affordances. No top-level `/import` route.
+4. **Review** — one Insights page with 5 bands: net worth · allocation · spending · budgets · goals. Replaces Dashboard for both scopes.
+5. **AI chat** — deferred. Provider config lives once in Settings; no sidebar route in personal scope.
+
+Issues:
+- [ ] #224 — Scope-agnostic page foundation; consolidate Budgets + Goals pairs
+- [ ] #225 — Insights page (5 bands, replaces Dashboard for both scopes)
+- [ ] #226 — Sidebar + route restructure (drop `/import`, drop personal `/ai`, AI provider → Settings)
+- [ ] #227 — Add Account two-tile picker (absorbs `/import` and `/connect`)
+- [ ] #228 — Transactions: silent auto-categorize + "Needs review" banner & filter
+- [ ] #229 — Sign up strip-down (3 fields; kill vault/recovery/AI language)
+
+**Done criteria:** Fresh `docker compose up` → sign up (3 fields) → land on empty `/insights` → click "Add your first account" → two-tile picker → Plaid sandbox flow OR manual fallback → transactions appear with silent auto-categorize → "Needs review" banner surfaces low-confidence rows → Insights page shows all 5 bands populated. Household scope routes (`/h/insights`, `/h/budgets`, `/h/goals`) render via the same components as personal, with aggregator-sourced data. No `Household*Page.tsx` duplicates remain for surfaces shared between scopes.
+
+**Open question:** household AI surface (`/h/ai`) — personal AI chat is deferred entirely in v6; household AI was not explicitly addressed. Decide before closing M9 whether the household AI route stays, follows personal in being deferred, or moves under household Settings.
+
+### M10+ — Frontend Hi-Fi: Visual Pass [DEFERRED]
+
+Once M9 IA is in place, apply the visual hi-fi treatment from `docs/designs/Offbook Hi-Fi v1.html` — typography, color tokens, spacing, polished empty/loading/error states. Vertical-slice approach: pick one high-traffic surface (likely Insights or Transactions), establish the design-system reference there, then propagate.

--- a/docs/designs/App Hierarchy v6.html
+++ b/docs/designs/App Hierarchy v6.html
@@ -1,0 +1,1244 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Offbook — App Hierarchy v6 · Locked direction</title>
+<link rel="icon" type="image/svg+xml" href="assets/offbook-mark.svg" />
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Caveat:wght@500;600;700&family=Kalam:wght@400;700&family=Gloria+Hallelujah&display=swap" rel="stylesheet">
+<style>
+  :root{
+    --ink:#1a1a1a;
+    --ink-2:#3a3a3a;
+    --ink-3:#6a6a6a;
+    --ink-4:#9a9a9a;
+    --paper:#f6f3ec;
+    --paper-2:#efeae0;
+    --line:#2a2a2a;
+    --violet:#863bff;
+    --violet-soft:#ede1ff;
+    --violet-deep:#5a25b0;
+    --accent:#4f46e5;
+    --pos:#0c8a4a;
+    --neg:#c0392b;
+    --warn:#b8860b;
+  }
+  *{box-sizing:border-box}
+  html,body{margin:0;padding:0;background:var(--paper);color:var(--ink);font-family:'Kalam',cursive;}
+  body{
+    background-image:
+      radial-gradient(circle at 18% 12%, rgba(134,59,255,0.05), transparent 40%),
+      radial-gradient(circle at 82% 88%, rgba(79,70,229,0.04), transparent 40%),
+      repeating-linear-gradient(0deg, rgba(0,0,0,0.012) 0 1px, transparent 1px 32px);
+    min-height:100vh;
+    padding: 56px 48px 96px;
+  }
+  .doc{max-width:1320px;margin:0 auto;}
+
+  /* Header */
+  .doc-head{
+    display:grid;grid-template-columns:1fr auto;align-items:end;gap:24px;
+    border-bottom:2px dashed var(--ink-3);padding-bottom:18px;margin-bottom:28px;
+  }
+  .eyebrow{
+    font-family:'Caveat',cursive;font-size:22px;color:var(--ink-3);
+    letter-spacing:0.5px;transform:rotate(-1deg);display:inline-block;
+  }
+  h1.title{
+    font-family:'Caveat',cursive;font-weight:700;font-size:64px;line-height:1;
+    margin:6px 0 0;letter-spacing:-0.5px;
+  }
+  h1.title .mark{display:inline-block;width:40px;height:40px;vertical-align:-2px;margin-right:6px;}
+  .meta{text-align:right;font-size:15px;color:var(--ink-2);line-height:1.5;}
+  .meta b{font-family:'Caveat',cursive;font-size:22px;display:block;line-height:1;margin-bottom:4px}
+  .stamp{
+    display:inline-block;border:2px solid var(--neg);color:var(--neg);
+    padding:4px 10px 2px;font-family:'Gloria Hallelujah',cursive;
+    font-size:13px;letter-spacing:1.5px;transform:rotate(3deg);
+    border-radius:4px;margin-top:6px;
+  }
+  .intro{
+    font-family:'Kalam',cursive;font-size:17px;color:var(--ink-2);
+    line-height:1.55;max-width:84ch;margin:0 0 36px;
+  }
+  .intro b{color:var(--ink);font-weight:700}
+
+  /* Section headers */
+  .sec-head{display:flex;align-items:baseline;gap:14px;margin:56px 0 18px;}
+  .sec-num{
+    font-family:'Caveat',cursive;font-size:44px;line-height:1;
+    color:var(--violet);transform:rotate(-3deg);display:inline-block;
+  }
+  .sec-title{font-family:'Caveat',cursive;font-size:38px;margin:0;line-height:1;}
+  .sec-sub{font-size:15px;color:var(--ink-3);margin-left:auto;max-width:52ch;text-align:right;line-height:1.4;}
+
+  /* Card / sketch base */
+  .sketch{
+    background:var(--paper);border:1.5px solid var(--line);border-radius:12px;
+    padding:20px 22px 24px;position:relative;
+    box-shadow:3px 4px 0 rgba(0,0,0,0.08);
+  }
+  .sketch .num{
+    position:absolute;top:-14px;left:16px;background:var(--ink);color:var(--paper);
+    width:30px;height:30px;border-radius:50%;display:grid;place-items:center;
+    font-family:'Caveat',cursive;font-size:20px;font-weight:700;transform:rotate(-5deg);
+  }
+  .sketch.violet .num{background:var(--violet);color:#fff}
+  .sketch h3{font-family:'Caveat',cursive;font-size:32px;margin:4px 0 2px;line-height:1;}
+  .sketch .role{font-size:13px;color:var(--ink-3);margin-bottom:16px;line-height:1.3;}
+  .sketch .role b{color:var(--violet-deep)}
+
+  /* Diagnosis row */
+  .diag{
+    display:grid;grid-template-columns:1fr 1fr;gap:24px;
+    background:var(--paper-2);border:1.5px solid var(--line);border-radius:14px;
+    padding:24px 28px;position:relative;box-shadow:4px 5px 0 rgba(0,0,0,0.06);
+  }
+  .diag::before{
+    content:"postmortem.md";position:absolute;top:-12px;left:22px;
+    background:var(--paper);padding:0 8px;font-family:'Caveat',cursive;
+    font-size:18px;color:var(--ink-3);
+  }
+  .diag h4{
+    font-family:'Caveat',cursive;font-size:24px;margin:0 0 8px;
+    display:flex;align-items:center;gap:8px;
+  }
+  .diag .bad h4{color:var(--neg)}
+  .diag .good h4{color:var(--pos)}
+  .diag ul{margin:0;padding-left:18px;font-size:14px;line-height:1.55;color:var(--ink-2)}
+  .diag li{margin-bottom:4px}
+  .diag li b{color:var(--ink)}
+  .diag .stamp-x{
+    display:inline-block;border:2px solid var(--neg);color:var(--neg);
+    padding:2px 8px;font-family:'Gloria Hallelujah',cursive;font-size:11px;
+    letter-spacing:1px;transform:rotate(-2deg);border-radius:3px;
+  }
+
+  /* Tabs */
+  .tabs{
+    display:flex;gap:6px;margin-bottom:14px;flex-wrap:wrap;
+    border-bottom:2px dashed var(--ink-3);padding-bottom:10px;
+  }
+  .tab{
+    background:var(--paper);border:1.5px solid var(--line);
+    border-radius:8px 8px 0 0;padding:6px 14px 8px;
+    font-family:'Kalam',cursive;font-size:13px;font-weight:700;
+    cursor:pointer;color:var(--ink-2);
+    box-shadow:2px 2px 0 var(--ink);
+  }
+  .tab.active{background:var(--violet);color:#fff;border-color:var(--violet-deep);box-shadow:2px 2px 0 var(--violet-deep)}
+  .tab .vlabel{font-family:'Caveat',cursive;font-size:15px;font-weight:400;color:var(--ink-3);margin-left:6px}
+  .tab.active .vlabel{color:rgba(255,255,255,0.85)}
+  .panel{display:none}
+  .panel.active{display:block}
+
+  /* Side-by-side variations */
+  .var-row{
+    display:grid;grid-template-columns:1fr 1fr;gap:22px;align-items:stretch;
+  }
+  .var-row.tri{grid-template-columns:1fr 1fr 1fr}
+  .var-row > .sketch{margin:0}
+
+  /* Mini wireframe blocks (reused from v4) */
+  .wf{
+    border:1.5px solid var(--line);border-radius:6px;padding:8px 10px;
+    background:var(--paper-2);font-size:13px;line-height:1.3;position:relative;
+  }
+  .wf.flat{background:transparent}
+  .wf.dashed{border-style:dashed}
+  .wf.violet{background:var(--violet-soft);border-color:var(--violet-deep)}
+  .wf .label{
+    font-family:'Caveat',cursive;font-size:17px;color:var(--ink-2);
+    display:block;margin-bottom:4px;
+  }
+  .wf.violet .label{color:var(--violet-deep)}
+  .row{display:flex;gap:8px;margin-bottom:8px}
+  .row.tight{gap:6px}
+  .row > *{flex:1}
+  .row.spread{justify-content:space-between;align-items:center}
+  .row.nogrow > *{flex:initial}
+  .col{display:flex;flex-direction:column;gap:8px}
+  .stat{border:1.5px solid var(--line);border-radius:6px;padding:8px 10px;background:var(--paper-2)}
+  .stat .e{font-family:'Caveat',cursive;font-size:14px;color:var(--ink-3);line-height:1}
+  .stat .v{font-family:'Kalam',cursive;font-weight:700;font-size:20px;line-height:1.1;margin-top:4px}
+  .stat .d{font-size:12px;color:var(--pos)}
+  .stat .d.neg{color:var(--neg)}
+  .squiggle-line{
+    height:36px;width:100%;
+    background-image:url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 200 36' preserveAspectRatio='none'><path d='M0,28 Q12,20 22,24 T44,18 T66,22 T88,14 T110,18 T132,10 T154,16 T176,8 T200,4' fill='none' stroke='%231a1a1a' stroke-width='2'/></svg>");
+    background-repeat:no-repeat;background-size:100% 100%;
+  }
+  .squiggle-line.spark{height:28px}
+  .bar-row{
+    display:flex;align-items:center;gap:8px;padding:4px 0;
+    border-bottom:1px dashed var(--ink-4);font-size:13px;
+  }
+  .bar-row:last-child{border-bottom:none}
+  .bar-row .name{flex:1.4}
+  .bar-row .bar{
+    flex:2;height:8px;border:1.5px solid var(--line);border-radius:4px;
+    background:var(--paper-2);position:relative;overflow:hidden;
+  }
+  .bar-row .bar::before{
+    content:"";position:absolute;inset:0;width:var(--p,60%);
+    background:repeating-linear-gradient(45deg,var(--ink) 0 2px,transparent 2px 5px);
+  }
+  .bar-row .bar.warn::before{background:repeating-linear-gradient(45deg,var(--warn) 0 2px,transparent 2px 5px)}
+  .bar-row .bar.over::before{background:repeating-linear-gradient(45deg,var(--neg) 0 2px,transparent 2px 5px);width:100%}
+  .bar-row .bar.violet::before{background:repeating-linear-gradient(45deg,var(--violet) 0 2px,transparent 2px 5px)}
+  .bar-row .pct{flex:0 0 auto;font-size:12px;color:var(--ink-3)}
+  .pill{
+    display:inline-block;border:1.5px solid var(--line);border-radius:999px;
+    padding:2px 10px;font-size:12px;background:var(--paper);
+  }
+  .pill.violet{background:var(--violet-soft);border-color:var(--violet);color:var(--violet-deep)}
+  .pill.dashed{border-style:dashed}
+  .pill.solid{background:var(--ink);color:var(--paper);border-color:var(--ink)}
+  .pill.pos{color:var(--pos);border-color:var(--pos)}
+  .pill.neg{color:var(--neg);border-color:var(--neg)}
+  .pill.warn{color:var(--warn);border-color:var(--warn)}
+  .pills{display:flex;flex-wrap:wrap;gap:6px}
+  .table{border:1.5px solid var(--line);border-radius:6px;overflow:hidden}
+  .tr{
+    display:grid;grid-template-columns:1.2fr 2fr 1fr 1fr;gap:8px;
+    padding:6px 10px;font-size:13px;border-bottom:1px dashed var(--ink-4);
+    align-items:center;
+  }
+  .tr:last-child{border-bottom:none}
+  .tr.head{background:var(--paper-2);font-family:'Caveat',cursive;font-size:15px;color:var(--ink-3)}
+  .tr .amt{text-align:right;font-variant-numeric:tabular-nums}
+  .tr .amt.pos{color:var(--pos)}
+  .tr .amt.neg{color:var(--neg)}
+  .placeholder{
+    border:1.5px dashed var(--ink-3);border-radius:6px;height:90px;
+    background:
+      linear-gradient(135deg,transparent 49%,var(--ink-3) 49%,var(--ink-3) 51%,transparent 51%),
+      linear-gradient(45deg,transparent 49%,var(--ink-3) 49%,var(--ink-3) 51%,transparent 51%);
+    background-size:30px 30px;background-position:0 0;opacity:0.35;
+  }
+  .note{
+    font-family:'Caveat',cursive;font-size:16px;color:var(--violet-deep);
+    line-height:1.2;position:relative;padding-left:18px;margin-top:8px;
+  }
+  .note::before{
+    content:"↳";position:absolute;left:0;top:-1px;color:var(--violet);font-size:20px;
+  }
+  .annotate{
+    font-family:'Gloria Hallelujah',cursive;color:var(--violet-deep);
+    font-size:14px;line-height:1.25;
+  }
+  .muted{color:var(--ink-3)}
+  .strikeout{text-decoration:line-through;color:var(--ink-4)}
+
+  /* Phone / page frames */
+  .frame{
+    border:2px solid var(--ink);border-radius:14px;background:var(--paper);
+    padding:14px;box-shadow:4px 5px 0 rgba(0,0,0,0.1);position:relative;
+  }
+  .frame::before{
+    content:"";position:absolute;top:6px;left:50%;transform:translateX(-50%);
+    width:38px;height:4px;background:var(--ink-3);border-radius:2px;opacity:0.4;
+  }
+  .frame .url{
+    font-family:'Caveat',cursive;font-size:14px;color:var(--ink-3);
+    text-align:center;margin-bottom:8px;border-bottom:1.5px dashed var(--ink-4);
+    padding-bottom:6px;
+  }
+
+  /* Sidebar mock */
+  .sb-mock{
+    display:grid;grid-template-columns:110px 1fr;gap:0;
+    border:1.5px solid var(--line);border-radius:8px;overflow:hidden;min-height:240px;
+  }
+  .sb-mock .sb{
+    background:var(--paper-2);border-right:1.5px solid var(--line);
+    padding:10px 8px;display:flex;flex-direction:column;gap:4px;
+  }
+  .sb-item{padding:4px 6px;border-radius:4px;font-size:12px;color:var(--ink-2)}
+  .sb-item.active{background:var(--accent);color:var(--paper);font-weight:700}
+  .sb-mock .canvas{padding:12px;font-size:13px}
+
+  /* Big drop zone */
+  .drop{
+    border:2px dashed var(--violet);border-radius:10px;
+    background:var(--violet-soft);padding:24px;text-align:center;
+    font-family:'Caveat',cursive;font-size:24px;color:var(--violet-deep);
+    line-height:1.15;
+  }
+  .drop small{font-family:'Kalam',cursive;font-size:12px;color:var(--ink-2);display:block;margin-top:6px}
+
+  /* Flow strip */
+  .flow{
+    display:grid;grid-template-columns:repeat(4,1fr);gap:0;align-items:stretch;
+    border:1.5px solid var(--line);border-radius:12px;overflow:hidden;background:var(--paper);
+  }
+  .step{padding:14px 16px;border-right:1.5px dashed var(--ink-3);position:relative}
+  .step:last-child{border-right:none}
+  .step .n{font-family:'Caveat',cursive;font-size:20px;color:var(--violet);line-height:1}
+  .step h4{margin:6px 0 6px;font-family:'Kalam',cursive;font-size:15px;font-weight:700}
+  .step p{margin:0;font-size:12px;color:var(--ink-2);line-height:1.4}
+  .step .arrow{
+    position:absolute;top:50%;right:-10px;transform:translateY(-50%);
+    background:var(--paper);color:var(--violet-deep);font-size:18px;z-index:2;
+    padding:0 4px;line-height:1;
+  }
+  .step:last-child .arrow{display:none}
+
+  /* Allocation donut placeholder */
+  .donut{
+    width:130px;height:130px;border-radius:50%;
+    background:conic-gradient(
+      var(--ink) 0 38%,
+      var(--violet) 38% 62%,
+      var(--accent) 62% 80%,
+      var(--warn) 80% 92%,
+      var(--ink-4) 92% 100%);
+    position:relative;margin:0 auto;
+  }
+  .donut::after{
+    content:"";position:absolute;inset:22px;background:var(--paper);border-radius:50%;
+  }
+  .donut .center{
+    position:absolute;inset:22px;display:grid;place-items:center;
+    font-family:'Kalam',cursive;font-weight:700;text-align:center;line-height:1.1;z-index:1;
+  }
+  .donut .center small{font-family:'Caveat',cursive;font-weight:400;font-size:13px;color:var(--ink-3);display:block;margin-top:2px}
+  .legend-dots{display:flex;flex-direction:column;gap:4px;font-size:12px}
+  .legend-dots .dot{
+    display:inline-block;width:10px;height:10px;border-radius:2px;margin-right:6px;
+    vertical-align:middle;border:1px solid var(--line);
+  }
+  .legend-dots .d-ink{background:var(--ink)}
+  .legend-dots .d-violet{background:var(--violet)}
+  .legend-dots .d-accent{background:var(--accent)}
+  .legend-dots .d-warn{background:var(--warn)}
+  .legend-dots .d-mute{background:var(--ink-4)}
+
+  /* Sitemap delta */
+  .delta{
+    display:grid;grid-template-columns:1fr 1fr;gap:22px;
+  }
+  .delta .col{
+    border:1.5px solid var(--line);border-radius:10px;padding:18px 20px;
+    background:var(--paper);box-shadow:3px 3px 0 rgba(0,0,0,0.06);
+  }
+  .delta .col h4{font-family:'Caveat',cursive;font-size:28px;margin:0 0 12px}
+  .delta .col.before h4{color:var(--ink-3)}
+  .delta .col.after h4{color:var(--violet-deep)}
+  .delta-route{
+    display:flex;align-items:center;gap:8px;padding:6px 8px;
+    border:1.5px solid var(--line);border-radius:6px;margin-bottom:6px;
+    background:var(--paper-2);font-size:13px;
+  }
+  .delta-route.violet{background:var(--violet-soft);border-color:var(--violet-deep);color:var(--violet-deep)}
+  .delta-route.removed{
+    opacity:0.55;text-decoration:line-through;border-style:dashed;background:transparent;
+  }
+  .delta-route .tag{
+    margin-left:auto;font-family:'Caveat',cursive;font-size:14px;color:var(--ink-3);
+  }
+  .delta-route.violet .tag{color:var(--violet-deep)}
+
+  /* Footer */
+  .footer{
+    margin-top:56px;border-top:2px dashed var(--ink-3);padding-top:18px;
+    display:grid;grid-template-columns:1fr auto;gap:24px;font-size:14px;color:var(--ink-3);
+  }
+  .footer .right{text-align:right;font-family:'Caveat',cursive;font-size:22px;color:var(--ink-2)}
+
+  /* Misc */
+  .arrow-cb{font-family:'Caveat',cursive;color:var(--violet-deep);font-size:18px;line-height:1.1}
+  .kbd{
+    font-family:'Kalam',cursive;font-size:11px;background:var(--paper);
+    border:1.5px solid var(--line);border-radius:4px;padding:1px 6px;
+    box-shadow:1px 1px 0 var(--ink);
+  }
+
+  @media (max-width:1100px){
+    .var-row, .var-row.tri{grid-template-columns:1fr}
+    .diag, .delta{grid-template-columns:1fr}
+    .flow{grid-template-columns:1fr}
+    .step{border-right:none;border-bottom:1.5px dashed var(--ink-3)}
+    .step:last-child{border-bottom:none}
+  }
+</style>
+</head>
+<body>
+<template id="__bundler_thumbnail" data-bg-color="#f6f3ec">
+  <svg viewBox="0 0 1200 800" xmlns="http://www.w3.org/2000/svg">
+    <rect width="1200" height="800" fill="#f6f3ec"/>
+    <g transform="translate(600 380)">
+      <path d="M50 -180 L-110 0 H-15 L-30 200 L120 -60 H30 Z" fill="#863bff" stroke="#5a25b0" stroke-width="6" stroke-linejoin="round"/>
+    </g>
+    <text x="600" y="640" text-anchor="middle" font-family="Caveat, Comic Sans MS, cursive" font-size="80" font-weight="700" fill="#1a1a1a">offbook</text>
+    <text x="600" y="710" text-anchor="middle" font-family="Caveat, Comic Sans MS, cursive" font-size="40" fill="#6a6a6a">app hierarchy · v5</text>
+  </svg>
+</template>
+
+<div class="doc">
+
+  <!-- ─────────── HEADER ─────────── -->
+  <div class="doc-head">
+    <div>
+      <span class="eyebrow">v6 · locked direction · ready for hi-fi</span>
+      <h1 class="title">
+        <svg class="mark" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+          <path d="M13 2 L4 14 H11 L10 22 L20 9 H13 Z" fill="#863bff" stroke="#5a25b0" stroke-width="0.6" stroke-linejoin="round"/>
+        </svg>
+        offbook — app hierarchy
+      </h1>
+    </div>
+    <div class="meta">
+      <b>direction picked</b>
+      Plaid-native picker · manual fallback ·<br/>
+      one Insights page · Budgets &amp; Goals back in.
+      <div class="stamp" style="border-color:var(--pos);color:var(--pos)">v6 · LOCKED</div>
+    </div>
+  </div>
+
+  <p class="intro">
+    v6 commits to the direction from v5 review: <b>kill the wizard</b>, give Add Account <b>both an up-front choice and a fallback</b>,
+    use the <b>Plaid native picker</b> (we don't build our own), keep auto-categorize <b>silent with a banner</b>, fold manual import into
+    Add Account, and put net worth + allocation + spending + <b>budgets + goals</b> on one <b>Insights</b> page. AI provider lives in
+    Settings; AI chat is deferred.
+  </p>
+
+  <!-- ─────────── 00 · POSTMORTEM ─────────── -->
+  <div class="sec-head">
+    <span class="sec-num">00</span>
+    <h2 class="sec-title">What went off the chart</h2>
+    <p class="sec-sub">Quick honest read of where the hi-fi journey
+      diverged from the requirements, so v5 doesn't repeat it.</p>
+  </div>
+
+  <div class="diag">
+    <div class="bad">
+      <h4>✗ Hi-fi went off the chart</h4>
+      <ul>
+        <li><b>Forced wizard</b> shoved 3 unrelated functions into 1 linear flow. <span class="stamp-x">linear</span></li>
+        <li><b>Onboarding "Connect bank"</b> duplicated the in-app <b>Accounts → Connect bank</b> action. Two homes for the same job.</li>
+        <li><b>Onboarding "Import progress"</b> page existed only to fill a step — auto-import is a <em>background</em> outcome, not a screen.</li>
+        <li><b>"Manual import" route</b> in the sidebar AND a "+ add manually" tile in the wizard — same function, two doors.</li>
+        <li><b>AI advisor</b> mentioned in onboarding ("AI you can audit"). User said: <em>AI provider is global setup, don't emphasize.</em></li>
+        <li><b>Vault passphrase</b> + recovery key + restore-from-backup at sign-up — way past the requirement of "sign up".</li>
+      </ul>
+    </div>
+    <div class="good">
+      <h4>✓ v5 principles</h4>
+      <ul>
+        <li><b>5 requirements → 5 surfaces.</b> Sign up · Add account · Transactions · Insights · Net worth. No wrapper.</li>
+        <li><b>One door per job.</b> Adding an account — Plaid or manual — is always the same screen, regardless of how you got there.</li>
+        <li><b>Auto-categorize is silent.</b> It runs on import; users review by exception on the Transactions page.</li>
+        <li><b>Manual import lives inside Add Account</b> — it's just the second of two paths. Not a separate sidebar route.</li>
+        <li><b>Review surface is one page.</b> Net worth + asset allocation + spending categories + trend collapse into a single Insights view.</li>
+        <li><b>No AI mentions in onboarding.</b> The AI provider is set during instance setup once; users never see it again unless they open Settings.</li>
+      </ul>
+    </div>
+  </div>
+
+  <!-- ─────────── 01 · SHAPE OF THE JOURNEY ─────────── -->
+  <div class="sec-head">
+    <span class="sec-num">01</span>
+    <h2 class="sec-title">The shape — 5 surfaces, not a flow</h2>
+    <p class="sec-sub">Each surface is a real, durable route. The user can enter, exit, and return at any time.
+      The "journey" is just the order most users will discover them in.</p>
+  </div>
+
+  <div class="flow">
+    <div class="step" style="background:var(--violet-soft)">
+      <div class="n">01</div>
+      <h4>Sign up</h4>
+      <p><b>Standalone page.</b> Name, email, password. Drops you on an empty Dashboard with one CTA.</p>
+      <div class="arrow">→</div>
+    </div>
+    <div class="step">
+      <div class="n">02</div>
+      <h4>Add account</h4>
+      <p>Two paths in one modal: <b>Connect via Plaid</b> or <b>Add manually</b>. Auto-categorize starts in the background.</p>
+      <div class="arrow">→</div>
+    </div>
+    <div class="step">
+      <div class="n">03</div>
+      <h4>Transactions</h4>
+      <p>Categorized rows arrive automatically. Top of the table flags low-confidence guesses for review.</p>
+      <div class="arrow">→</div>
+    </div>
+    <div class="step">
+      <div class="n">04</div>
+      <h4>Insights</h4>
+      <p>One page: net worth · allocation · categories · trend. The "how am I doing" answer.</p>
+    </div>
+  </div>
+
+  <div class="row" style="margin-top:14px;gap:14px">
+    <div class="wf flat">
+      <span class="label">No wrapper chrome</span>
+      No step indicator. No "Continue to next step" CTA. Every screen is the real
+      app screen — same shell, same navigation. Sign up is the only exception.
+    </div>
+    <div class="wf flat">
+      <span class="label">Re-entry is free</span>
+      User can come back to Add Account any time. Can run a CSV import three months later. Can shuffle between Transactions and Insights without losing context.
+    </div>
+    <div class="wf flat violet">
+      <span class="label">Auto-categorize is the win, not the show</span>
+      It runs invisibly. The only UI for it is a "Needs review" filter on Transactions
+      that surfaces the few rows the model wasn't confident about.
+    </div>
+  </div>
+
+  <!-- ─────────── 02 · SIGN UP ─────────── -->
+  <div class="sec-head">
+    <span class="sec-num">02</span>
+    <h2 class="sec-title">Sign up</h2>
+    <p class="sec-sub">Just sign up. No vault metaphor, no backup keys, no AI promises.
+      Two wireframes — minimum-fields vs. one-screen-with-context.</p>
+  </div>
+
+  <div class="tabs" data-group="signup">
+    <button class="tab active" data-tab="su-a">A · Bare minimum <span class="vlabel">3 fields</span></button>
+    <button class="tab" data-tab="su-b">B · Plus context <span class="vlabel">why signing in</span></button>
+  </div>
+
+  <div class="panel active" data-panel="su-a">
+    <div class="var-row">
+      <div class="sketch">
+        <span class="num">A1</span>
+        <h3>Sign up · bare</h3>
+        <div class="role">3 fields, one button. Lands you on an empty Dashboard with a single "Add your first account" CTA.</div>
+        <div class="frame" style="max-width:460px;margin:0 auto">
+          <div class="url">offbook.local / sign-up</div>
+          <div style="padding:18px 20px 14px">
+            <div style="font-family:'Caveat',cursive;font-size:30px;line-height:1;margin-bottom:4px">create your account</div>
+            <div style="font-size:12px;color:var(--ink-3);margin-bottom:14px">stays on this device.</div>
+            <div class="wf flat" style="padding:6px 10px"><span class="muted">name</span></div>
+            <div class="wf flat" style="padding:6px 10px;margin-top:8px"><span class="muted">email</span></div>
+            <div class="wf flat" style="padding:6px 10px;margin-top:8px"><span class="muted">password</span></div>
+            <div class="row spread" style="margin-top:14px">
+              <span class="muted" style="font-size:11px">already have one? <u>sign in</u></span>
+              <span class="pill solid">create account →</span>
+            </div>
+          </div>
+        </div>
+        <div class="note">no recovery key, no vault language, no AI mention</div>
+      </div>
+
+      <div class="sketch">
+        <span class="num">A2</span>
+        <h3>Right after · empty dashboard</h3>
+        <div class="role">Signed-in landing. Empty stats, single hero CTA. No tour, no checklist, no progress bar.</div>
+        <div class="sb-mock">
+          <div class="sb">
+            <div style="font-family:'Caveat',cursive;font-size:16px;margin-bottom:6px">⚡ offbook</div>
+            <div class="sb-item active">Dashboard</div>
+            <div class="sb-item muted">Accounts</div>
+            <div class="sb-item muted">Transactions</div>
+            <div class="sb-item muted">Insights</div>
+            <div class="sb-item muted">Settings</div>
+            <div style="margin-top:auto;padding-top:10px;border-top:1px dashed var(--ink-4);font-size:10px;color:var(--ink-3)">
+              👤 Alex<br/>
+              <span style="color:var(--pos)">●</span> local · ready
+            </div>
+          </div>
+          <div class="canvas">
+            <div style="font-family:'Caveat',cursive;font-size:24px;line-height:1">welcome, Alex</div>
+            <div style="font-size:12px;color:var(--ink-3);margin-bottom:14px">nothing here yet — let's bring some accounts in.</div>
+            <div class="row">
+              <div class="stat"><div class="e">net worth</div><div class="v muted">—</div></div>
+              <div class="stat"><div class="e">accounts</div><div class="v muted">0</div></div>
+              <div class="stat"><div class="e">this month</div><div class="v muted">—</div></div>
+            </div>
+            <div class="drop" style="margin-top:14px">
+              + add your first account
+              <small>connect a bank · upload a statement · type one in</small>
+            </div>
+          </div>
+        </div>
+        <div class="note">the entire onboarding pressure collapses into this one button</div>
+      </div>
+    </div>
+  </div>
+
+  <div class="panel" data-panel="su-b">
+    <div class="var-row">
+      <div class="sketch">
+        <span class="num">B1</span>
+        <h3>Sign up · with a line of context</h3>
+        <div class="role">Same 3 fields, but a single line of copy explaining what offbook is — for users who land cold.</div>
+        <div class="frame" style="max-width:480px;margin:0 auto">
+          <div class="url">offbook.local / sign-up</div>
+          <div style="padding:18px 20px 14px">
+            <div class="wf flat" style="margin-bottom:14px;padding:8px 12px;background:var(--violet-soft);border-color:var(--violet)">
+              <b style="color:var(--violet-deep)">offbook</b> is your private money dashboard. all data stays on this device.
+            </div>
+            <div style="font-family:'Caveat',cursive;font-size:28px;line-height:1;margin-bottom:10px">create your account</div>
+            <div class="wf flat" style="padding:6px 10px"><span class="muted">name</span></div>
+            <div class="wf flat" style="padding:6px 10px;margin-top:8px"><span class="muted">email</span></div>
+            <div class="wf flat" style="padding:6px 10px;margin-top:8px"><span class="muted">password</span></div>
+            <span class="pill solid" style="margin-top:14px;display:inline-block">create account →</span>
+          </div>
+        </div>
+        <div class="note">one paragraph, not 4 promise tiles</div>
+      </div>
+
+      <div class="sketch">
+        <span class="num">B2</span>
+        <h3>If invite-only mode</h3>
+        <div class="role">When the instance admin chose invite-only at install. Single extra input — the invite code — gates the form.</div>
+        <div class="frame" style="max-width:480px;margin:0 auto">
+          <div class="url">offbook.local / sign-up?code=…</div>
+          <div style="padding:18px 20px 14px">
+            <div class="wf flat" style="padding:6px 10px;border-color:var(--violet);background:var(--violet-soft)">
+              <span style="color:var(--violet-deep)">invite code · </span><b>OFB-7K9P-2X41</b> <span class="pill pos" style="font-size:10px;margin-left:6px">valid</span>
+            </div>
+            <div style="font-family:'Caveat',cursive;font-size:24px;line-height:1;margin:14px 0 8px">create your account</div>
+            <div class="wf flat" style="padding:6px 10px"><span class="muted">name</span></div>
+            <div class="wf flat" style="padding:6px 10px;margin-top:8px"><span class="muted">email</span></div>
+            <div class="wf flat" style="padding:6px 10px;margin-top:8px"><span class="muted">password</span></div>
+            <span class="pill solid" style="margin-top:14px;display:inline-block">accept invite →</span>
+          </div>
+        </div>
+        <div class="note">same form, gated. invite-only is an admin toggle, not a separate flow.</div>
+      </div>
+    </div>
+  </div>
+
+  <!-- ─────────── 03 · ADD ACCOUNT ─────────── -->
+  <div class="sec-head">
+    <span class="sec-num">03</span>
+    <h2 class="sec-title">Add account · two tiles, then Plaid does the hard part</h2>
+    <p class="sec-sub">Choice up front (<b>Connect bank</b> vs. <b>Add manually</b>). "Connect bank" hands off to the
+      <b>Plaid native picker</b> — we don't build our own search. If they dismiss Plaid, we offer manual as the fallback.</p>
+  </div>
+
+  <div class="flow" style="grid-template-columns:repeat(4,1fr);margin-bottom:20px">
+    <div class="step" style="background:var(--violet-soft)">
+      <div class="n">step 1</div>
+      <h4>Pick a path</h4>
+      <p>Two tiles. Two real choices. No assumption about which is "primary".</p>
+      <div class="arrow">→</div>
+    </div>
+    <div class="step">
+      <div class="n">2a · bank</div>
+      <h4>Plaid Link opens</h4>
+      <p>Hand-off to the <b>Plaid native picker</b>. Their search, their grid, their flows. We don't reimplement it.</p>
+      <div class="arrow">→</div>
+    </div>
+    <div class="step">
+      <div class="n">if dismissed</div>
+      <h4>Fallback prompt</h4>
+      <p>User closes Plaid without linking. We surface: <em>"didn't find it? add it manually"</em>.</p>
+      <div class="arrow">→</div>
+    </div>
+    <div class="step">
+      <div class="n">2b · manual</div>
+      <h4>Manual form + drop</h4>
+      <p>Name, type, optional starting balance · CSV/PDF/photo dropzone. Same screen for both entry points.</p>
+    </div>
+  </div>
+
+  <div class="var-row">
+    <div class="sketch violet">
+      <span class="num">1</span>
+      <h3>Step 1 · pick a path</h3>
+      <div class="role">Plain two-tile modal opened from <code>+ Add account</code>. No bank logos, no taxonomy gymnastics.</div>
+      <div class="frame" style="max-width:560px;margin:0 auto">
+        <div class="url">Accounts &nbsp;›&nbsp; + add account</div>
+        <div style="font-family:'Caveat',cursive;font-size:24px;line-height:1;margin:4px 0 14px">add an account</div>
+        <div class="row">
+          <div class="wf" style="text-align:center;padding:18px 14px">
+            <div style="font-size:32px;line-height:1">🏦</div>
+            <div style="font-family:'Caveat',cursive;font-size:22px;margin:6px 0 2px">connect a bank</div>
+            <div style="font-size:11px;color:var(--ink-3);line-height:1.35">via Plaid · 12,000+ institutions · auto-syncs going forward</div>
+            <span class="pill solid" style="margin-top:10px;font-size:11px">continue &nbsp;→</span>
+          </div>
+          <div class="wf" style="text-align:center;padding:18px 14px">
+            <div style="font-size:32px;line-height:1">📄</div>
+            <div style="font-family:'Caveat',cursive;font-size:22px;margin:6px 0 2px">add it manually</div>
+            <div style="font-size:11px;color:var(--ink-3);line-height:1.35">crypto wallets · foreign banks · cash · anything Plaid can't see</div>
+            <span class="pill solid" style="margin-top:10px;font-size:11px">continue &nbsp;→</span>
+          </div>
+        </div>
+        <div style="text-align:center;font-size:11px;color:var(--ink-3);margin-top:10px">
+          not sure? <b>Connect a bank</b> is the easier of the two if you have one Plaid supports.
+        </div>
+      </div>
+      <div class="note">the choice is honest — both are real paths · neither hidden in a "more" link</div>
+    </div>
+
+    <div class="sketch">
+      <span class="num">2a</span>
+      <h3>Step 2a · Plaid native picker</h3>
+      <div class="role">Hand-off. <b>We don't build a picker.</b> Plaid Link is its own iframe/modal with search, logos, popular grid, MFA, OAuth. Their UX, end to end.</div>
+      <div class="frame" style="max-width:560px;margin:0 auto;border-color:var(--ink-3);border-style:dashed">
+        <div class="url" style="color:var(--ink-3)">Plaid Link · cdn.plaid.com (their iframe)</div>
+        <div style="text-align:center;padding:14px 8px 4px">
+          <div style="font-family:'Kalam',cursive;font-weight:700;font-size:16px;color:var(--ink-3)">Plaid</div>
+          <div style="font-family:'Kalam',cursive;font-weight:700;font-size:18px;margin-top:8px">Select your bank</div>
+        </div>
+        <div class="wf flat" style="padding:8px 12px;margin:12px 16px;background:var(--paper-2)"><span class="muted">⌕ &nbsp;Search 12,000+ institutions</span></div>
+        <div style="display:grid;grid-template-columns:repeat(3,1fr);gap:6px;margin:0 16px 14px">
+          <div class="pill" style="text-align:center">Chase</div>
+          <div class="pill" style="text-align:center">BofA</div>
+          <div class="pill" style="text-align:center">Wells Fargo</div>
+          <div class="pill" style="text-align:center">Citi</div>
+          <div class="pill" style="text-align:center">Capital One</div>
+          <div class="pill" style="text-align:center">Ally</div>
+          <div class="pill" style="text-align:center">Amex</div>
+          <div class="pill" style="text-align:center">Schwab</div>
+          <div class="pill" style="text-align:center">Fidelity</div>
+        </div>
+        <div style="text-align:center;font-size:10px;color:var(--ink-3);padding:8px;border-top:1px dashed var(--ink-4)">
+          ⚪ Powered by Plaid &nbsp;·&nbsp; Privacy &nbsp;·&nbsp; <span style="color:var(--ink)">×</span>
+        </div>
+      </div>
+      <div class="annotate" style="text-align:center;margin-top:8px">
+        ↑ Plaid renders this. We render <em>nothing</em> inside it.
+      </div>
+      <div class="note">two callbacks we care about: <code>onSuccess(publicToken)</code> &amp; <code>onExit({err,metadata})</code></div>
+    </div>
+  </div>
+
+  <div class="var-row" style="margin-top:18px">
+    <div class="sketch">
+      <span class="num">2b</span>
+      <h3>Plaid dismissed → manual fallback</h3>
+      <div class="role">User closes Plaid without linking. We catch <code>onExit</code> and surface a single follow-up — no dead end, no "retry?" loop.</div>
+      <div class="frame" style="max-width:560px;margin:0 auto">
+        <div class="url">Accounts &nbsp;›&nbsp; + add account</div>
+        <div style="font-family:'Caveat',cursive;font-size:22px;line-height:1;margin:4px 0 4px">didn't find your bank?</div>
+        <div style="font-size:12px;color:var(--ink-3);margin-bottom:14px">that's fine — Plaid covers most US/CA/EU banks, but not all of them.</div>
+
+        <div class="wf violet" style="padding:14px 16px">
+          <span class="label" style="color:var(--violet-deep)">add it manually</span>
+          <div style="font-size:12px;color:var(--ink-2);line-height:1.45">
+            You'll create an account by hand, then drop a CSV / PDF / photo to seed transactions
+            (or just type a starting balance and add rows later).
+          </div>
+          <div style="margin-top:10px;display:flex;gap:6px">
+            <span class="pill solid" style="font-size:11px">add manually →</span>
+            <span class="pill dashed" style="font-size:11px">try Plaid again</span>
+            <span class="pill dashed" style="font-size:11px">cancel</span>
+          </div>
+        </div>
+
+        <div style="font-size:11px;color:var(--ink-3);margin-top:10px;line-height:1.45">
+          <b>note:</b> if Plaid exited with a real error (network, server-side), we show that instead.
+          The manual fallback only fires when the user dismissed without picking — i.e. <code>onExit</code> with no <code>err</code>.
+        </div>
+      </div>
+      <div class="note">one fallback prompt · no nesting · no "are you sure" modal</div>
+    </div>
+
+    <div class="sketch">
+      <span class="num">3</span>
+      <h3>Manual form + dropzone</h3>
+      <div class="role">Where both the "add manually" tile from step 1 and the fallback from step 2 land. One screen.</div>
+      <div class="frame" style="max-width:560px;margin:0 auto">
+        <div class="url">+ add account · manual</div>
+        <div style="font-family:'Caveat',cursive;font-size:22px;line-height:1;margin:4px 0 10px">tell us about it</div>
+        <div class="row" style="margin-bottom:8px">
+          <div class="wf flat" style="padding:6px 10px"><span class="muted">name · e.g. "Ledger BTC"</span></div>
+          <div class="wf flat" style="padding:6px 10px"><span class="muted">type ▾ &nbsp;checking · savings · credit · brokerage · crypto · property · cash</span></div>
+        </div>
+        <div class="row" style="margin-bottom:8px">
+          <div class="wf flat" style="padding:6px 10px"><span class="muted">institution (optional)</span></div>
+          <div class="wf flat" style="padding:6px 10px"><span class="muted">starting balance</span></div>
+        </div>
+        <div class="drop" style="margin-top:14px;padding:18px">
+          drop a CSV, PDF, or photo
+          <small>or paste a screenshot · skip to create empty account</small>
+        </div>
+        <div class="row spread" style="margin-top:14px">
+          <span class="muted" style="font-size:11px"><span class="kbd">esc</span> cancel</span>
+          <span><span class="pill dashed">skip · empty</span> <span class="pill solid">create →</span></span>
+        </div>
+      </div>
+      <div class="note">CSV / PDF / photo all go through the same dropzone — no separate "import" page</div>
+    </div>
+  </div>
+
+  <div class="row" style="margin-top:18px;gap:14px">
+    <div class="wf flat violet">
+      <span class="label">why hand off to Plaid native</span>
+      Their picker already handles 12,000+ institutions, regional logos, MFA, OAuth bank redirects,
+      and re-auth flows. <b>Anything we build is strictly worse and a maintenance tax.</b>
+    </div>
+    <div class="wf flat">
+      <span class="label">why the fallback is one prompt, not a flow</span>
+      Dismissing Plaid is rarely a "need help" moment — it's usually "my bank isn't there".
+      One offer, three buttons, done.
+    </div>
+    <div class="wf flat">
+      <span class="label">where re-connect lives later</span>
+      Same modal. <code>+ Add account</code> → tile 1 → Plaid Link in "update mode" if a token's stale.
+      No new surface needed.
+    </div>
+  </div>
+
+
+  <!-- ─────────── 04 · AUTO-CATEGORIZE ─────────── -->
+  <div class="sec-head">
+    <span class="sec-num">04</span>
+    <h2 class="sec-title">Auto-categorize · silent banner + filter</h2>
+    <p class="sec-sub">"Import transactions, all auto-categorized" — happens on import. The only UI for it is a
+      <b>banner + filter</b> on the Transactions page that surfaces the few rows the model wasn't sure about.</p>
+  </div>
+
+
+  <div class="panel active" data-panel="cat-a">
+    <div class="var-row">
+      <div class="sketch">
+        <span class="num">A1</span>
+        <h3>Transactions page · just after import</h3>
+        <div class="role">All 218 rows arrive already categorized. A thin banner at the top: <b>"6 rows need a quick look"</b>. Everything else is silent.</div>
+
+        <div class="row spread" style="margin-bottom:8px">
+          <div>
+            <div style="font-family:'Caveat',cursive;font-size:22px;line-height:1">Transactions</div>
+            <div style="font-size:12px;color:var(--ink-3)">218 imported from Chase · 4s ago</div>
+          </div>
+          <div class="pills">
+            <span class="pill dashed">last 30 days</span>
+            <span class="pill dashed">all accts</span>
+          </div>
+        </div>
+
+        <div class="wf violet" style="margin-bottom:10px;padding:10px 14px">
+          <div class="row spread" style="margin:0">
+            <span><b style="color:var(--violet-deep)">6 rows need a quick look.</b> <span class="muted" style="font-size:12px">low-confidence guesses · click to review</span></span>
+            <span><span class="pill violet" style="font-size:11px">review now →</span> <span class="pill dashed" style="font-size:11px">later</span></span>
+          </div>
+        </div>
+
+        <div class="table" style="font-size:12px">
+          <div class="tr head" style="grid-template-columns:0.7fr 1.6fr 0.9fr 0.7fr 0.9fr"><span>Date</span><span>Payee</span><span>Category</span><span></span><span class="amt">Amount</span></div>
+          <div class="tr" style="grid-template-columns:0.7fr 1.6fr 0.9fr 0.7fr 0.9fr;background:var(--violet-soft)">
+            <span>Aug 14</span><span>SQ *TRINITY CAF</span>
+            <span><span class="pill violet" style="font-size:11px">Dining?</span></span>
+            <span><span class="pill" style="font-size:10px;color:var(--warn);border-color:var(--warn)">low</span></span>
+            <span class="amt neg">−$ 18.40</span>
+          </div>
+          <div class="tr" style="grid-template-columns:0.7fr 1.6fr 0.9fr 0.7fr 0.9fr">
+            <span>Aug 14</span><span>Whole Foods Market</span>
+            <span><span class="pill" style="font-size:11px">Groceries</span></span>
+            <span></span>
+            <span class="amt neg">−$ 112.40</span>
+          </div>
+          <div class="tr" style="grid-template-columns:0.7fr 1.6fr 0.9fr 0.7fr 0.9fr">
+            <span>Aug 14</span><span>Uber · trip 24m</span>
+            <span><span class="pill" style="font-size:11px">Transport</span></span>
+            <span></span>
+            <span class="amt neg">−$ 18.20</span>
+          </div>
+          <div class="tr" style="grid-template-columns:0.7fr 1.6fr 0.9fr 0.7fr 0.9fr">
+            <span>Aug 13</span><span>Direct dep · ACME Co</span>
+            <span><span class="pill" style="font-size:11px">Income</span></span>
+            <span></span>
+            <span class="amt pos">+$ 3,200.00</span>
+          </div>
+        </div>
+        <div class="note">99% of rows render normally · the 6 unconfident ones get a tinted bg and a "?" suffix on the category</div>
+      </div>
+
+      <div class="sketch">
+        <span class="num">A2</span>
+        <h3>Review side-panel</h3>
+        <div class="role">Click the banner or any low-confidence row. Side panel walks them one at a time, with the model's top 3 guesses.</div>
+
+        <div style="border-left:3px solid var(--violet);padding:10px 14px;background:var(--paper-2);border-radius:0 8px 8px 0">
+          <div style="font-family:'Caveat',cursive;font-size:18px;color:var(--violet-deep);line-height:1">3 of 6</div>
+          <div style="font-size:14px;font-weight:700;margin:4px 0">SQ *TRINITY CAF</div>
+          <div style="font-size:12px;color:var(--ink-3);margin-bottom:10px">Aug 14 · Chase ··4119 · −$18.40</div>
+
+          <div style="font-family:'Caveat',cursive;font-size:14px;color:var(--ink-3);margin-bottom:4px">model's guesses</div>
+          <div style="display:flex;flex-direction:column;gap:4px">
+            <div class="wf flat" style="padding:5px 10px;font-size:12px;display:flex;justify-content:space-between"><span><b>Dining</b> · café keyword</span><span class="muted">52%</span></div>
+            <div class="wf flat" style="padding:5px 10px;font-size:12px;display:flex;justify-content:space-between"><span>Coffee</span><span class="muted">31%</span></div>
+            <div class="wf flat" style="padding:5px 10px;font-size:12px;display:flex;justify-content:space-between"><span>Groceries</span><span class="muted">11%</span></div>
+            <div class="wf flat dashed" style="padding:5px 10px;font-size:12px;color:var(--ink-3)">something else…</div>
+          </div>
+
+          <div class="row spread" style="margin-top:14px">
+            <span class="muted" style="font-size:11px"><span class="kbd">1</span>—<span class="kbd">4</span> &nbsp; <span class="kbd">→</span> next</span>
+            <span class="pill solid" style="font-size:11px">apply &amp; next →</span>
+          </div>
+
+          <div style="margin-top:10px;padding-top:8px;border-top:1px dashed var(--ink-4);font-size:11px;color:var(--ink-3)">
+            ☐ also apply to similar future transactions (creates a rule)
+          </div>
+        </div>
+        <div class="note">keyboard-first · 6 rows resolved in ~20 seconds</div>
+      </div>
+    </div>
+  </div>
+    <span class="sec-num">05</span>
+    <h2 class="sec-title">Manual import · CSV / PDF / photo</h2>
+    <p class="sec-sub">Two complementary moments — the <b>first drop</b> (what AI extracted, before commit) and the
+      <b>ongoing lifecycle</b> (re-imports, cross-account drops). Same dropzone underneath both.</p>
+  </div>
+
+
+  <div class="panel active" data-panel="mi-a">
+    <div class="var-row">
+      <div class="sketch">
+        <span class="num">A1</span>
+        <h3>Just dropped a file</h3>
+        <div class="role">Same modal — but the dropzone now shows what was extracted, in editable rows.</div>
+
+        <div class="row spread" style="margin-bottom:8px">
+          <div>
+            <div style="font-family:'Caveat',cursive;font-size:22px;line-height:1">extracted from chase-aug.pdf</div>
+            <div style="font-size:12px;color:var(--ink-3)">218 rows · 4 columns mapped · 6 need attention</div>
+          </div>
+          <span class="pill violet" style="font-size:11px">AI parser</span>
+        </div>
+
+        <div class="table" style="font-size:12px">
+          <div class="tr head" style="grid-template-columns:0.7fr 1.8fr 1fr 0.9fr"><span>Date</span><span>Payee (from text)</span><span>Category guess</span><span class="amt">Amount</span></div>
+          <div class="tr" style="grid-template-columns:0.7fr 1.8fr 1fr 0.9fr"><span>Aug 14</span><span>WHOLE FOODS MKT #221</span><span><span class="pill" style="font-size:11px">Groceries</span></span><span class="amt neg">−$112.40</span></div>
+          <div class="tr" style="grid-template-columns:0.7fr 1.8fr 1fr 0.9fr"><span>Aug 14</span><span>UBER TRIP HELP.UBER</span><span><span class="pill" style="font-size:11px">Transport</span></span><span class="amt neg">−$18.20</span></div>
+          <div class="tr" style="grid-template-columns:0.7fr 1.8fr 1fr 0.9fr;background:var(--violet-soft)"><span>Aug 13</span><span>SQ *TRINITY CAF<span class="muted" style="font-size:10px"> · OCR</span></span><span><span class="pill violet" style="font-size:11px">Dining?</span></span><span class="amt neg">−$18.40</span></div>
+          <div class="tr" style="grid-template-columns:0.7fr 1.8fr 1fr 0.9fr"><span>Aug 13</span><span>DIR DEP · ACME CO PAY</span><span><span class="pill" style="font-size:11px">Income</span></span><span class="amt pos">+$3,200.00</span></div>
+        </div>
+
+        <div class="row" style="margin-top:10px;gap:8px">
+          <div class="wf flat" style="font-size:12px">
+            <span class="label">column mapping</span>
+            date col 1 · payee col 2 · amount col 4 · sign from col 3
+          </div>
+          <div class="wf flat violet" style="font-size:12px">
+            <span class="label" style="color:var(--violet-deep)">parser confidence</span>
+            high overall · 6 ambiguous rows highlighted
+          </div>
+        </div>
+
+        <div class="row spread" style="margin-top:10px">
+          <span class="muted" style="font-size:11px">file stays local. nothing uploaded.</span>
+          <span><span class="pill dashed">edit mapping</span> <span class="pill solid">import 218 rows →</span></span>
+        </div>
+        <div class="note">CSV, PDF, photo all converge here — same preview, same approval</div>
+      </div>
+
+      <div class="sketch">
+        <span class="num">A2</span>
+        <h3>Photo / screenshot path</h3>
+        <div class="role">Same extract screen, just sourced from a phone photo of a paper statement. AI labels what it saw; user accepts.</div>
+        <div style="display:grid;grid-template-columns:0.9fr 1.1fr;gap:10px">
+          <div class="placeholder" style="height:200px;background-image:linear-gradient(135deg,transparent 49%,var(--ink-3) 49%,var(--ink-3) 51%,transparent 51%),linear-gradient(45deg,transparent 49%,var(--ink-3) 49%,var(--ink-3) 51%,transparent 51%);position:relative">
+            <span style="position:absolute;bottom:6px;left:8px;background:var(--paper);padding:2px 8px;border:1.5px solid var(--ink);border-radius:4px;font-family:'Caveat',cursive;font-size:14px">paper statement · iPhone photo</span>
+          </div>
+          <div>
+            <div class="wf flat" style="font-size:12px;line-height:1.6">
+              <span class="label">what AI saw</span>
+              <b>Citibank · Acct 4521</b><br/>
+              Statement period: <b>Aug 1 – Aug 31</b><br/>
+              <b>14 transactions</b> · all USD<br/>
+              ending balance <b>$2,140.12</b>
+            </div>
+            <div class="wf flat violet" style="font-size:12px;margin-top:6px">
+              <span class="label" style="color:var(--violet-deep)">parser found 2 blurry rows</span>
+              You'll be asked to confirm those 2 rows before import.
+            </div>
+            <span class="pill solid" style="margin-top:8px;display:inline-block;font-size:11px">review 2 blurry rows →</span>
+          </div>
+        </div>
+        <div class="note">we never claim 100% accuracy on photos · user-confirmable rows ride next to the image</div>
+      </div>
+    </div>
+  </div>
+
+  <div class="panel active" data-panel="mi-b">
+    <div class="var-row">
+      <div class="sketch">
+        <span class="num">B1</span>
+        <h3>Existing manual account · add more transactions</h3>
+        <div class="role">Once a manual account exists, "add transactions" lives on the account detail page itself. No global "Import" route.</div>
+
+        <div style="font-family:'Caveat',cursive;font-size:22px;line-height:1">Ledger BTC</div>
+        <div style="font-size:12px;color:var(--ink-3);margin-bottom:10px">Manual · last updated 12d ago</div>
+
+        <div class="row">
+          <div class="stat"><div class="e">balance</div><div class="v">0.05123 BTC</div><div class="d">≈ $5,341</div></div>
+          <div class="stat"><div class="e">rows</div><div class="v">42</div><div class="d">+18 last import</div></div>
+          <div class="stat"><div class="e">last import</div><div class="v" style="font-size:16px">Aug 2 · CSV</div><div class="d muted">14 rows · ok</div></div>
+        </div>
+
+        <div class="drop" style="margin-top:14px;padding:18px">
+          + add transactions
+          <small>drop another CSV / PDF / photo · or type one in</small>
+        </div>
+
+        <div class="wf flat" style="margin-top:10px;font-size:12px">
+          <span class="label">import history</span>
+          aug 2 — ledger-export.csv · 18 rows · <span style="color:var(--pos)">ok</span><br/>
+          jul 1 — ledger-export.csv · 14 rows · <span style="color:var(--pos)">ok</span><br/>
+          jun 3 — wallet-photo.jpg · 10 rows · <span style="color:var(--pos)">ok</span>
+        </div>
+        <div class="note">"Import" as a sidebar route is killed — adding more lives where the account does</div>
+      </div>
+
+      <div class="sketch">
+        <span class="num">B2</span>
+        <h3>Cross-account drop</h3>
+        <div class="role">User drags a random CSV onto the app from anywhere. App offers to assign it to an existing account, or create a new one.</div>
+
+        <div style="border:2px dashed var(--violet);background:var(--violet-soft);border-radius:10px;padding:18px">
+          <div style="font-family:'Caveat',cursive;font-size:22px;color:var(--violet-deep);line-height:1.1">dropped <b>chase-sep.csv</b></div>
+          <div style="font-size:12px;color:var(--ink-2);margin-top:4px">218 rows · looks like Chase format · which account?</div>
+
+          <div style="margin-top:14px;display:flex;flex-direction:column;gap:6px">
+            <div class="wf" style="background:var(--paper);display:flex;justify-content:space-between"><span>🏦 <b>Chase Checking</b> ··4119 <span class="muted" style="font-size:11px">· already linked via Plaid</span></span><span class="pill dashed" style="font-size:11px">add</span></div>
+            <div class="wf" style="background:var(--paper);display:flex;justify-content:space-between"><span>🏦 Chase Savings ··2308</span><span class="pill dashed" style="font-size:11px">add</span></div>
+            <div class="wf dashed" style="background:transparent;display:flex;justify-content:space-between"><span>+ create new account from this file</span><span class="pill dashed" style="font-size:11px">new</span></div>
+          </div>
+
+          <div class="annotate" style="margin-top:10px;color:var(--violet-deep)">
+            ⚠ if you add to an account that's also Plaid-linked, we'll de-dupe by date + amount + payee
+          </div>
+        </div>
+        <div class="note">manual + Plaid coexist on the same account · de-dupe is the only place they touch</div>
+      </div>
+    </div>
+  </div>
+
+  <!-- ─────────── 06 · REVIEW / INSIGHTS ─────────── -->
+  <div class="sec-head">
+    <span class="sec-num">06</span>
+    <h2 class="sec-title">Insights · the review page</h2>
+    <p class="sec-sub">One page — net worth + asset/investment allocation + spending categories + trend.
+      Plus the <b>Budgets</b> and <b>Goals</b> widgets that fell out of v5's draft. They each still own a full page; this is the at-a-glance row.</p>
+  </div>
+
+
+  <div class="panel active" data-panel="rev-a">
+    <div class="sketch">
+      <span class="num">A</span>
+      <h3>Insights · single page, five bands</h3>
+      <div class="role">Net worth at the top (the headline) · allocation · spending categories · <b>budgets</b> &amp; <b>goals</b> · then the account list. Scrolls.</div>
+
+      <!-- Band 1: Net worth headline -->
+      <div class="wf" style="margin-bottom:10px">
+        <div class="row spread" style="margin:0">
+          <div>
+            <span class="label">net worth · as of today</span>
+            <div style="font-family:'Kalam',cursive;font-weight:700;font-size:36px;line-height:1">$142,308</div>
+            <div style="font-size:13px;color:var(--pos)">+ $2,140 this month · + $18,420 ytd</div>
+          </div>
+          <div style="flex:1.6">
+            <div class="squiggle-line"></div>
+            <div style="display:flex;justify-content:space-between;font-size:11px;color:var(--ink-3);margin-top:2px"><span>Aug '25</span><span>now</span></div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Band 2: Allocation -->
+      <div class="row" style="margin-bottom:10px">
+        <div class="wf" style="flex:1.2">
+          <span class="label">asset allocation</span>
+          <div style="display:flex;gap:14px;align-items:center;margin-top:6px">
+            <div style="position:relative;width:130px;height:130px">
+              <div class="donut"></div>
+              <div class="center" style="position:absolute;inset:22px;display:grid;place-items:center;text-align:center"><div><div style="font-size:16px">$142k</div><small>total</small></div></div>
+            </div>
+            <div class="legend-dots" style="flex:1">
+              <div><span class="dot d-ink"></span>Cash &amp; HYSA<span style="float:right">38%</span></div>
+              <div><span class="dot d-violet"></span>Stocks &amp; ETFs<span style="float:right">24%</span></div>
+              <div><span class="dot d-accent"></span>Retirement<span style="float:right">18%</span></div>
+              <div><span class="dot d-warn"></span>Crypto<span style="float:right">12%</span></div>
+              <div><span class="dot d-mute"></span>Property &amp; other<span style="float:right">8%</span></div>
+            </div>
+          </div>
+        </div>
+
+        <div class="wf" style="flex:1.4">
+          <span class="label">investment breakdown</span>
+          <div class="bar-row"><div class="name">VTI</div><div class="bar violet" style="--p:48%"></div><div class="pct">$40,344</div></div>
+          <div class="bar-row"><div class="name">NVDA</div><div class="bar violet" style="--p:20%"></div><div class="pct">$17,147</div></div>
+          <div class="bar-row"><div class="name">ETH</div><div class="bar violet" style="--p:13%"></div><div class="pct">$10,750</div></div>
+          <div class="bar-row"><div class="name">BTC</div><div class="bar violet" style="--p:6%"></div><div class="pct">$5,341</div></div>
+          <div class="bar-row"><div class="name">other</div><div class="bar violet" style="--p:13%"></div><div class="pct">$11,319</div></div>
+        </div>
+      </div>
+
+      <!-- Band 3: Spending -->
+      <div class="row" style="margin-bottom:10px">
+        <div class="wf" style="flex:1">
+          <span class="label">spending by category · this month</span>
+          <div class="bar-row"><div class="name">Housing</div><div class="bar" style="--p:65%"></div><div class="pct">$2,100</div></div>
+          <div class="bar-row"><div class="name">Groceries</div><div class="bar" style="--p:62%"></div><div class="pct">$310</div></div>
+          <div class="bar-row"><div class="name">Dining</div><div class="bar warn" style="--p:55%"></div><div class="pct">$188 <span class="muted">↑ vs avg</span></div></div>
+          <div class="bar-row"><div class="name">Transport</div><div class="bar over"></div><div class="pct">$272 <span style="color:var(--neg)">over avg</span></div></div>
+          <div class="bar-row"><div class="name">Subscriptions</div><div class="bar" style="--p:18%"></div><div class="pct">$62</div></div>
+          <div class="bar-row"><div class="name">Misc</div><div class="bar" style="--p:9%"></div><div class="pct">$32</div></div>
+        </div>
+        <div class="wf" style="flex:1">
+          <span class="label">vs. 6-month average</span>
+          <div style="font-family:'Kalam',cursive;font-weight:700;font-size:24px;line-height:1.1">$ 3,217<span style="font-size:13px;color:var(--ink-3)"> spent this mo</span></div>
+          <div style="font-size:12px;color:var(--neg);margin-bottom:8px">+ $ 420 vs. 6mo avg of $2,797</div>
+          <div class="squiggle-line spark"></div>
+          <div style="display:flex;justify-content:space-between;font-size:11px;color:var(--ink-3);margin-top:2px"><span>Mar</span><span>Aug</span></div>
+          <div class="note" style="margin-top:6px">click any category → drills into the matching txns</div>
+        </div>
+      </div>
+
+      <!-- Band 4: Budgets + Goals (the v5 omission) -->
+      <div class="row" style="margin-bottom:10px">
+        <div class="wf" style="flex:1">
+          <div class="row spread" style="margin:0">
+            <span class="label">budgets · this month</span>
+            <a class="pill dashed" style="font-size:11px;text-decoration:none">full page →</a>
+          </div>
+          <div class="bar-row"><div class="name">Groceries</div><div class="bar" style="--p:62%"></div><div class="pct">$310 / $500</div></div>
+          <div class="bar-row"><div class="name">Dining</div><div class="bar warn" style="--p:94%"></div><div class="pct">$188 / $200 <span class="muted">↑</span></div></div>
+          <div class="bar-row"><div class="name">Transport</div><div class="bar over"></div><div class="pct" style="color:var(--neg)">$272 / $200</div></div>
+          <div class="bar-row"><div class="name">Subscriptions</div><div class="bar" style="--p:62%"></div><div class="pct">$62 / $100</div></div>
+          <div class="bar-row"><div class="name">Misc</div><div class="bar" style="--p:32%"></div><div class="pct">$32 / $100</div></div>
+          <div style="font-size:11px;color:var(--ink-3);margin-top:6px;text-align:right">$ 864 of $1,100 envelopes · <span style="color:var(--neg)">1 over</span></div>
+        </div>
+
+        <div class="wf" style="flex:1">
+          <div class="row spread" style="margin:0">
+            <span class="label">savings goals</span>
+            <a class="pill dashed" style="font-size:11px;text-decoration:none">full page →</a>
+          </div>
+          <div style="display:flex;flex-direction:column;gap:6px;margin-top:4px">
+            <div>
+              <div class="row spread" style="margin-bottom:2px;font-size:12px"><span>🏠 House down-payment</span><span class="muted">$18.4k / $40k</span></div>
+              <div class="bar" style="--p:46%;height:8px;border:1.5px solid var(--line);border-radius:4px;background:var(--paper-2);position:relative;overflow:hidden"></div>
+              <div style="font-size:10px;color:var(--ink-3);margin-top:2px">on track · Mar '27 at this pace</div>
+            </div>
+            <div>
+              <div class="row spread" style="margin-bottom:2px;font-size:12px"><span>✈ Japan trip</span><span class="muted">$2.1k / $5k</span></div>
+              <div class="bar violet" style="--p:42%;height:8px;border:1.5px solid var(--line);border-radius:4px;background:var(--paper-2);position:relative;overflow:hidden"></div>
+              <div style="font-size:10px;color:var(--ink-3);margin-top:2px">slow · need + $240/mo to hit Apr '27</div>
+            </div>
+            <div>
+              <div class="row spread" style="margin-bottom:2px;font-size:12px"><span>🛟 Emergency fund</span><span class="muted">$11k / $12k</span></div>
+              <div class="bar" style="--p:92%;height:8px;border:1.5px solid var(--line);border-radius:4px;background:var(--paper-2);position:relative;overflow:hidden"></div>
+              <div style="font-size:10px;color:var(--pos);margin-top:2px">almost there · ~ 2 mo to go</div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Band 5: Account list summary -->
+      <div class="wf">
+        <span class="label">accounts feeding this</span>
+        <div class="table" style="font-size:12px">
+          <div class="tr head" style="grid-template-columns:1fr 1.2fr 0.8fr 0.9fr 0.9fr"><span>Account</span><span>Source</span><span>Last sync</span><span>Type</span><span class="amt">Balance</span></div>
+          <div class="tr" style="grid-template-columns:1fr 1.2fr 0.8fr 0.9fr 0.9fr"><span>Chase Checking</span><span><span class="pill" style="font-size:10px">Plaid</span></span><span class="muted">12s</span><span class="muted">checking</span><span class="amt">$ 8,204</span></div>
+          <div class="tr" style="grid-template-columns:1fr 1.2fr 0.8fr 0.9fr 0.9fr"><span>Ally HYSA</span><span><span class="pill" style="font-size:10px">Plaid</span></span><span class="muted">12s</span><span class="muted">savings</span><span class="amt">$ 24,000</span></div>
+          <div class="tr" style="grid-template-columns:1fr 1.2fr 0.8fr 0.9fr 0.9fr"><span>Schwab Brokerage</span><span><span class="pill" style="font-size:10px">Plaid</span></span><span class="muted">12s</span><span class="muted">invest</span><span class="amt">$ 84,901</span></div>
+          <div class="tr" style="grid-template-columns:1fr 1.2fr 0.8fr 0.9fr 0.9fr"><span>Ledger BTC</span><span><span class="pill violet" style="font-size:10px">Manual</span></span><span class="muted">12d</span><span class="muted">crypto</span><span class="amt">$ 5,341</span></div>
+          <div class="tr" style="grid-template-columns:1fr 1.2fr 0.8fr 0.9fr 0.9fr"><span>Property · 401(k)</span><span><span class="pill violet" style="font-size:10px">Manual</span></span><span class="muted">1mo</span><span class="muted">retire</span><span class="amt">$ 20,250</span></div>
+        </div>
+      </div>
+
+      <div class="note">one page answers it all · net worth · allocation · spending · budgets · goals — user scrolls top-to-bottom on their schedule</div>
+    </div>
+  </div>
+
+  <!-- ─────────── 07 · SITEMAP DELTA ─────────── -->
+  <div class="sec-head">
+    <span class="sec-num">07</span>
+    <h2 class="sec-title">Sitemap delta · what changes from v4</h2>
+    <p class="sec-sub">Just the personal scope. Household scope is unaffected.
+      Three routes leave, one gets renamed, nothing else moves.</p>
+  </div>
+
+  <div class="delta">
+    <div class="col before">
+      <h4>before · v4</h4>
+      <div class="delta-route">Dashboard <span class="tag">snapshot</span></div>
+      <div class="delta-route">Accounts <span class="tag">+ connect bank</span></div>
+      <div class="delta-route">Transactions <span class="tag">categorize</span></div>
+      <div class="delta-route">Budgets <span class="tag">envelopes</span></div>
+      <div class="delta-route">Savings Goals <span class="tag">cards</span></div>
+      <div class="delta-route">Investments <span class="tag">holdings</span></div>
+      <div class="delta-route removed">Import <span class="tag">CSV · OFX</span></div>
+      <div class="delta-route removed">AI Advisor <span class="tag">deferred — not v6</span></div>
+      <div class="delta-route">Settings <span class="tag">profile · keys</span></div>
+    </div>
+    <div class="col after">
+      <h4>after · v6</h4>
+      <div class="delta-route violet">Insights <span class="tag">net worth + alloc + spend (was Dashboard)</span></div>
+      <div class="delta-route">Accounts <span class="tag">+ add account (Plaid OR manual)</span></div>
+      <div class="delta-route">Transactions <span class="tag">categorize · needs-review filter</span></div>
+      <div class="delta-route">Budgets <span class="tag">unchanged</span></div>
+      <div class="delta-route">Savings Goals <span class="tag">unchanged</span></div>
+      <div class="delta-route">Investments <span class="tag">unchanged</span></div>
+      <div class="delta-route">Settings <span class="tag">profile · AI provider lives here once</span></div>
+      <div style="margin-top:14px;padding-top:10px;border-top:1.5px dashed var(--ink-4);font-size:12px;line-height:1.5;color:var(--ink-2)">
+        <b>Killed:</b> Import as a top-level route — folded into Add Account + each account's own "add more" affordance.<br/>
+        <b>Deferred:</b> AI Advisor / chat — not in v6. Reconsider later as a side-panel on any page, never as a sidebar route.<br/>
+        <b>Renamed:</b> Dashboard → Insights — it's a read-only review surface; "Dashboard" implied a place to act.
+      </div>
+    </div>
+  </div>
+
+  <div class="row" style="margin-top:14px;gap:14px">
+    <div class="wf flat violet">
+      <span class="label">why kill "Import"</span>
+      It duplicated "+ Add account". Now: first-time CSV/PDF/photo lives in
+      Add Account; subsequent drops live on each account's own page.
+    </div>
+    <div class="wf flat violet">
+      <span class="label">why defer AI Advisor</span>
+      You said chat can come later. Provider choice lives once in Settings; no chat surface in v6.
+      Easy to add later as a side-panel on any page.
+    </div>
+    <div class="wf flat">
+      <span class="label">why rename Dashboard → Insights</span>
+      "Dashboard" implied "place to act". The review surface is read-only.
+      "Insights" sets that expectation.
+    </div>
+  </div>
+
+  <!-- ─────────── FOOTER ─────────── -->
+  <div class="footer">
+    <div>
+      <b>v6 locked decisions →</b><br/>
+      <span style="color:var(--ink-2)">
+        1. <b>Add account</b> — two tiles up front · "connect bank" hands to the <b>Plaid native picker</b> · dismissing it offers manual as fallback.<br/>
+        2. <b>Auto-categorize</b> — banner + filter · silent on confident rows.<br/>
+        3. <b>Manual import</b> — lives inside Add Account and each account's detail page · no top-level Import route.<br/>
+        4. <b>Review</b> — one Insights page with <b>5 bands</b>: net worth · allocation · spending · budgets · goals.<br/>
+        5. <b>AI chat</b> — deferred. Provider config in Settings only.
+      </span>
+    </div>
+    <div class="right">
+      shipping the hi-fi pass next.<br/>
+      → Plaid hand-off is the only critical edge.
+    </div>
+  </div>
+
+</div>
+
+<script>
+  // Simple tab switcher per group
+  document.querySelectorAll('.tabs[data-group]').forEach(function(group){
+    var tabs = group.querySelectorAll('.tab');
+    tabs.forEach(function(tab){
+      tab.addEventListener('click', function(){
+        var name = tab.getAttribute('data-tab');
+        tabs.forEach(function(t){ t.classList.remove('active'); });
+        tab.classList.add('active');
+        // panels are siblings AFTER the group
+        var n = group.nextElementSibling;
+        while(n){
+          if(n.matches && n.matches('.panel[data-panel]')){
+            n.classList.toggle('active', n.getAttribute('data-panel') === name);
+          }
+          // stop at next .tabs[data-group] or .sec-head
+          if(n.matches && (n.matches('.tabs[data-group]') || n.matches('.sec-head'))) break;
+          n = n.nextElementSibling;
+        }
+      });
+    });
+  });
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Adds `docs/designs/App Hierarchy v6.html` (the locked direction).
- Rewrites the M9 section in `docs/ROADMAP.md` from a deferred placeholder into a concrete plan tied to issues #224–#229.
- Documents the consolidation principle: household pages reuse the same components as personal — scope swaps the data source.
- Flags an open question for the household AI surface (`/h/ai`) since v6 only addresses personal AI.

Loose end: this is meta-work for M9, attached to #224 (the foundation issue) so the branch passes the naming hook. Does not close #224.

## Test plan
- [ ] Skim the roadmap diff and the v6 design doc render on GitHub.