### PR TITLE
M10 Phase 1: position model foundation tables + backfill

### DIFF
--- a/backend/internal/db/migration_backfill_test.go
+++ b/backend/internal/db/migration_backfill_test.go
@@ -1,0 +1,272 @@
+package db_test
+
+import (
+	"context"
+	"database/sql"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	_ "github.com/lib/pq"
+)
+
+// TestMigration000013_PositionModelBackfill verifies the ADR-0013 Phase 1
+// migration (#231):
+//   - new tables (assets, positions, prices) are created and the seed
+//     fiat/crypto assets are present
+//   - users.primary_currency_asset_id and accounts.primary_quote_asset_id
+//     are populated for every pre-existing row
+//   - positions are backfilled correctly:
+//   - cash-type accounts produce one position (asset = currency, qty = balance)
+//   - investment accounts with snapshots produce one position per ticker
+//     using the LATEST snapshot's quantity + cost_basis
+//   - investment accounts without snapshots fall back to a single cash-blob
+//   - prices are backfilled from every historical investments snapshot
+//   - transactions table is untouched (the app never invents transactions)
+//   - the auto-populate triggers on accounts/users fire correctly when a
+//     new row is inserted post-migration without the FK columns set
+func TestMigration000013_PositionModelBackfill(t *testing.T) {
+	loadRepoDotenv(t)
+	baseURL := os.Getenv("TEST_DATABASE_URL")
+	if baseURL == "" {
+		baseURL = os.Getenv("DATABASE_URL")
+	}
+	if baseURL == "" {
+		t.Skip("no DATABASE_URL set; skipping migration backfill test")
+	}
+
+	migrationsPath, err := filepath.Abs(filepath.Join("..", "..", "migrations"))
+	if err != nil {
+		t.Fatalf("resolve migrations path: %v", err)
+	}
+
+	ephemeral, cleanup := createEphemeralDB(t, baseURL)
+	defer cleanup()
+
+	m, closeFn := newMigrator(t, ephemeral, migrationsPath)
+	defer closeFn()
+
+	// 1. Bring schema up to N-1 (= 12). The position-model migration is 13.
+	mustMigrateTo(t, m, 12)
+
+	conn, err := sql.Open("postgres", ephemeral)
+	if err != nil {
+		t.Fatalf("open ephemeral: %v", err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// 2. Seed fixture rows. Mirrors a typical post-M6 state: one user with
+	//    a cash account, an investment account holding two snapshots of one
+	//    ticker, and a Plaid-style investment account with NO snapshots (so
+	//    the fallback cash-blob backfill kicks in).
+	var userID int64
+	if err := conn.QueryRowContext(ctx, `
+		INSERT INTO users (email, password_hash, last_scope, default_scope)
+		VALUES ('m13-test@example.com', 'x', 'personal', 'personal')
+		RETURNING id`).Scan(&userID); err != nil {
+		t.Fatalf("seed user: %v", err)
+	}
+
+	var checkingID int64
+	if err := conn.QueryRowContext(ctx, `
+		INSERT INTO accounts (user_id, name, institution_slug, account_type, currency, balance)
+		VALUES ($1, 'fixture-checking', 'fix', 'checking', 'USD', 1000.00)
+		RETURNING id`, userID).Scan(&checkingID); err != nil {
+		t.Fatalf("seed checking: %v", err)
+	}
+
+	var brokerageWithHoldingsID int64
+	if err := conn.QueryRowContext(ctx, `
+		INSERT INTO accounts (user_id, name, institution_slug, account_type, currency, balance)
+		VALUES ($1, 'fixture-brokerage', 'fix', 'investment', 'USD', 1820.00)
+		RETURNING id`, userID).Scan(&brokerageWithHoldingsID); err != nil {
+		t.Fatalf("seed brokerage: %v", err)
+	}
+
+	var brokerageNoHoldingsID int64
+	if err := conn.QueryRowContext(ctx, `
+		INSERT INTO accounts (user_id, name, institution_slug, account_type, currency, balance)
+		VALUES ($1, 'fixture-plaid-only', 'fix', 'investment', 'USD', 50000.00)
+		RETURNING id`, userID).Scan(&brokerageNoHoldingsID); err != nil {
+		t.Fatalf("seed plaid-only brokerage: %v", err)
+	}
+
+	// Two AAPL snapshots: older at $170, newer at $182. Latest qty=10.
+	if _, err := conn.ExecContext(ctx, `
+		INSERT INTO investments
+		  (user_id, account_id, ticker, name, asset_class, quantity, cost_basis, market_value, snapshot_date, source)
+		VALUES
+		  ($1, $2, 'AAPL', 'Apple Inc.', 'equity', 10,   1500, 1700, '2025-01-15', 'csv'),
+		  ($1, $2, 'AAPL', 'Apple Inc.', 'equity', 10,   1500, 1820, '2025-05-15', 'csv')`,
+		userID, brokerageWithHoldingsID); err != nil {
+		t.Fatalf("seed investments: %v", err)
+	}
+
+	txCountBefore := scalarInt(t, conn, "SELECT COUNT(*) FROM transactions")
+
+	// 3. Apply migration 13.
+	mustMigrateTo(t, m, 13)
+
+	// 4. Assertions.
+
+	// 4a. Seed assets are present.
+	for _, sym := range []string{"USD", "EUR", "BTC", "ETH"} {
+		var id int64
+		if err := conn.QueryRowContext(ctx,
+			`SELECT id FROM assets WHERE symbol = $1 AND kind IN ('fiat','crypto') LIMIT 1`, sym).Scan(&id); err != nil {
+			t.Errorf("seed asset %s not present: %v", sym, err)
+		}
+	}
+
+	// AAPL was added via the investments backfill, classified as equity.
+	var aaplID int64
+	if err := conn.QueryRowContext(ctx,
+		`SELECT id FROM assets WHERE symbol = 'AAPL' AND kind = 'equity'`).Scan(&aaplID); err != nil {
+		t.Fatalf("AAPL asset not created: %v", err)
+	}
+
+	// 4b. users.primary_currency_asset_id populated for the pre-existing user.
+	var pcid sql.NullInt64
+	if err := conn.QueryRowContext(ctx,
+		`SELECT primary_currency_asset_id FROM users WHERE id = $1`, userID).Scan(&pcid); err != nil {
+		t.Fatalf("read user primary_currency_asset_id: %v", err)
+	}
+	if !pcid.Valid {
+		t.Errorf("user primary_currency_asset_id is NULL after migration")
+	}
+
+	// 4c. accounts.primary_quote_asset_id populated for every account.
+	for _, id := range []int64{checkingID, brokerageWithHoldingsID, brokerageNoHoldingsID} {
+		var pqaid sql.NullInt64
+		if err := conn.QueryRowContext(ctx,
+			`SELECT primary_quote_asset_id FROM accounts WHERE id = $1`, id).Scan(&pqaid); err != nil {
+			t.Fatalf("read account %d primary_quote_asset_id: %v", id, err)
+		}
+		if !pqaid.Valid {
+			t.Errorf("account %d primary_quote_asset_id is NULL after migration", id)
+		}
+	}
+
+	// 4d. positions: checking has 1 USD position with qty 1000.
+	checkingPositions := listPositions(t, conn, ctx, checkingID)
+	if len(checkingPositions) != 1 {
+		t.Errorf("checking: want 1 position, got %d", len(checkingPositions))
+	} else if checkingPositions[0].quantity != "1000.000000000000000000" {
+		t.Errorf("checking position qty = %q, want 1000.000000000000000000", checkingPositions[0].quantity)
+	}
+
+	// 4e. brokerage with holdings: 1 AAPL position with qty 10 (from the
+	//     LATEST snapshot — not summed across snapshots).
+	brokeragePositions := listPositions(t, conn, ctx, brokerageWithHoldingsID)
+	if len(brokeragePositions) != 1 {
+		t.Errorf("brokerage-w-holdings: want 1 position, got %d", len(brokeragePositions))
+	} else {
+		if brokeragePositions[0].assetID != aaplID {
+			t.Errorf("brokerage position asset_id = %d, want %d (AAPL)", brokeragePositions[0].assetID, aaplID)
+		}
+		if brokeragePositions[0].quantity != "10.000000000000000000" {
+			t.Errorf("brokerage position qty = %q, want 10", brokeragePositions[0].quantity)
+		}
+	}
+
+	// 4f. brokerage WITHOUT holdings: falls back to a cash-blob USD position
+	//     so the account still has value representable in the new model.
+	fallbackPositions := listPositions(t, conn, ctx, brokerageNoHoldingsID)
+	if len(fallbackPositions) != 1 {
+		t.Errorf("brokerage-no-holdings: want 1 fallback position, got %d", len(fallbackPositions))
+	} else if fallbackPositions[0].quantity != "50000.000000000000000000" {
+		t.Errorf("fallback position qty = %q, want 50000", fallbackPositions[0].quantity)
+	}
+
+	// 4g. prices: 2 rows for AAPL (one per snapshot).
+	var aaplPriceCount int
+	if err := conn.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM prices WHERE asset_id = $1`, aaplID).Scan(&aaplPriceCount); err != nil {
+		t.Fatalf("count AAPL prices: %v", err)
+	}
+	if aaplPriceCount != 2 {
+		t.Errorf("AAPL price rows = %d, want 2 (one per snapshot)", aaplPriceCount)
+	}
+
+	// 4h. transactions table untouched.
+	txCountAfter := scalarInt(t, conn, "SELECT COUNT(*) FROM transactions")
+	if txCountAfter != txCountBefore {
+		t.Errorf("transactions row count changed: before=%d after=%d (the app must not invent transactions)",
+			txCountBefore, txCountAfter)
+	}
+
+	// 4i. Triggers: insert a new account WITHOUT primary_quote_asset_id and
+	//     verify the trigger populated it. Same for users.
+	var triggerAcctID int64
+	if err := conn.QueryRowContext(ctx, `
+		INSERT INTO accounts (user_id, name, institution_slug, account_type, currency, balance)
+		VALUES ($1, 'trigger-check', 'fix', 'checking', 'EUR', 0)
+		RETURNING id`, userID).Scan(&triggerAcctID); err != nil {
+		t.Fatalf("insert trigger-check account: %v", err)
+	}
+	var triggerAcctPQAID sql.NullInt64
+	if err := conn.QueryRowContext(ctx,
+		`SELECT primary_quote_asset_id FROM accounts WHERE id = $1`, triggerAcctID).Scan(&triggerAcctPQAID); err != nil {
+		t.Fatalf("read trigger-check FK: %v", err)
+	}
+	if !triggerAcctPQAID.Valid {
+		t.Errorf("account trigger did not populate primary_quote_asset_id")
+	}
+
+	var triggerUserID int64
+	if err := conn.QueryRowContext(ctx, `
+		INSERT INTO users (email, password_hash, last_scope, default_scope)
+		VALUES ('m13-trigger@example.com', 'x', 'personal', 'personal')
+		RETURNING id`).Scan(&triggerUserID); err != nil {
+		t.Fatalf("insert trigger user: %v", err)
+	}
+	var triggerUserPCID sql.NullInt64
+	if err := conn.QueryRowContext(ctx,
+		`SELECT primary_currency_asset_id FROM users WHERE id = $1`, triggerUserID).Scan(&triggerUserPCID); err != nil {
+		t.Fatalf("read trigger user FK: %v", err)
+	}
+	if !triggerUserPCID.Valid {
+		t.Errorf("user trigger did not populate primary_currency_asset_id")
+	}
+}
+
+type positionRow struct {
+	assetID  int64
+	quantity string
+}
+
+func listPositions(t *testing.T, conn *sql.DB, ctx context.Context, accountID int64) []positionRow {
+	t.Helper()
+	rows, err := conn.QueryContext(ctx,
+		`SELECT asset_id, quantity::text FROM positions WHERE account_id = $1 AND deleted_at IS NULL ORDER BY id`,
+		accountID)
+	if err != nil {
+		t.Fatalf("list positions for account %d: %v", accountID, err)
+	}
+	defer func() { _ = rows.Close() }()
+	var out []positionRow
+	for rows.Next() {
+		var p positionRow
+		if err := rows.Scan(&p.assetID, &p.quantity); err != nil {
+			t.Fatalf("scan position: %v", err)
+		}
+		out = append(out, p)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("position rows.Err: %v", err)
+	}
+	return out
+}
+
+func scalarInt(t *testing.T, conn *sql.DB, q string) int {
+	t.Helper()
+	var n int
+	if err := conn.QueryRow(q).Scan(&n); err != nil {
+		t.Fatalf("scalarInt %q: %v", q, err)
+	}
+	return n
+}

--- a/backend/internal/model/account.go
+++ b/backend/internal/model/account.go
@@ -8,20 +8,21 @@ import (
 )
 
 type Account struct {
-	ID              int64           `gorm:"primaryKey" json:"id"`
-	UserID          int64           `gorm:"not null" json:"user_id"`
-	Name            string          `gorm:"not null" json:"name"`
-	InstitutionSlug string          `gorm:"not null" json:"institution_slug"`
-	AccountType     string          `gorm:"not null" json:"account_type"`
-	Currency        string          `gorm:"not null;default:USD" json:"currency"`
-	Balance         decimal.Decimal `gorm:"type:numeric(30,18);not null;default:0" json:"balance"`
-	LastFour        *string         `json:"last_four,omitempty"`
-	PlaidAccountID  *string         `gorm:"column:plaid_account_id" json:"plaid_account_id,omitempty"`
-	PlaidItemID     *string         `gorm:"column:plaid_item_id" json:"plaid_item_id,omitempty"`
-	IsActive        bool            `gorm:"not null;default:true" json:"is_active"`
-	CreatedAt       time.Time       `json:"created_at"`
-	UpdatedAt       time.Time       `json:"updated_at"`
-	DeletedAt       gorm.DeletedAt  `gorm:"index" json:"-"`
+	ID                  int64           `gorm:"primaryKey" json:"id"`
+	UserID              int64           `gorm:"not null" json:"user_id"`
+	Name                string          `gorm:"not null" json:"name"`
+	InstitutionSlug     string          `gorm:"not null" json:"institution_slug"`
+	AccountType         string          `gorm:"not null" json:"account_type"`
+	Currency            string          `gorm:"not null;default:USD" json:"currency"`
+	Balance             decimal.Decimal `gorm:"type:numeric(30,18);not null;default:0" json:"balance"`
+	PrimaryQuoteAssetID int64           `gorm:"column:primary_quote_asset_id;not null" json:"primary_quote_asset_id"`
+	LastFour            *string         `json:"last_four,omitempty"`
+	PlaidAccountID      *string         `gorm:"column:plaid_account_id" json:"plaid_account_id,omitempty"`
+	PlaidItemID         *string         `gorm:"column:plaid_item_id" json:"plaid_item_id,omitempty"`
+	IsActive            bool            `gorm:"not null;default:true" json:"is_active"`
+	CreatedAt           time.Time       `json:"created_at"`
+	UpdatedAt           time.Time       `json:"updated_at"`
+	DeletedAt           gorm.DeletedAt  `gorm:"index" json:"-"`
 }
 
 func (Account) TableName() string { return "accounts" }

--- a/backend/internal/model/asset.go
+++ b/backend/internal/model/asset.go
@@ -1,0 +1,31 @@
+package model
+
+import "time"
+
+const (
+	AssetKindFiat      = "fiat"
+	AssetKindEquity    = "equity"
+	AssetKindFund      = "fund"
+	AssetKindCrypto    = "crypto"
+	AssetKindBond      = "bond"
+	AssetKindCommodity = "commodity"
+	AssetKindOther     = "other"
+)
+
+// Asset is a unit of value tracked by the system. Fiat currencies (USD,
+// EUR), securities (AAPL, VTSAX), and crypto (BTC) all live here.
+//
+// QuoteCurrencyAssetID points at the fiat asset this asset is normally
+// priced in (e.g. AAPL → USD). NULL for fiat assets themselves.
+type Asset struct {
+	ID                   int64     `gorm:"primaryKey" json:"id"`
+	Symbol               string    `gorm:"not null" json:"symbol"`
+	Kind                 string    `gorm:"not null" json:"kind"`
+	DisplayName          *string   `json:"display_name,omitempty"`
+	QuoteCurrencyAssetID *int64    `gorm:"column:quote_currency_asset_id" json:"quote_currency_asset_id,omitempty"`
+	Precision            int16     `gorm:"not null;default:8" json:"precision"`
+	CreatedAt            time.Time `json:"created_at"`
+	UpdatedAt            time.Time `json:"updated_at"`
+}
+
+func (Asset) TableName() string { return "assets" }

--- a/backend/internal/model/position.go
+++ b/backend/internal/model/position.go
@@ -1,0 +1,28 @@
+package model
+
+import (
+	"time"
+
+	"github.com/shopspring/decimal"
+	"gorm.io/gorm"
+)
+
+// Position is the current (account × asset) holding. Quantity is the fact;
+// market value derives from quantity × the latest price for asset_id in the
+// user's primary currency.
+//
+// CostBasis is the running average-cost basis in the user's primary
+// currency. NULL when unknown (e.g. positions backfilled from holdings
+// snapshots that didn't carry cost basis).
+type Position struct {
+	ID        int64            `gorm:"primaryKey" json:"id"`
+	UserID    int64            `gorm:"not null" json:"user_id"`
+	AccountID int64            `gorm:"not null" json:"account_id"`
+	AssetID   int64            `gorm:"not null" json:"asset_id"`
+	Quantity  decimal.Decimal  `gorm:"type:numeric(30,18);not null" json:"quantity"`
+	CostBasis *decimal.Decimal `gorm:"type:numeric(30,18)" json:"cost_basis,omitempty"`
+	UpdatedAt time.Time        `json:"updated_at"`
+	DeletedAt gorm.DeletedAt   `gorm:"index" json:"-"`
+}
+
+func (Position) TableName() string { return "positions" }

--- a/backend/internal/model/price.go
+++ b/backend/internal/model/price.go
@@ -1,0 +1,23 @@
+package model
+
+import (
+	"time"
+
+	"github.com/shopspring/decimal"
+)
+
+// Price is one observation of (asset, quote_asset, as_of, price). Append-only.
+// Source identifies where the observation came from — 'plaid', 'manual',
+// 'historical_snapshot' (from the M6 investments backfill), and later
+// 'yahoo'/'ecb'/'coingecko' when the Tier-3 provider lands (ADR-0014).
+type Price struct {
+	ID           int64           `gorm:"primaryKey" json:"id"`
+	AssetID      int64           `gorm:"not null" json:"asset_id"`
+	QuoteAssetID int64           `gorm:"column:quote_asset_id;not null" json:"quote_asset_id"`
+	AsOf         time.Time       `gorm:"not null" json:"as_of"`
+	Price        decimal.Decimal `gorm:"type:numeric(30,18);not null" json:"price"`
+	Source       string          `gorm:"not null" json:"source"`
+	CreatedAt    time.Time       `json:"created_at"`
+}
+
+func (Price) TableName() string { return "prices" }

--- a/backend/internal/model/user.go
+++ b/backend/internal/model/user.go
@@ -13,15 +13,16 @@ const (
 )
 
 type User struct {
-	ID           int64          `gorm:"primaryKey" json:"id"`
-	Email        string         `gorm:"not null" json:"email"`
-	PasswordHash string         `gorm:"not null" json:"-"`
-	IsAdmin      bool           `gorm:"not null;default:false" json:"is_admin"`
-	LastScope    string         `gorm:"not null;default:personal" json:"last_scope"`
-	DefaultScope string         `gorm:"not null;default:personal" json:"default_scope"`
-	CreatedAt    time.Time      `json:"created_at"`
-	UpdatedAt    time.Time      `json:"updated_at"`
-	DeletedAt    gorm.DeletedAt `gorm:"index" json:"-"`
+	ID                     int64          `gorm:"primaryKey" json:"id"`
+	Email                  string         `gorm:"not null" json:"email"`
+	PasswordHash           string         `gorm:"not null" json:"-"`
+	IsAdmin                bool           `gorm:"not null;default:false" json:"is_admin"`
+	LastScope              string         `gorm:"not null;default:personal" json:"last_scope"`
+	DefaultScope           string         `gorm:"not null;default:personal" json:"default_scope"`
+	PrimaryCurrencyAssetID int64          `gorm:"column:primary_currency_asset_id;not null" json:"primary_currency_asset_id"`
+	CreatedAt              time.Time      `json:"created_at"`
+	UpdatedAt              time.Time      `json:"updated_at"`
+	DeletedAt              gorm.DeletedAt `gorm:"index" json:"-"`
 }
 
 func (User) TableName() string { return "users" }

--- a/backend/internal/repository/asset_repo.go
+++ b/backend/internal/repository/asset_repo.go
@@ -1,0 +1,63 @@
+package repository
+
+import (
+	"context"
+	"errors"
+
+	"github.com/gregwym/offbook/backend/internal/model"
+	"gorm.io/gorm"
+)
+
+// AssetRepository is the read interface for the assets reference table.
+// Assets are global (not user-scoped) — they describe units of value
+// (USD, AAPL, BTC), not anyone's holdings. Phase 1 of ADR-0013 exposes
+// only the lookups the rest of the system needs; write paths land in
+// Phase 2 once services start consuming positions/prices.
+type AssetRepository interface {
+	GetByID(ctx context.Context, id int64) (*model.Asset, error)
+	GetBySymbolKind(ctx context.Context, symbol, kind string) (*model.Asset, error)
+	ListByKind(ctx context.Context, kind string) ([]model.Asset, error)
+}
+
+type assetRepo struct {
+	db *gorm.DB
+}
+
+func NewAssetRepository(db *gorm.DB) AssetRepository {
+	return &assetRepo{db: db}
+}
+
+func (r *assetRepo) GetByID(ctx context.Context, id int64) (*model.Asset, error) {
+	var a model.Asset
+	if err := r.db.WithContext(ctx).First(&a, id).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, ErrNotFound
+		}
+		return nil, err
+	}
+	return &a, nil
+}
+
+func (r *assetRepo) GetBySymbolKind(ctx context.Context, symbol, kind string) (*model.Asset, error) {
+	var a model.Asset
+	if err := r.db.WithContext(ctx).
+		Where("symbol = ? AND kind = ?", symbol, kind).
+		First(&a).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, ErrNotFound
+		}
+		return nil, err
+	}
+	return &a, nil
+}
+
+func (r *assetRepo) ListByKind(ctx context.Context, kind string) ([]model.Asset, error) {
+	var rows []model.Asset
+	if err := r.db.WithContext(ctx).
+		Where("kind = ?", kind).
+		Order("symbol").
+		Find(&rows).Error; err != nil {
+		return nil, err
+	}
+	return rows, nil
+}

--- a/backend/internal/repository/position_repo.go
+++ b/backend/internal/repository/position_repo.go
@@ -1,0 +1,61 @@
+package repository
+
+import (
+	"context"
+	"errors"
+
+	"github.com/gregwym/offbook/backend/internal/model"
+	"gorm.io/gorm"
+)
+
+// PositionRepository is the read interface for positions. All reads are
+// scoped by user_id — there is no cross-tenant "fetch by id" path. Phase 2
+// of ADR-0013 adds the write methods.
+type PositionRepository interface {
+	GetByID(ctx context.Context, userID, id int64) (*model.Position, error)
+	ListByAccountID(ctx context.Context, userID, accountID int64) ([]model.Position, error)
+	ListByUserID(ctx context.Context, userID int64) ([]model.Position, error)
+}
+
+type positionRepo struct {
+	db *gorm.DB
+}
+
+func NewPositionRepository(db *gorm.DB) PositionRepository {
+	return &positionRepo{db: db}
+}
+
+func (r *positionRepo) GetByID(ctx context.Context, userID, id int64) (*model.Position, error) {
+	var p model.Position
+	if err := r.db.WithContext(ctx).
+		Where("user_id = ?", userID).
+		First(&p, id).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, ErrNotFound
+		}
+		return nil, err
+	}
+	return &p, nil
+}
+
+func (r *positionRepo) ListByAccountID(ctx context.Context, userID, accountID int64) ([]model.Position, error) {
+	var rows []model.Position
+	if err := r.db.WithContext(ctx).
+		Where("user_id = ? AND account_id = ?", userID, accountID).
+		Order("id").
+		Find(&rows).Error; err != nil {
+		return nil, err
+	}
+	return rows, nil
+}
+
+func (r *positionRepo) ListByUserID(ctx context.Context, userID int64) ([]model.Position, error) {
+	var rows []model.Position
+	if err := r.db.WithContext(ctx).
+		Where("user_id = ?", userID).
+		Order("account_id, id").
+		Find(&rows).Error; err != nil {
+		return nil, err
+	}
+	return rows, nil
+}

--- a/backend/internal/repository/price_repo.go
+++ b/backend/internal/repository/price_repo.go
@@ -1,0 +1,59 @@
+package repository
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/gregwym/offbook/backend/internal/model"
+	"gorm.io/gorm"
+)
+
+// PriceRepository is the read interface for the prices time series. Prices
+// are global (not user-scoped) — they describe market observations, not
+// holdings. Phase 2 of ADR-0013 adds the write methods.
+type PriceRepository interface {
+	// LatestPriceAt returns the most recent price for (assetID quoted in
+	// quoteAssetID) at or before asOf. Returns ErrNotFound when no row
+	// matches — callers decide whether that's a hard error (stale-price
+	// guard) or a soft skip.
+	LatestPriceAt(ctx context.Context, assetID, quoteAssetID int64, asOf time.Time) (*model.Price, error)
+
+	// ListHistory returns prices for (assetID, quoteAssetID) ordered by
+	// as_of ASC, within [from, to). For Phase 1 this is exercised by tests
+	// only; the trend chart in Phase 2 consumes it.
+	ListHistory(ctx context.Context, assetID, quoteAssetID int64, from, to time.Time) ([]model.Price, error)
+}
+
+type priceRepo struct {
+	db *gorm.DB
+}
+
+func NewPriceRepository(db *gorm.DB) PriceRepository {
+	return &priceRepo{db: db}
+}
+
+func (r *priceRepo) LatestPriceAt(ctx context.Context, assetID, quoteAssetID int64, asOf time.Time) (*model.Price, error) {
+	var p model.Price
+	if err := r.db.WithContext(ctx).
+		Where("asset_id = ? AND quote_asset_id = ? AND as_of <= ?", assetID, quoteAssetID, asOf).
+		Order("as_of DESC").
+		First(&p).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, ErrNotFound
+		}
+		return nil, err
+	}
+	return &p, nil
+}
+
+func (r *priceRepo) ListHistory(ctx context.Context, assetID, quoteAssetID int64, from, to time.Time) ([]model.Price, error) {
+	var rows []model.Price
+	if err := r.db.WithContext(ctx).
+		Where("asset_id = ? AND quote_asset_id = ? AND as_of >= ? AND as_of < ?", assetID, quoteAssetID, from, to).
+		Order("as_of ASC").
+		Find(&rows).Error; err != nil {
+		return nil, err
+	}
+	return rows, nil
+}

--- a/backend/migrations/000013_position_model_foundation.down.sql
+++ b/backend/migrations/000013_position_model_foundation.down.sql
@@ -1,0 +1,18 @@
+-- Reverse #231 / ADR-0013 Phase 1.
+--
+-- Drop in reverse order: columns referencing assets first, then the new
+-- tables. Old columns (accounts.balance, investments.market_value,
+-- transactions.currency) were never touched by the up migration, so they
+-- need no restoration.
+
+DROP TRIGGER IF EXISTS trg_users_primary_currency_asset    ON users;
+DROP TRIGGER IF EXISTS trg_accounts_primary_quote_asset    ON accounts;
+DROP FUNCTION IF EXISTS set_user_primary_currency_asset();
+DROP FUNCTION IF EXISTS set_account_primary_quote_asset();
+
+ALTER TABLE accounts DROP COLUMN IF EXISTS primary_quote_asset_id;
+ALTER TABLE users    DROP COLUMN IF EXISTS primary_currency_asset_id;
+
+DROP TABLE IF EXISTS prices;
+DROP TABLE IF EXISTS positions;
+DROP TABLE IF EXISTS assets;

--- a/backend/migrations/000013_position_model_foundation.up.sql
+++ b/backend/migrations/000013_position_model_foundation.up.sql
@@ -1,0 +1,246 @@
+-- #231: Phase 1 of ADR-0013 — position-based account model foundation.
+--
+-- Adds assets / positions / prices tables, seeds common assets, adds
+-- primary-currency columns on users and accounts, and backfills positions
+-- and prices from existing accounts.balance + investments snapshots.
+--
+-- Old columns (accounts.balance, investments.market_value,
+-- transactions.currency) remain populated and authoritative. No service
+-- read path switches in this phase; that's Phase 2 (issue #232).
+--
+-- Invariant from ADR-0013: the app never invents transactions. This
+-- migration inserts ZERO rows into transactions.
+
+-- ──────────────────────────────────────────────────────────────────────────
+-- 1. assets — every unit of value (fiat, equity, fund, crypto, bond, …)
+-- ──────────────────────────────────────────────────────────────────────────
+CREATE TABLE assets (
+    id                      BIGSERIAL PRIMARY KEY,
+    symbol                  TEXT NOT NULL,
+    kind                    TEXT NOT NULL CHECK (kind IN
+                                ('fiat','equity','fund','crypto','bond','commodity','other')),
+    display_name            TEXT,
+    quote_currency_asset_id BIGINT REFERENCES assets(id),
+    precision               SMALLINT NOT NULL DEFAULT 8,
+    created_at              TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at              TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (symbol, kind)
+);
+
+-- Seed common fiat + crypto. Idempotent on (symbol, kind).
+INSERT INTO assets (symbol, kind, display_name, precision) VALUES
+    ('USD', 'fiat',   'US Dollar',         2),
+    ('EUR', 'fiat',   'Euro',              2),
+    ('GBP', 'fiat',   'British Pound',     2),
+    ('JPY', 'fiat',   'Japanese Yen',      0),
+    ('CNY', 'fiat',   'Chinese Yuan',      2),
+    ('CAD', 'fiat',   'Canadian Dollar',   2),
+    ('AUD', 'fiat',   'Australian Dollar', 2),
+    ('CHF', 'fiat',   'Swiss Franc',       2),
+    ('HKD', 'fiat',   'Hong Kong Dollar',  2),
+    ('SGD', 'fiat',   'Singapore Dollar',  2),
+    ('BTC', 'crypto', 'Bitcoin',           8),
+    ('ETH', 'crypto', 'Ethereum',          8)
+ON CONFLICT (symbol, kind) DO NOTHING;
+
+-- ──────────────────────────────────────────────────────────────────────────
+-- 2. positions — current (account × asset) holdings. Quantity is the fact.
+-- ──────────────────────────────────────────────────────────────────────────
+CREATE TABLE positions (
+    id          BIGSERIAL PRIMARY KEY,
+    user_id     BIGINT NOT NULL REFERENCES users(id),
+    account_id  BIGINT NOT NULL REFERENCES accounts(id),
+    asset_id    BIGINT NOT NULL REFERENCES assets(id),
+    quantity    NUMERIC(30, 18) NOT NULL,
+    cost_basis  NUMERIC(30, 18),
+    updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    deleted_at  TIMESTAMPTZ
+);
+CREATE UNIQUE INDEX uq_positions_account_asset
+    ON positions (account_id, asset_id) WHERE deleted_at IS NULL;
+CREATE INDEX ix_positions_user_account
+    ON positions (user_id, account_id) WHERE deleted_at IS NULL;
+
+-- ──────────────────────────────────────────────────────────────────────────
+-- 3. prices — append-only (asset, quote_asset, as_of, price) time series.
+-- ──────────────────────────────────────────────────────────────────────────
+CREATE TABLE prices (
+    id             BIGSERIAL PRIMARY KEY,
+    asset_id       BIGINT NOT NULL REFERENCES assets(id),
+    quote_asset_id BIGINT NOT NULL REFERENCES assets(id),
+    as_of          TIMESTAMPTZ NOT NULL,
+    price          NUMERIC(30, 18) NOT NULL,
+    source         TEXT NOT NULL,
+    created_at     TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX ix_prices_lookup ON prices (asset_id, quote_asset_id, as_of DESC);
+
+-- ──────────────────────────────────────────────────────────────────────────
+-- 4. users.primary_currency_asset_id — drives net worth / dashboard rollups
+-- ──────────────────────────────────────────────────────────────────────────
+ALTER TABLE users ADD COLUMN primary_currency_asset_id BIGINT REFERENCES assets(id);
+UPDATE users
+   SET primary_currency_asset_id = (SELECT id FROM assets WHERE symbol = 'USD' AND kind = 'fiat');
+ALTER TABLE users ALTER COLUMN primary_currency_asset_id SET NOT NULL;
+
+-- ──────────────────────────────────────────────────────────────────────────
+-- 5. accounts.primary_quote_asset_id — the currency this account reports in
+-- ──────────────────────────────────────────────────────────────────────────
+ALTER TABLE accounts ADD COLUMN primary_quote_asset_id BIGINT REFERENCES assets(id);
+
+-- Auto-seed any unseen account currencies as fiat assets so the FK backfill
+-- doesn't fail on instances using currencies outside the curated seed list.
+INSERT INTO assets (symbol, kind, display_name, precision)
+SELECT DISTINCT a.currency, 'fiat', a.currency, 2
+  FROM accounts a
+ WHERE NOT EXISTS (
+       SELECT 1 FROM assets ass
+        WHERE ass.symbol = a.currency AND ass.kind = 'fiat'
+   )
+ON CONFLICT (symbol, kind) DO NOTHING;
+
+UPDATE accounts
+   SET primary_quote_asset_id = (
+       SELECT id FROM assets WHERE symbol = COALESCE(accounts.currency, 'USD') AND kind = 'fiat'
+   );
+ALTER TABLE accounts ALTER COLUMN primary_quote_asset_id SET NOT NULL;
+
+-- ──────────────────────────────────────────────────────────────────────────
+-- 5b. BEFORE-INSERT/UPDATE triggers auto-populate the new FK columns on
+-- accounts and users if the caller leaves them at NULL or 0. Phase 1 of
+-- ADR-0013 deliberately does not touch service code — these triggers let
+-- existing account-creation and user-signup paths keep working without
+-- modification. Phase 2 will move the population into the Go layer and
+-- drop these triggers.
+-- ──────────────────────────────────────────────────────────────────────────
+CREATE OR REPLACE FUNCTION set_account_primary_quote_asset() RETURNS TRIGGER AS $$
+BEGIN
+    IF NEW.primary_quote_asset_id IS NULL OR NEW.primary_quote_asset_id = 0 THEN
+        -- Defensive: create the fiat asset on first encounter so the FK lookup
+        -- never returns NULL for an unfamiliar currency.
+        INSERT INTO assets (symbol, kind, display_name, precision)
+        VALUES (COALESCE(NEW.currency, 'USD'), 'fiat', COALESCE(NEW.currency, 'USD'), 2)
+        ON CONFLICT (symbol, kind) DO NOTHING;
+        NEW.primary_quote_asset_id := (
+            SELECT id FROM assets WHERE symbol = COALESCE(NEW.currency, 'USD') AND kind = 'fiat'
+        );
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trg_accounts_primary_quote_asset
+    BEFORE INSERT OR UPDATE ON accounts
+    FOR EACH ROW EXECUTE FUNCTION set_account_primary_quote_asset();
+
+CREATE OR REPLACE FUNCTION set_user_primary_currency_asset() RETURNS TRIGGER AS $$
+BEGIN
+    IF NEW.primary_currency_asset_id IS NULL OR NEW.primary_currency_asset_id = 0 THEN
+        NEW.primary_currency_asset_id := (SELECT id FROM assets WHERE symbol = 'USD' AND kind = 'fiat');
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trg_users_primary_currency_asset
+    BEFORE INSERT OR UPDATE ON users
+    FOR EACH ROW EXECUTE FUNCTION set_user_primary_currency_asset();
+
+-- ──────────────────────────────────────────────────────────────────────────
+-- 6. Helper: classify free-form investments.asset_class → assets.kind.
+-- Lives in pg_temp so it's session-scoped and auto-removed; we only need it
+-- during this migration's data backfill.
+-- ──────────────────────────────────────────────────────────────────────────
+CREATE OR REPLACE FUNCTION pg_temp.classify_asset_class(c TEXT) RETURNS TEXT AS $$
+SELECT CASE LOWER(COALESCE(c, ''))
+    WHEN 'equity'         THEN 'equity'
+    WHEN 'stock'          THEN 'equity'
+    WHEN 'stocks'         THEN 'equity'
+    WHEN 'etf'            THEN 'fund'
+    WHEN 'fund'           THEN 'fund'
+    WHEN 'mutual_fund'    THEN 'fund'
+    WHEN 'mutual fund'    THEN 'fund'
+    WHEN 'crypto'         THEN 'crypto'
+    WHEN 'cryptocurrency' THEN 'crypto'
+    WHEN 'bond'           THEN 'bond'
+    WHEN 'bonds'          THEN 'bond'
+    WHEN 'fixed_income'   THEN 'bond'
+    WHEN 'commodity'      THEN 'commodity'
+    ELSE 'other'
+END;
+$$ LANGUAGE SQL IMMUTABLE;
+
+-- ──────────────────────────────────────────────────────────────────────────
+-- 7. Seed assets for tickers found in investments.
+-- ──────────────────────────────────────────────────────────────────────────
+INSERT INTO assets (symbol, kind, display_name, precision)
+SELECT DISTINCT
+       i.ticker,
+       pg_temp.classify_asset_class(i.asset_class),
+       COALESCE(i.name, i.ticker),
+       8
+  FROM investments i
+ WHERE NOT EXISTS (
+       SELECT 1 FROM assets ass
+        WHERE ass.symbol = i.ticker
+          AND ass.kind   = pg_temp.classify_asset_class(i.asset_class)
+   )
+ON CONFLICT (symbol, kind) DO NOTHING;
+
+-- ──────────────────────────────────────────────────────────────────────────
+-- 8. Backfill positions from accounts.balance.
+--
+-- Rule: every active account gets at least one position. For investment /
+-- crypto account types where investments snapshots exist, skip this step
+-- (positions come from snapshots — step 9). When no snapshots exist (e.g.
+-- a Plaid brokerage with M3 sync only), fall back to a single cash-blob
+-- position so the account still has value representable in the new model.
+-- ──────────────────────────────────────────────────────────────────────────
+INSERT INTO positions (user_id, account_id, asset_id, quantity, cost_basis, updated_at)
+SELECT a.user_id,
+       a.id,
+       a.primary_quote_asset_id,
+       a.balance,
+       NULL,
+       NOW()
+  FROM accounts a
+ WHERE a.deleted_at IS NULL
+   AND (
+       a.account_type NOT IN ('investment', 'crypto')
+       OR NOT EXISTS (SELECT 1 FROM investments i WHERE i.account_id = a.id)
+   );
+
+-- ──────────────────────────────────────────────────────────────────────────
+-- 9. Backfill positions from the latest investments snapshot per
+-- (account_id, ticker). One position row per distinct holding.
+-- ──────────────────────────────────────────────────────────────────────────
+INSERT INTO positions (user_id, account_id, asset_id, quantity, cost_basis, updated_at)
+SELECT DISTINCT ON (i.account_id, i.ticker)
+       i.user_id,
+       i.account_id,
+       (SELECT ass.id FROM assets ass
+         WHERE ass.symbol = i.ticker
+           AND ass.kind   = pg_temp.classify_asset_class(i.asset_class)),
+       i.quantity,
+       i.cost_basis,
+       NOW()
+  FROM investments i
+  JOIN accounts a ON a.id = i.account_id AND a.deleted_at IS NULL
+ ORDER BY i.account_id, i.ticker, i.snapshot_date DESC, i.id DESC;
+
+-- ──────────────────────────────────────────────────────────────────────────
+-- 10. Backfill prices from historical investments snapshots.
+-- price = market_value / quantity, quoted in the parent account's currency.
+-- ──────────────────────────────────────────────────────────────────────────
+INSERT INTO prices (asset_id, quote_asset_id, as_of, price, source)
+SELECT (SELECT ass.id FROM assets ass
+         WHERE ass.symbol = i.ticker
+           AND ass.kind   = pg_temp.classify_asset_class(i.asset_class)),
+       a.primary_quote_asset_id,
+       i.snapshot_date::timestamptz,
+       (i.market_value / i.quantity),
+       'historical_snapshot'
+  FROM investments i
+  JOIN accounts a ON a.id = i.account_id AND a.deleted_at IS NULL
+ WHERE i.market_value IS NOT NULL
+   AND i.quantity > 0;


### PR DESCRIPTION
## Summary
First concrete step of [ADR-0013](https://github.com/gregwym/offbook/blob/main/docs/ADR/0013-position-based-account-model.md) — the position-based account model. Foundation only: tables land, data is backfilled, but no service read path switches yet.

- New tables: `assets`, `positions`, `prices` (per ADR-0013 §1).
- Seeded fiat (USD, EUR, GBP, JPY, CNY, CAD, AUD, CHF, HKD, SGD) and crypto (BTC, ETH) assets.
- New FK columns: `users.primary_currency_asset_id`, `accounts.primary_quote_asset_id`. Backfilled from existing data, then set NOT NULL.
- Positions backfilled per ADR-0013 §Phase 1 rules:
  - Non-investment accounts → 1 cash-currency position (qty = `balance`).
  - Investment accounts with `investments` snapshots → 1 position per ticker from the latest snapshot.
  - Investment accounts without snapshots → fall back to a cash-blob position so the account still has a representable value.
- Prices backfilled from every historical `investments` snapshot.
- BEFORE-INSERT triggers on `accounts` and `users` auto-populate the new FK columns so existing creation paths keep working — Phase 2 moves the logic into Go and drops the triggers.
- Read-only repositories: `AssetRepository`, `PositionRepository`, `PriceRepository`. Wired into nothing yet.

**Invariant per ADR-0013:** zero `transactions` rows inserted by this migration. Verified by the new backfill integration test.

## Test plan
- [x] `command make verify` — backend green; frontend untouched (pnpm not available locally, CI covers it).
- [x] `TestMigration000013_PositionModelBackfill` covers: seed assets, FK backfill on users + accounts, positions for cash / brokerage-with-holdings / brokerage-no-holdings, prices for AAPL × snapshots, transactions count unchanged, triggers fire for new rows.
- [x] Existing `TestMigrations_UpDownUpIsIdempotent` walks up→down→up around migration 13.

Refs #231

🤖 Generated with [Claude Code](https://claude.com/claude-code)