### PR TITLE
Simplify M10 plan — pre-prod, no data migration needed

### DIFF
--- a/docs/ADR/0013-position-based-account-model.md
+++ b/docs/ADR/0013-position-based-account-model.md
@@ -140,34 +140,39 @@ Per constraint #6, computed values (account balance in primary currency, househo
 
 The invariant: `positions` + `prices` are the only sources of truth. Drop the cache, recompute everything.
 
-## Migration Plan
+## Implementation Plan
 
-Phased to keep the system runnable between phases.
+Offbook has not shipped to production. There are no users to migrate and no
+historical data to preserve. Implementation is therefore **a consolidated
+refactor**, not a phased dual-representation rollout. Drop legacy columns
+and switch all reads/writes in one coherent change. Dev databases are wiped
+and re-seeded by re-running `make dev` against a fresh volume.
 
-**Phase 1 — Foundation tables, backfill, dual-write.**
-- Migration creates `assets`, `positions`, `prices`. Seeds common fiat assets (USD, EUR, GBP, JPY, CNY, CAD, AUD) and crypto (BTC, ETH).
-- Add `users.primary_currency_asset_id` (default USD asset id).
-- Backfill `positions` from existing `accounts.balance` (one row per cash account) and from the latest `investments` snapshot per `(account_id, ticker)`.
-- Backfill `prices` from historical `investments.market_value / quantity` rows.
-- Old columns (`accounts.balance`, `investments.market_value`) **stay populated** by a dual-write layer.
+**Step 1 (#231, in flight) — Foundation tables and read-only repositories.**
+Adds `assets`, `positions`, `prices` tables, seeds common assets, adds
+`users.primary_currency_asset_id` and `accounts.primary_quote_asset_id`,
+and exposes read-only repositories. Backfill logic and BEFORE-INSERT
+triggers in this PR are scaffolding that the next step deletes — they
+exist because the PR was authored before the pre-prod confirmation.
 
-**Phase 2 — Reads migrate to positions/prices.**
-- Investment service `PortfolioSummary` reads from positions + prices.
-- Dashboard service net-worth/balance reads from positions + prices (with FX where needed).
-- Plaid sync writes positions in addition to `accounts.balance` and `investments`.
-- Household aggregator gains `Allocation`, `NetWorthTrend`, `AccountSummaries` methods using the new tables (closes the M9 #225 gap).
+**Step 2 (M10a) — Schema completion + service switchover.** One migration
+that:
+- Drops `accounts.balance`, `investments.market_value`, `transactions.currency`.
+- Drops the `investments` table (superseded by `positions` + `prices`).
+- Drops the Phase-1 triggers and backfill remnants.
+- Adds `transactions.asset_id NOT NULL REFERENCES assets(id)`.
 
-**Phase 3 — Trades and `transactions.asset_id`.**
-- Migration adds `transactions.asset_id NOT NULL` (backfilled from `accounts.currency` for existing rows — all current transactions are cash transactions, so `asset_id = currency asset of the parent account`).
-- Plaid investment-transactions API ingestion: writes paired-row trades.
-- CSV/manual trade entry forms produce paired rows.
-- Cost-basis recomputation job populates `positions.cost_basis`.
+Plus all service rewrites in the same PR:
+- Plaid sync writes positions + prices, not balances/holdings.
+- Investment service queries through positions; remove the snapshot model.
+- Dashboard service computes via `positions × prices` (with FX where needed).
+- Household aggregator gains `Allocation`, `NetWorthTrend`,
+  `AccountSummaries` (closes the M9 #225 gap).
 
-**Phase 4 — Drop legacy columns.**
-- Drop `accounts.balance`, `investments.market_value`, `transactions.currency`.
-- `investments` table may remain as the historical snapshot log or be retired in favor of `prices` + `positions` — decide at the end of Phase 3.
-
-Each phase is a separate PR. The system runs the full product surface after each phase; rollback is a single migration `down`.
+**Step 3 (M10b) — Trade ingestion.** Plaid investment-transactions API
+produces paired-row trades; manual trade form ditto; cost-basis recompute
+runs on every trade-affecting write. Smaller surface; isolated from the
+schema completion to keep PR size manageable.
 
 ## Consequences
 
@@ -176,7 +181,7 @@ Each phase is a separate PR. The system runs the full product surface after each
 - Brokerage cash sleeves stop being a special case.
 - Trades become first-class transactions; budgets, categorization rules, AI context, and household aggregation all see them.
 - Allocation, net worth, unrealized G/L become deterministic functions of `(positions, prices, as_of)`. Bug surface drops because there's no second source of truth to keep in sync.
-- Cost is real: 4 phased migrations, sync rewrites for Plaid, frontend refactors for the dashboard and investments pages, an FX layer at the price service. Estimated effort: a full milestone (M10).
+- Cost is real: schema completion + service rewrites + trade ingestion, plus an FX layer at the price service. Estimated effort: a milestone (M10) split into two PRs (schema/reads + trades).
 - Tier 3 price providers, tax-lot precision, and FX-historical revaluation are deferred but unblocked by the schema.
 
 ## Alternatives Considered
@@ -191,4 +196,4 @@ Each phase is a separate PR. The system runs the full product surface after each
 
 - **ADR-0014: Price provider interface (Tier 3).** Pluggable `PriceProvider` covering Yahoo/Polygon for equities, ECB/openexchangerates for FX, CoinGecko for crypto. Mirrors `AIProvider` pattern. Defer until at least one non-Plaid user asks for live prices.
 - **ADR-0015: Tax-lot precision opt-in.** Defines `tax_lots` table, lot-selection method (FIFO/LIFO/spec ID), and the migration path from `positions.cost_basis` average-cost to tax-lot precision. Defer until a user needs it.
-- **Cash sleeve in brokerage Plaid sync.** Plaid's investment-holdings endpoint reports cash as a position with `security.ticker_symbol = 'CUR:USD'` or similar. The Phase 2 sync rewrite must handle this consistently with bank-account cash, not as a separate code path.
+- **Cash sleeve in brokerage Plaid sync.** Plaid's investment-holdings endpoint reports cash as a position with `security.ticker_symbol = 'CUR:USD'` or similar. The M10a sync rewrite must handle this consistently with bank-account cash, not as a separate code path.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -209,16 +209,15 @@ Issues:
 
 **Goal:** Refactor account valuation to a position-based model. Every account is a bag of positions; **quantities are facts**, **valuations derive from positions × prices** (never stored). Closes the multi-currency, brokerage-cash-sleeve, trade-visibility, and household-allocation gaps the current two-shape schema (`accounts.balance` scalar + separate `investments` snapshots) leaves open.
 
-See [ADR-0013](ADR/0013-position-based-account-model.md) for the full rationale. Phased so the system runs after each phase:
+See [ADR-0013](ADR/0013-position-based-account-model.md) for the full rationale. Pre-prod — we wipe dev DBs and rebuild rather than migrating data. Two integrated PRs land the refactor:
 
-- [ ] #231 — Phase 1: Foundation tables (`assets`, `positions`, `prices`) + backfill from existing data. Dual representation; no reads switched.
-- [ ] #232 — Phase 2: Reads migrate to positions/prices; Plaid sync dual-writes; **household allocation aggregator** lands (closes M9 #225 gap).
-- [ ] #233 — Phase 3: `transactions.asset_id` + paired-row trade ingestion from Plaid investment-transactions and a manual trade form. Cost-basis recomputation (average cost).
-- [ ] #234 — Phase 4: Drop legacy `accounts.balance`, `investments.market_value`, `transactions.currency` columns. Retire dual-write code.
+- [ ] #231 — Foundation tables (`assets`, `positions`, `prices`) + read-only repositories. **PR open at #236.** Triggers + backfill in this PR are scaffolding the next step deletes.
+- [ ] #237 — M10a: drop legacy columns + drop `investments` table + add `transactions.asset_id` + rewrite all service reads + Plaid sync writes positions/prices + household aggregator gains `Allocation`/`NetWorthTrend`/`AccountSummaries` (closes M9 #225 gap).
+- [ ] #238 — M10b: trade ingestion — Plaid investment-transactions → paired-row trades; manual trade form; cost-basis recompute (average cost).
 
 **Invariant carried throughout:** the app never invents transactions. Trade rows come from real import sources (Plaid, statement CSV) or explicit user input — never synthesized to reconcile a holdings-snapshot delta.
 
-**Done criteria:** A user with mixed cash + brokerage + crypto accounts (across multiple currencies) sees the same net worth they saw before the refactor, computed from `positions × prices` with FX conversion to their primary currency. Plaid trades appear as paired rows in the Transactions list. Household scope shows asset allocation with per-account share visibility honored. Legacy `accounts.balance` is gone from the schema.
+**Done criteria:** A user with mixed cash + brokerage + crypto accounts (across multiple currencies) sees net worth, allocation, and per-asset values computed from `positions × prices` with FX conversion to their primary currency. Plaid trades appear as paired rows in the Transactions list. Household scope shows asset allocation with per-account share visibility honored. `accounts.balance`, `investments.market_value`, `transactions.currency`, and the `investments` table are gone from the schema.
 
 **Deferred to follow-up ADRs:**
 - ADR-0014: Pluggable Tier-3 price provider (Yahoo, Polygon, ECB, CoinGecko).


### PR DESCRIPTION
## Summary
Per owner direction: Offbook hasn't shipped to production, so M10 doesn't need a phased dual-write rollout. Drops Phases 2/3/4 of ADR-0013 in favor of a consolidated refactor.

- **ADR-0013 §Implementation Plan** rewritten: 4 phases → 3 steps (Step 1 in flight as #236; Step 2 = M10a #237; Step 3 = M10b #238).
- **ROADMAP M10** updated to point at the new issue set.
- Issues **#232 / #233 / #234 closed** and replaced by **#237 (M10a)** + **#238 (M10b)**.

Phase 1 PR #236 stays as-is — its triggers and backfill become scaffolding the M10a PR removes in a few lines. Re-editing an in-flight tested PR isn't worth the churn.

## Test plan
- [ ] Skim ADR + roadmap diffs.
- [ ] Confirm the M10a + M10b issue bodies cover the right scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)