### PR TITLE
M10a part 2: valuation helper + household insights aggregator

### DIFF
--- a/backend/internal/handler/household_aggregator_handler.go
+++ b/backend/internal/handler/household_aggregator_handler.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"errors"
 	"net/http"
+	"strconv"
 
 	"github.com/gin-gonic/gin"
 
@@ -24,7 +25,8 @@ func NewHouseholdAggregatorHandler(agg *household.Aggregator, members repository
 }
 
 // Register mounts /h/dashboard, /h/budgets/pace, /h/goals/progress,
-// /h/ai/context. All are gated by the secured group + the membership lookup
+// /h/ai/context, and the /h/insights/* trio (allocation, net-worth,
+// accounts). All are gated by the secured group + the membership lookup
 // below (no membership ⇒ 403).
 func (h *HouseholdAggregatorHandler) Register(g *gin.RouterGroup) {
 	r := g.Group("/h")
@@ -32,6 +34,9 @@ func (h *HouseholdAggregatorHandler) Register(g *gin.RouterGroup) {
 	r.GET("/budgets/pace", h.BudgetPace)
 	r.GET("/goals/progress", h.GoalProgress)
 	r.GET("/ai/context", h.AIContext)
+	r.GET("/insights/allocation", h.Allocation)
+	r.GET("/insights/net-worth", h.NetWorthTrend)
+	r.GET("/insights/accounts", h.AccountSummaries)
 }
 
 func (h *HouseholdAggregatorHandler) requireHousehold(c *gin.Context) (int64, bool) {
@@ -107,6 +112,54 @@ func (h *HouseholdAggregatorHandler) AIContext(c *gin.Context) {
 		return
 	}
 	c.JSON(http.StatusOK, gin.H{"data": out})
+}
+
+func (h *HouseholdAggregatorHandler) Allocation(c *gin.Context) {
+	hhID, ok := h.requireHousehold(c)
+	if !ok {
+		return
+	}
+	out, err := h.agg.Allocation(c.Request.Context(), hhID)
+	if err != nil {
+		writeAggregatorErr(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"data": out, "total": int64(len(out))})
+}
+
+func (h *HouseholdAggregatorHandler) NetWorthTrend(c *gin.Context) {
+	hhID, ok := h.requireHousehold(c)
+	if !ok {
+		return
+	}
+	months := 12
+	if v := c.Query("months"); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil || n <= 0 || n > 60 {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "months must be 1..60", "code": "INVALID_REQUEST"})
+			return
+		}
+		months = n
+	}
+	out, err := h.agg.NetWorthTrend(c.Request.Context(), hhID, months)
+	if err != nil {
+		writeAggregatorErr(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"data": out, "total": int64(len(out))})
+}
+
+func (h *HouseholdAggregatorHandler) AccountSummaries(c *gin.Context) {
+	hhID, ok := h.requireHousehold(c)
+	if !ok {
+		return
+	}
+	out, err := h.agg.AccountSummaries(c.Request.Context(), hhID)
+	if err != nil {
+		writeAggregatorErr(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"data": out, "total": int64(len(out))})
 }
 
 func writeAggregatorErr(c *gin.Context, err error) {

--- a/backend/internal/repository/household_aggregator_repo.go
+++ b/backend/internal/repository/household_aggregator_repo.go
@@ -2,6 +2,7 @@ package repository
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/shopspring/decimal"
@@ -70,6 +71,53 @@ type HouseholdAggregatorRepository interface {
 	// ListPersonalThreadsForUser returns the user's own threads NOT shared
 	// with any household. Order: most recently updated first.
 	ListPersonalThreadsForUser(ctx context.Context, userID int64, limit int) ([]model.AIThread, error)
+
+	// AllocationByKind sums positions × latest prices across the given
+	// account IDs, grouped by assets.kind, in each position owner's
+	// primary currency. Empty accountIDs returns nil.
+	AllocationByKind(ctx context.Context, accountIDs []int64) ([]AllocationBucket, error)
+
+	// NetWorthSeries returns one daily net-worth point per day in
+	// [from, to] (inclusive), summing CURRENT positions × historical
+	// prices across accountIDs. Days with no fresh price for a position
+	// contribute 0 for that position — matches the soft-fallback behavior
+	// of the live dashboard query so the chart is renderable even when a
+	// pricing gap exists.
+	NetWorthSeries(ctx context.Context, accountIDs []int64, from, to time.Time) ([]NetWorthPoint, error)
+
+	// AccountBalances returns one row per account in accountIDs with the
+	// account's current balance in its owner's primary currency. Missing
+	// account IDs (e.g. soft-deleted) are silently omitted.
+	AccountBalances(ctx context.Context, accountIDs []int64) ([]AccountBalanceRow, error)
+}
+
+// AllocationBucket is one (asset_kind, value) row of the household
+// allocation rollup. Value is in each position owner's primary currency
+// — heterogeneous-currency households mix into the owner's preferred
+// quote per position.
+type AllocationBucket struct {
+	Kind  string
+	Value decimal.Decimal
+}
+
+// NetWorthPoint is one (date, value) point of the household net-worth
+// trend. Date is the calendar day (UTC midnight); Value is the sum of
+// current positions × historical prices for that day.
+type NetWorthPoint struct {
+	Date  time.Time
+	Value decimal.Decimal
+}
+
+// AccountBalanceRow is the per-account balance contribution from
+// AccountBalances — minimal projection so handlers can join with the
+// share view to add visibility and owner info.
+type AccountBalanceRow struct {
+	AccountID   int64
+	Name        string
+	AccountType string
+	Currency    string
+	OwnerUserID int64
+	Balance     decimal.Decimal
 }
 
 type householdAggregatorRepo struct{ db *gorm.DB }
@@ -283,6 +331,139 @@ func (r *householdAggregatorRepo) ListSharedThreads(ctx context.Context, househo
 		Limit(limit).
 		Find(&out).Error
 	return out, err
+}
+
+// positionValueExpr is the SQL fragment that prices one position into its
+// owner's primary currency. Shared between AllocationByKind, NetWorthSeries,
+// and AccountBalances so a future price-source change touches one spot.
+// References: positions p, users u, prices pr. For NetWorthSeries the
+// trailing as_of bound is replaced via the asOfBound parameter.
+const positionValueExpr = `
+		CASE
+			WHEN p.asset_id = u.primary_currency_asset_id THEN p.quantity
+			ELSE COALESCE(
+				p.quantity * (
+					SELECT pr.price FROM prices pr
+					WHERE pr.asset_id = p.asset_id
+					  AND pr.quote_asset_id = u.primary_currency_asset_id
+					  %s
+					ORDER BY pr.as_of DESC
+					LIMIT 1
+				), 0)
+		END`
+
+func (r *householdAggregatorRepo) AllocationByKind(ctx context.Context, accountIDs []int64) ([]AllocationBucket, error) {
+	if len(accountIDs) == 0 {
+		return nil, nil
+	}
+	type rawRow struct {
+		Kind  string
+		Value string
+	}
+	var rows []rawRow
+	err := r.db.WithContext(ctx).Raw(`
+		SELECT ass.kind AS kind,
+		       COALESCE(SUM(`+fmt.Sprintf(positionValueExpr, "")+`), 0)::text AS value
+		FROM positions p
+		JOIN accounts a ON a.id = p.account_id AND a.deleted_at IS NULL
+		JOIN users    u ON u.id = p.user_id
+		JOIN assets   ass ON ass.id = p.asset_id
+		WHERE p.deleted_at IS NULL AND p.account_id IN ?
+		GROUP BY ass.kind
+		ORDER BY ass.kind
+	`, accountIDs).Scan(&rows).Error
+	if err != nil {
+		return nil, err
+	}
+	out := make([]AllocationBucket, 0, len(rows))
+	for _, row := range rows {
+		v, _ := decimal.NewFromString(row.Value)
+		out = append(out, AllocationBucket{Kind: row.Kind, Value: v})
+	}
+	return out, nil
+}
+
+func (r *householdAggregatorRepo) NetWorthSeries(ctx context.Context, accountIDs []int64, from, to time.Time) ([]NetWorthPoint, error) {
+	if len(accountIDs) == 0 || !to.After(from.Add(-time.Second)) {
+		return nil, nil
+	}
+	fromDay := time.Date(from.Year(), from.Month(), from.Day(), 0, 0, 0, 0, time.UTC)
+	toDay := time.Date(to.Year(), to.Month(), to.Day(), 0, 0, 0, 0, time.UTC)
+	type rawRow struct {
+		Date  time.Time
+		Value string
+	}
+	var rows []rawRow
+	// Cross-join generate_series with positions; price lookup is bounded by
+	// `d + 1 day` so a day's entry uses the latest price posted ON OR BEFORE
+	// end-of-that-day. LEFT JOIN keeps days with no positions at 0.
+	err := r.db.WithContext(ctx).Raw(`
+		WITH days AS (
+			SELECT generate_series(?::date, ?::date, interval '1 day')::date AS d
+		)
+		SELECT days.d AS date,
+		       COALESCE(SUM(`+fmt.Sprintf(positionValueExpr, "AND pr.as_of <= days.d + interval '1 day'")+`), 0)::text AS value
+		FROM days
+		LEFT JOIN positions p ON p.deleted_at IS NULL AND p.account_id IN ?
+		LEFT JOIN accounts  a ON a.id = p.account_id AND a.deleted_at IS NULL
+		LEFT JOIN users     u ON u.id = p.user_id
+		GROUP BY days.d
+		ORDER BY days.d
+	`, fromDay, toDay, accountIDs).Scan(&rows).Error
+	if err != nil {
+		return nil, err
+	}
+	out := make([]NetWorthPoint, 0, len(rows))
+	for _, row := range rows {
+		v, _ := decimal.NewFromString(row.Value)
+		out = append(out, NetWorthPoint{Date: row.Date.UTC(), Value: v})
+	}
+	return out, nil
+}
+
+func (r *householdAggregatorRepo) AccountBalances(ctx context.Context, accountIDs []int64) ([]AccountBalanceRow, error) {
+	if len(accountIDs) == 0 {
+		return nil, nil
+	}
+	type rawRow struct {
+		AccountID   int64
+		Name        string
+		AccountType string
+		Currency    string
+		OwnerUserID int64
+		Balance     string
+	}
+	var rows []rawRow
+	err := r.db.WithContext(ctx).Raw(`
+		SELECT a.id           AS account_id,
+		       a.name         AS name,
+		       a.account_type AS account_type,
+		       a.currency     AS currency,
+		       a.user_id      AS owner_user_id,
+		       COALESCE(SUM(`+fmt.Sprintf(positionValueExpr, "")+`), 0)::text AS balance
+		FROM accounts a
+		JOIN users     u ON u.id = a.user_id
+		LEFT JOIN positions p ON p.deleted_at IS NULL AND p.account_id = a.id
+		WHERE a.deleted_at IS NULL AND a.id IN ?
+		GROUP BY a.id, a.name, a.account_type, a.currency, a.user_id
+		ORDER BY a.id
+	`, accountIDs).Scan(&rows).Error
+	if err != nil {
+		return nil, err
+	}
+	out := make([]AccountBalanceRow, 0, len(rows))
+	for _, row := range rows {
+		b, _ := decimal.NewFromString(row.Balance)
+		out = append(out, AccountBalanceRow{
+			AccountID:   row.AccountID,
+			Name:        row.Name,
+			AccountType: row.AccountType,
+			Currency:    row.Currency,
+			OwnerUserID: row.OwnerUserID,
+			Balance:     b,
+		})
+	}
+	return out, nil
 }
 
 func (r *householdAggregatorRepo) ListPersonalThreadsForUser(ctx context.Context, userID int64, limit int) ([]model.AIThread, error) {

--- a/backend/internal/service/household/aggregator.go
+++ b/backend/internal/service/household/aggregator.go
@@ -138,6 +138,39 @@ type ThreadSummary struct {
 	UpdatedAt           time.Time `json:"updated_at"`
 }
 
+// AssetClassAllocation is one row of the household allocation rollup — the
+// total value of shared positions whose asset kind matches, expressed as
+// each owner's primary-currency value. Heterogeneous-currency households
+// surface their primary-currency rollup per position; the wire string keeps
+// NUMERIC precision intact.
+type AssetClassAllocation struct {
+	Kind  string `json:"kind"`
+	Value string `json:"value"`
+}
+
+// NetWorthPoint is one (date, value) row of the household net-worth trend.
+// Date is the UTC calendar day; Value is the rolled-up net worth across
+// shared accounts owned by live members at that day.
+type NetWorthPoint struct {
+	Date  time.Time `json:"date"`
+	Value string    `json:"value"`
+}
+
+// AccountSummary is one row of the household account breakdown. Aggregator
+// output: lightweight projection (name, type, balance, owner, visibility)
+// — never a raw account row, never PII. The OwnerUserID is the household
+// peer's user_id (already known to other members in /h/members) and is not
+// treated as PII at this layer.
+type AccountSummary struct {
+	AccountID   int64  `json:"account_id"`
+	Name        string `json:"name"`
+	AccountType string `json:"account_type"`
+	Currency    string `json:"currency"`
+	Balance     string `json:"balance"`
+	OwnerUserID int64  `json:"owner_user_id"`
+	Visibility  string `json:"visibility"`
+}
+
 // --- core methods ---
 
 // Dashboard returns the household-level rollup for the period. Aggregates over
@@ -403,6 +436,127 @@ func (a *Aggregator) AIContext(ctx context.Context, householdID, requesterUserID
 		SharedThreads:   toThreadSummaries(shared),
 		PersonalThreads: toThreadSummaries(personal),
 	}, nil
+}
+
+// Allocation returns the household's positions rolled up by asset kind
+// (fiat / equity / fund / crypto / …) across shared accounts owned by
+// LIVE members. Visibility floor is balance_only — private accounts
+// have no share row to begin with, so they're excluded by construction.
+// In-grace members are excluded from this LIVE rollup.
+func (a *Aggregator) Allocation(ctx context.Context, householdID int64) ([]AssetClassAllocation, error) {
+	if err := a.requireHousehold(ctx, householdID); err != nil {
+		return nil, err
+	}
+	live, _, err := a.liveAndInGrace(ctx, householdID)
+	if err != nil {
+		return nil, err
+	}
+	liveUserIDs := userIDs(live)
+	shares, err := a.repo.ListAccountShares(ctx, householdID,
+		[]string{model.VisibilityBalanceOnly, model.VisibilityBalanceAndTxns})
+	if err != nil {
+		return nil, fmt.Errorf("list shares: %w", err)
+	}
+	accountIDs := filterAccountsByUsers(shares, liveUserIDs)
+	buckets, err := a.repo.AllocationByKind(ctx, accountIDs)
+	if err != nil {
+		return nil, fmt.Errorf("allocation by kind: %w", err)
+	}
+	out := make([]AssetClassAllocation, 0, len(buckets))
+	for _, b := range buckets {
+		out = append(out, AssetClassAllocation{Kind: b.Kind, Value: b.Value.String()})
+	}
+	return out, nil
+}
+
+// NetWorthTrend returns a daily net-worth series for the trailing `months`
+// calendar months ending at the aggregator's clock. Uses CURRENT positions
+// × historical prices — for a household that holds the same securities
+// today as it did 6 months ago, the curve traces price movement, not
+// rebalancing. (M10b's trade ingestion lays the foundation for a
+// quantity-history view; this one is the foundation.)
+//
+// Defaults: months ≤ 0 → 12. Excludes private accounts and in-grace members
+// — same lifecycle rules as Dashboard/Allocation.
+func (a *Aggregator) NetWorthTrend(ctx context.Context, householdID int64, months int) ([]NetWorthPoint, error) {
+	if err := a.requireHousehold(ctx, householdID); err != nil {
+		return nil, err
+	}
+	if months <= 0 {
+		months = 12
+	}
+	live, _, err := a.liveAndInGrace(ctx, householdID)
+	if err != nil {
+		return nil, err
+	}
+	liveUserIDs := userIDs(live)
+	shares, err := a.repo.ListAccountShares(ctx, householdID,
+		[]string{model.VisibilityBalanceOnly, model.VisibilityBalanceAndTxns})
+	if err != nil {
+		return nil, fmt.Errorf("list shares: %w", err)
+	}
+	accountIDs := filterAccountsByUsers(shares, liveUserIDs)
+	now := a.now().UTC()
+	from := now.AddDate(0, -months, 0)
+	points, err := a.repo.NetWorthSeries(ctx, accountIDs, from, now)
+	if err != nil {
+		return nil, fmt.Errorf("net worth series: %w", err)
+	}
+	out := make([]NetWorthPoint, 0, len(points))
+	for _, p := range points {
+		out = append(out, NetWorthPoint{Date: p.Date, Value: p.Value.String()})
+	}
+	return out, nil
+}
+
+// AccountSummaries returns one row per SHARED account, including
+// balance_only and balance_and_txns (private accounts have no share row).
+// Balance is computed in the OWNER's primary currency. Visibility comes
+// from the share row so the UI can render the chip without an extra
+// fetch. Owned by an in-grace member ⇒ excluded from live output.
+func (a *Aggregator) AccountSummaries(ctx context.Context, householdID int64) ([]AccountSummary, error) {
+	if err := a.requireHousehold(ctx, householdID); err != nil {
+		return nil, err
+	}
+	live, _, err := a.liveAndInGrace(ctx, householdID)
+	if err != nil {
+		return nil, err
+	}
+	liveUserIDs := userIDs(live)
+	shares, err := a.repo.ListAccountShares(ctx, householdID,
+		[]string{model.VisibilityBalanceOnly, model.VisibilityBalanceAndTxns})
+	if err != nil {
+		return nil, fmt.Errorf("list shares: %w", err)
+	}
+	type shareMeta struct {
+		visibility string
+	}
+	meta := make(map[int64]shareMeta, len(shares))
+	accountIDs := make([]int64, 0, len(shares))
+	for _, s := range shares {
+		if _, ok := liveUserIDs[s.UserID]; !ok {
+			continue
+		}
+		meta[s.AccountID] = shareMeta{visibility: s.Visibility}
+		accountIDs = append(accountIDs, s.AccountID)
+	}
+	balances, err := a.repo.AccountBalances(ctx, accountIDs)
+	if err != nil {
+		return nil, fmt.Errorf("account balances: %w", err)
+	}
+	out := make([]AccountSummary, 0, len(balances))
+	for _, b := range balances {
+		out = append(out, AccountSummary{
+			AccountID:   b.AccountID,
+			Name:        b.Name,
+			AccountType: b.AccountType,
+			Currency:    b.Currency,
+			Balance:     b.Balance.String(),
+			OwnerUserID: b.OwnerUserID,
+			Visibility:  meta[b.AccountID].visibility,
+		})
+	}
+	return out, nil
 }
 
 // --- internal helpers ---

--- a/backend/internal/service/household/aggregator_insights_test.go
+++ b/backend/internal/service/household/aggregator_insights_test.go
@@ -1,0 +1,307 @@
+// Privacy and behavior coverage for the three /h/insights/* methods added in
+// M10a: Allocation, NetWorthTrend, AccountSummaries. The static "no PII"
+// guard and the reflection walk over return types live in aggregator_test.go;
+// here we cover the three additions against the rules-of-the-road:
+//
+//	(a) private accounts excluded from aggregates
+//	(c) in-grace members excluded from live aggregates
+//
+// (b) (balance_only excluded from category breakdown), (d) (no raw txn
+// rows in return types) and (e) (AI cross-member leak) don't apply to
+// these methods or are covered by the existing reflection check in
+// TestAggregator_NoRawTransactionRows.
+package household_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/shopspring/decimal"
+	"gorm.io/gorm"
+
+	"github.com/gregwym/offbook/backend/internal/model"
+	"github.com/gregwym/offbook/backend/internal/service/household"
+	"github.com/gregwym/offbook/backend/internal/testutil"
+)
+
+// seedAsset creates a non-fiat asset with the given native quote, returning
+// the new asset id. Used to construct an "equity" class entry for the
+// allocation test without colliding with the seeded fiat rows.
+func seedAsset(t *testing.T, g *gorm.DB, symbol, kind string, quoteAssetID int64) int64 {
+	t.Helper()
+	a := &model.Asset{Symbol: symbol, Kind: kind, QuoteCurrencyAssetID: &quoteAssetID, Precision: 8}
+	if err := g.Create(a).Error; err != nil {
+		t.Fatalf("seed asset %s/%s: %v", symbol, kind, err)
+	}
+	t.Cleanup(func() { g.Unscoped().Delete(&model.Asset{}, a.ID) })
+	return a.ID
+}
+
+// upsertPosition writes a (account, asset, quantity) row.
+func upsertPosition(t *testing.T, g *gorm.DB, userID, accountID, assetID int64, quantity string) {
+	t.Helper()
+	q, _ := decimal.NewFromString(quantity)
+	p := &model.Position{UserID: userID, AccountID: accountID, AssetID: assetID, Quantity: q}
+	if err := g.Create(p).Error; err != nil {
+		t.Fatalf("seed position: %v", err)
+	}
+	t.Cleanup(func() { g.Unscoped().Delete(&model.Position{}, p.ID) })
+}
+
+func insertPrice(t *testing.T, g *gorm.DB, assetID, quoteAssetID int64, price string, asOf time.Time) {
+	t.Helper()
+	pr, _ := decimal.NewFromString(price)
+	p := &model.Price{AssetID: assetID, QuoteAssetID: quoteAssetID, Price: pr, AsOf: asOf, Source: "test"}
+	if err := g.Create(p).Error; err != nil {
+		t.Fatalf("seed price: %v", err)
+	}
+	t.Cleanup(func() { g.Unscoped().Delete(&model.Price{}, p.ID) })
+}
+
+// TestAggregator_Allocation rolls cash + equity into kind buckets and
+// verifies private accounts are excluded.
+func TestAggregator_Allocation(t *testing.T) {
+	agg, g := newAggregator(t)
+	ctx := context.Background()
+	usd := testutil.LookupUSDAssetID(t, g)
+	aapl := seedAsset(t, g, "AAPL-AL-"+fmt.Sprintf("%d", time.Now().UnixNano()), model.AssetKindEquity, usd)
+	insertPrice(t, g, aapl, usd, "150", time.Now().Add(-time.Hour))
+
+	ownerID := seedUser(t, g, "alloc-owner")
+	hh := seedHouseholdRow(t, g, ownerID, "Allocation", 30)
+	addMember(t, g, hh.ID, ownerID, model.RoleOwner, nil)
+
+	chk := seedAccount(t, g, ownerID, "chk")
+	brk := seedAccount(t, g, ownerID, "brk")
+	priv := seedAccount(t, g, ownerID, "private")
+	// Shared
+	upsertPosition(t, g, ownerID, chk.ID, usd, "1000")
+	upsertPosition(t, g, ownerID, brk.ID, aapl, "10") // 10 × 150 = 1500
+	// Private — must not show up anywhere
+	upsertPosition(t, g, ownerID, priv.ID, usd, "9999")
+
+	setShare(t, g, chk.ID, hh.ID, model.VisibilityBalanceOnly)
+	setShare(t, g, brk.ID, hh.ID, model.VisibilityBalanceAndTxns)
+
+	out, err := agg.Allocation(ctx, hh.ID)
+	if err != nil {
+		t.Fatalf("Allocation: %v", err)
+	}
+	byKind := map[string]string{}
+	for _, b := range out {
+		byKind[b.Kind] = b.Value
+	}
+	if byKind[model.AssetKindFiat] != "1000" {
+		t.Errorf("fiat bucket = %q, want 1000", byKind[model.AssetKindFiat])
+	}
+	if byKind[model.AssetKindEquity] != "1500" {
+		t.Errorf("equity bucket = %q, want 1500", byKind[model.AssetKindEquity])
+	}
+	for _, b := range out {
+		if b.Value == "9999" {
+			t.Errorf("private account leaked into allocation: %+v", b)
+		}
+	}
+}
+
+// TestAggregator_Allocation_InGraceExcluded ensures a leaver's shared
+// account stops contributing to allocation during grace.
+func TestAggregator_Allocation_InGraceExcluded(t *testing.T) {
+	agg, g := newAggregator(t)
+	ctx := context.Background()
+	usd := testutil.LookupUSDAssetID(t, g)
+	ownerID := seedUser(t, g, "alloc-grace-owner")
+	leaverID := seedUser(t, g, "alloc-grace-leaver")
+
+	hh := seedHouseholdRow(t, g, ownerID, "AllocGrace", 30)
+	addMember(t, g, hh.ID, ownerID, model.RoleOwner, nil)
+	leftAt := time.Now().Add(-3 * 24 * time.Hour)
+	addMember(t, g, hh.ID, leaverID, model.RoleContributor, &leftAt)
+
+	ownerAcct := seedAccount(t, g, ownerID, "owner-chk")
+	leaverAcct := seedAccount(t, g, leaverID, "leaver-chk")
+	upsertPosition(t, g, ownerID, ownerAcct.ID, usd, "100")
+	upsertPosition(t, g, leaverID, leaverAcct.ID, usd, "9999")
+	setShare(t, g, ownerAcct.ID, hh.ID, model.VisibilityBalanceAndTxns)
+	setShare(t, g, leaverAcct.ID, hh.ID, model.VisibilityBalanceAndTxns)
+
+	out, err := agg.Allocation(ctx, hh.ID)
+	if err != nil {
+		t.Fatalf("Allocation: %v", err)
+	}
+	for _, b := range out {
+		if b.Value == "9999" || b.Value == "10099" {
+			t.Errorf("in-grace leaver leaked into allocation: %+v", b)
+		}
+	}
+	// Owner's 100 fiat is what we expect.
+	var fiat string
+	for _, b := range out {
+		if b.Kind == model.AssetKindFiat {
+			fiat = b.Value
+		}
+	}
+	if fiat != "100" {
+		t.Errorf("fiat bucket = %q, want 100 (only owner)", fiat)
+	}
+}
+
+// TestAggregator_AccountSummaries returns one row per shared account with
+// balance + visibility, and excludes private accounts.
+func TestAggregator_AccountSummaries(t *testing.T) {
+	agg, g := newAggregator(t)
+	ctx := context.Background()
+	usd := testutil.LookupUSDAssetID(t, g)
+	ownerID := seedUser(t, g, "summ-owner")
+	hh := seedHouseholdRow(t, g, ownerID, "Summaries", 30)
+	addMember(t, g, hh.ID, ownerID, model.RoleOwner, nil)
+
+	a1 := seedAccount(t, g, ownerID, "chk")
+	a2 := seedAccount(t, g, ownerID, "sav")
+	priv := seedAccount(t, g, ownerID, "private")
+	upsertPosition(t, g, ownerID, a1.ID, usd, "200")
+	upsertPosition(t, g, ownerID, a2.ID, usd, "300")
+	upsertPosition(t, g, ownerID, priv.ID, usd, "9999")
+
+	setShare(t, g, a1.ID, hh.ID, model.VisibilityBalanceAndTxns)
+	setShare(t, g, a2.ID, hh.ID, model.VisibilityBalanceOnly)
+
+	out, err := agg.AccountSummaries(ctx, hh.ID)
+	if err != nil {
+		t.Fatalf("AccountSummaries: %v", err)
+	}
+	if len(out) != 2 {
+		t.Fatalf("len(out) = %d, want 2 (private excluded); got %+v", len(out), out)
+	}
+	byID := map[int64]household.AccountSummary{}
+	for _, s := range out {
+		byID[s.AccountID] = s
+	}
+	if byID[a1.ID].Balance != "200" || byID[a1.ID].Visibility != model.VisibilityBalanceAndTxns {
+		t.Errorf("a1 summary = %+v, want balance=200 visibility=balance_and_txns", byID[a1.ID])
+	}
+	if byID[a2.ID].Balance != "300" || byID[a2.ID].Visibility != model.VisibilityBalanceOnly {
+		t.Errorf("a2 summary = %+v, want balance=300 visibility=balance_only", byID[a2.ID])
+	}
+	if _, leaked := byID[priv.ID]; leaked {
+		t.Errorf("private account leaked into summaries")
+	}
+}
+
+// TestAggregator_AccountSummaries_InGraceExcluded ensures leaver's shared
+// account drops off during grace.
+func TestAggregator_AccountSummaries_InGraceExcluded(t *testing.T) {
+	agg, g := newAggregator(t)
+	ctx := context.Background()
+	usd := testutil.LookupUSDAssetID(t, g)
+	ownerID := seedUser(t, g, "summ-grace-owner")
+	leaverID := seedUser(t, g, "summ-grace-leaver")
+	hh := seedHouseholdRow(t, g, ownerID, "SummGrace", 30)
+	addMember(t, g, hh.ID, ownerID, model.RoleOwner, nil)
+	leftAt := time.Now().Add(-3 * 24 * time.Hour)
+	addMember(t, g, hh.ID, leaverID, model.RoleContributor, &leftAt)
+
+	ownerAcct := seedAccount(t, g, ownerID, "owner")
+	leaverAcct := seedAccount(t, g, leaverID, "leaver")
+	upsertPosition(t, g, ownerID, ownerAcct.ID, usd, "10")
+	upsertPosition(t, g, leaverID, leaverAcct.ID, usd, "9999")
+	setShare(t, g, ownerAcct.ID, hh.ID, model.VisibilityBalanceAndTxns)
+	setShare(t, g, leaverAcct.ID, hh.ID, model.VisibilityBalanceAndTxns)
+
+	out, err := agg.AccountSummaries(ctx, hh.ID)
+	if err != nil {
+		t.Fatalf("AccountSummaries: %v", err)
+	}
+	if len(out) != 1 || out[0].AccountID != ownerAcct.ID {
+		t.Fatalf("out = %+v, want one entry for owner only", out)
+	}
+}
+
+// TestAggregator_NetWorthTrend returns one point per day in the window
+// and reflects positions × historical prices.
+func TestAggregator_NetWorthTrend(t *testing.T) {
+	agg, g := newAggregator(t)
+	ctx := context.Background()
+	usd := testutil.LookupUSDAssetID(t, g)
+	eur := testutil.LookupAssetID(t, g, "EUR", "fiat")
+	ownerID := seedUser(t, g, "nwt-owner")
+	hh := seedHouseholdRow(t, g, ownerID, "NWT", 30)
+	addMember(t, g, hh.ID, ownerID, model.RoleOwner, nil)
+
+	// Account holds 100 USD + 50 EUR. EUR price history shifts mid-window.
+	acct := seedAccount(t, g, ownerID, "mixed")
+	upsertPosition(t, g, ownerID, acct.ID, usd, "100")
+	upsertPosition(t, g, ownerID, acct.ID, eur, "50")
+	setShare(t, g, acct.ID, hh.ID, model.VisibilityBalanceAndTxns)
+
+	// 60 days ago: EUR 1.0 → net worth 150.
+	// 10 days ago: EUR 2.0 → net worth 200.
+	insertPrice(t, g, eur, usd, "1.0", time.Now().Add(-60*24*time.Hour))
+	insertPrice(t, g, eur, usd, "2.0", time.Now().Add(-10*24*time.Hour))
+
+	// Freeze the clock so the window is deterministic.
+	now := time.Now().UTC()
+	agg.SetClock(func() time.Time { return now })
+
+	out, err := agg.NetWorthTrend(ctx, hh.ID, 3) // 3 months
+	if err != nil {
+		t.Fatalf("NetWorthTrend: %v", err)
+	}
+	if len(out) < 30 {
+		t.Fatalf("len(out) = %d, want at least 30 points", len(out))
+	}
+	// First point: prior to any price → 100 (USD only).
+	if out[0].Value != "100" {
+		t.Errorf("first point = %q, want 100 (EUR has no price yet → contributes 0)", out[0].Value)
+	}
+	// Some middle point after the 1.0 price → 150.
+	var saw150, saw200 bool
+	for _, p := range out {
+		if p.Value == "150" {
+			saw150 = true
+		}
+		if p.Value == "200" {
+			saw200 = true
+		}
+	}
+	if !saw150 {
+		t.Errorf("trend never reaches 150 (EUR=1.0 era)")
+	}
+	if !saw200 {
+		t.Errorf("trend never reaches 200 (EUR=2.0 era)")
+	}
+}
+
+// TestAggregator_NetWorthTrend_InGraceExcluded covers (c) on the trend.
+func TestAggregator_NetWorthTrend_InGraceExcluded(t *testing.T) {
+	agg, g := newAggregator(t)
+	ctx := context.Background()
+	usd := testutil.LookupUSDAssetID(t, g)
+	ownerID := seedUser(t, g, "nwt-grace-owner")
+	leaverID := seedUser(t, g, "nwt-grace-leaver")
+	hh := seedHouseholdRow(t, g, ownerID, "NWTGrace", 30)
+	addMember(t, g, hh.ID, ownerID, model.RoleOwner, nil)
+	leftAt := time.Now().Add(-3 * 24 * time.Hour)
+	addMember(t, g, hh.ID, leaverID, model.RoleContributor, &leftAt)
+
+	ownerAcct := seedAccount(t, g, ownerID, "owner")
+	leaverAcct := seedAccount(t, g, leaverID, "leaver")
+	upsertPosition(t, g, ownerID, ownerAcct.ID, usd, "100")
+	upsertPosition(t, g, leaverID, leaverAcct.ID, usd, "9999")
+	setShare(t, g, ownerAcct.ID, hh.ID, model.VisibilityBalanceAndTxns)
+	setShare(t, g, leaverAcct.ID, hh.ID, model.VisibilityBalanceAndTxns)
+
+	now := time.Now().UTC()
+	agg.SetClock(func() time.Time { return now })
+	out, err := agg.NetWorthTrend(ctx, hh.ID, 1)
+	if err != nil {
+		t.Fatalf("NetWorthTrend: %v", err)
+	}
+	for _, p := range out {
+		if p.Value != "100" {
+			t.Errorf("point %+v != 100 — in-grace leaver leaked", p)
+		}
+	}
+}

--- a/backend/internal/service/household/aggregator_test.go
+++ b/backend/internal/service/household/aggregator_test.go
@@ -365,6 +365,9 @@ func TestAggregator_NoRawTransactionRows(t *testing.T) {
 	check("GoalProgressItem", household.GoalProgressItem{})
 	check("HouseholdAIContext", household.HouseholdAIContext{})
 	check("ThreadSummary", household.ThreadSummary{})
+	check("AssetClassAllocation", household.AssetClassAllocation{})
+	check("NetWorthPoint", household.NetWorthPoint{})
+	check("AccountSummary", household.AccountSummary{})
 }
 
 func walkType(t *testing.T, path string, ty, forbid reflect.Type, seen map[reflect.Type]struct{}) {

--- a/backend/internal/service/valuation/valuation.go
+++ b/backend/internal/service/valuation/valuation.go
@@ -1,0 +1,174 @@
+// Package valuation centralizes the "positions × prices" math that
+// powers every monetary read after ADR-0013. Per the ADR, quantities
+// are facts and balances are derived — never stored on accounts. This
+// package is the single place that walks the (asset, quote_asset,
+// as_of) graph and decides when a price is too stale to trust.
+package valuation
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/shopspring/decimal"
+
+	"github.com/gregwym/offbook/backend/internal/model"
+	"github.com/gregwym/offbook/backend/internal/repository"
+)
+
+// DefaultStaleWindow is how recently a price must have been observed
+// for the helper to use it. Beyond this, callers get ErrStalePrice so
+// the UI can render "stale" instead of silently showing 0 (or worse,
+// a year-old price as if it were current).
+const DefaultStaleWindow = 7 * 24 * time.Hour
+
+// ErrStalePrice is returned when no price observation exists within
+// the stale window for a requested (asset → quote) hop. Callers
+// decide whether to surface as a warning or treat as 0.
+var ErrStalePrice = errors.New("valuation: no fresh price within stale window")
+
+// Service computes monetary values from positions × prices. It does
+// one-hop FX through the asset's native quote currency when no direct
+// (asset → user quote) price exists — e.g. AAPL is quoted in USD; to
+// price it in EUR we walk AAPL→USD then USD→EUR.
+type Service struct {
+	positions repository.PositionRepository
+	prices    repository.PriceRepository
+	assets    repository.AssetRepository
+	accounts  repository.AccountRepository
+
+	staleWindow time.Duration
+}
+
+// NewService wires the repositories the helper reads from. None are
+// optional — every method reads at least positions and prices.
+func NewService(
+	positions repository.PositionRepository,
+	prices repository.PriceRepository,
+	assets repository.AssetRepository,
+	accounts repository.AccountRepository,
+) *Service {
+	return &Service{
+		positions:   positions,
+		prices:      prices,
+		assets:      assets,
+		accounts:    accounts,
+		staleWindow: DefaultStaleWindow,
+	}
+}
+
+// WithStaleWindow overrides the default 7-day tolerance. Pass a
+// non-positive value to disable the staleness check entirely (used
+// by the historical net-worth trend, where any-age price is fine).
+func (s *Service) WithStaleWindow(d time.Duration) *Service {
+	s.staleWindow = d
+	return s
+}
+
+// StaleWindow returns the currently-configured stale window. Useful
+// for tests and for callers that want to render "as-of" labels.
+func (s *Service) StaleWindow() time.Duration { return s.staleWindow }
+
+// Value returns pos.Quantity priced in quoteAssetID at asOf. The
+// graph walk:
+//
+//  1. If position.asset_id == quoteAssetID, return quantity directly
+//     (no price lookup; never stale).
+//  2. Try a direct price (asset_id → quoteAssetID).
+//  3. If the position's asset has a native quote currency that is
+//     neither the asset nor quoteAssetID, walk the two hops
+//     asset → native quote → quoteAssetID.
+//
+// Returns ErrStalePrice if no fresh price chain is found. The
+// returned error wraps ErrStalePrice so errors.Is callers work.
+func (s *Service) Value(ctx context.Context, pos model.Position, asOf time.Time, quoteAssetID int64) (decimal.Decimal, error) {
+	if pos.AssetID == quoteAssetID {
+		return pos.Quantity, nil
+	}
+
+	if rate, ok, err := s.lookupRate(ctx, pos.AssetID, quoteAssetID, asOf); err != nil {
+		return decimal.Zero, err
+	} else if ok {
+		return pos.Quantity.Mul(rate), nil
+	}
+
+	asset, err := s.assets.GetByID(ctx, pos.AssetID)
+	if err != nil {
+		return decimal.Zero, fmt.Errorf("valuation: load asset %d: %w", pos.AssetID, err)
+	}
+	if asset.QuoteCurrencyAssetID == nil ||
+		*asset.QuoteCurrencyAssetID == pos.AssetID ||
+		*asset.QuoteCurrencyAssetID == quoteAssetID {
+		return decimal.Zero, fmt.Errorf("%w: asset %d → quote %d", ErrStalePrice, pos.AssetID, quoteAssetID)
+	}
+
+	leg1, ok, err := s.lookupRate(ctx, pos.AssetID, *asset.QuoteCurrencyAssetID, asOf)
+	if err != nil {
+		return decimal.Zero, err
+	}
+	if !ok {
+		return decimal.Zero, fmt.Errorf("%w: asset %d → native quote %d", ErrStalePrice, pos.AssetID, *asset.QuoteCurrencyAssetID)
+	}
+	leg2, ok, err := s.lookupRate(ctx, *asset.QuoteCurrencyAssetID, quoteAssetID, asOf)
+	if err != nil {
+		return decimal.Zero, err
+	}
+	if !ok {
+		return decimal.Zero, fmt.Errorf("%w: native quote %d → user quote %d", ErrStalePrice, *asset.QuoteCurrencyAssetID, quoteAssetID)
+	}
+	return pos.Quantity.Mul(leg1).Mul(leg2), nil
+}
+
+// AccountBalance returns the sum of the account's positions valued at
+// asOf in the account's primary_quote_asset_id. Positions whose price
+// chain is stale contribute 0 — this matches the soft-fallback behavior
+// of the dashboard query so callers can render a number without crashing,
+// and a separate stale-price audit surface can warn the user.
+//
+// Stale positions are still reported in `staleAssets` so the caller can
+// render the warning. An empty `staleAssets` means every position priced
+// fresh. The caller is responsible for tenancy (passing the right userID).
+func (s *Service) AccountBalance(ctx context.Context, userID, accountID int64, asOf time.Time) (decimal.Decimal, []int64, error) {
+	acct, err := s.accounts.GetByID(ctx, userID, accountID)
+	if err != nil {
+		return decimal.Zero, nil, fmt.Errorf("valuation: load account %d: %w", accountID, err)
+	}
+	positions, err := s.positions.ListByAccountID(ctx, userID, accountID)
+	if err != nil {
+		return decimal.Zero, nil, fmt.Errorf("valuation: list positions for account %d: %w", accountID, err)
+	}
+	total := decimal.Zero
+	var stale []int64
+	for _, p := range positions {
+		v, err := s.Value(ctx, p, asOf, acct.PrimaryQuoteAssetID)
+		if errors.Is(err, ErrStalePrice) {
+			stale = append(stale, p.AssetID)
+			continue
+		}
+		if err != nil {
+			return decimal.Zero, nil, err
+		}
+		total = total.Add(v)
+	}
+	return total, stale, nil
+}
+
+// lookupRate returns the most-recent price for (assetID → quoteAssetID)
+// at-or-before asOf, gated by the configured stale window. Returns
+// (price, true, nil) on hit, (_, false, nil) when no row or when the
+// freshest row is older than the window, (_, _, err) on a real I/O
+// error. A staleWindow <= 0 disables the freshness gate entirely.
+func (s *Service) lookupRate(ctx context.Context, assetID, quoteAssetID int64, asOf time.Time) (decimal.Decimal, bool, error) {
+	p, err := s.prices.LatestPriceAt(ctx, assetID, quoteAssetID, asOf)
+	if err != nil {
+		if errors.Is(err, repository.ErrNotFound) {
+			return decimal.Zero, false, nil
+		}
+		return decimal.Zero, false, fmt.Errorf("valuation: price lookup %d → %d at %s: %w", assetID, quoteAssetID, asOf.Format(time.RFC3339), err)
+	}
+	if s.staleWindow > 0 && asOf.Sub(p.AsOf) > s.staleWindow {
+		return decimal.Zero, false, nil
+	}
+	return p.Price, true, nil
+}

--- a/backend/internal/service/valuation/valuation_test.go
+++ b/backend/internal/service/valuation/valuation_test.go
@@ -1,0 +1,305 @@
+package valuation_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/joho/godotenv"
+	"github.com/shopspring/decimal"
+	"gorm.io/gorm"
+
+	"github.com/gregwym/offbook/backend/internal/db"
+	"github.com/gregwym/offbook/backend/internal/model"
+	"github.com/gregwym/offbook/backend/internal/repository"
+	"github.com/gregwym/offbook/backend/internal/service/valuation"
+	"github.com/gregwym/offbook/backend/internal/testutil"
+)
+
+func loadRepoDotenv() {
+	dir, err := os.Getwd()
+	if err != nil {
+		return
+	}
+	for i := 0; i < 8; i++ {
+		envPath := filepath.Join(dir, ".env")
+		if _, err := os.Stat(envPath); err == nil {
+			_ = godotenv.Load(envPath)
+			return
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return
+		}
+		dir = parent
+	}
+}
+
+func openTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	loadRepoDotenv()
+	url := os.Getenv("TEST_DATABASE_URL")
+	if url == "" {
+		url = os.Getenv("DATABASE_URL")
+	}
+	if url == "" {
+		t.Skip("no DATABASE_URL set; skipping integration test")
+	}
+	g, err := db.Open(url)
+	if err != nil {
+		t.Fatalf("db.Open: %v", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := db.Ping(ctx, g); err != nil {
+		t.Skipf("db.Ping: %v; skipping integration test", err)
+	}
+	return g
+}
+
+func newSvc(t *testing.T) (*valuation.Service, *gorm.DB) {
+	t.Helper()
+	g := openTestDB(t)
+	svc := valuation.NewService(
+		repository.NewPositionRepository(g),
+		repository.NewPriceRepository(g),
+		repository.NewAssetRepository(g),
+		repository.NewAccountRepository(g),
+	)
+	return svc, g
+}
+
+func seedUser(t *testing.T, g *gorm.DB, label string) int64 {
+	t.Helper()
+	u := &model.User{
+		Email:                  fmt.Sprintf("val-%s-%d@example.test", label, time.Now().UnixNano()),
+		PasswordHash:           "x",
+		LastScope:              model.ScopePersonal,
+		DefaultScope:           model.ScopePersonal,
+		PrimaryCurrencyAssetID: testutil.LookupUSDAssetID(t, g),
+	}
+	if err := g.Create(u).Error; err != nil {
+		t.Fatalf("seed user: %v", err)
+	}
+	t.Cleanup(func() {
+		g.Unscoped().Where("user_id = ?", u.ID).Delete(&model.Position{})
+		g.Unscoped().Where("user_id = ?", u.ID).Delete(&model.Account{})
+		g.Unscoped().Delete(&model.User{}, u.ID)
+	})
+	return u.ID
+}
+
+func seedAccount(t *testing.T, g *gorm.DB, userID int64, label string, currency string) *model.Account {
+	t.Helper()
+	a := &model.Account{
+		UserID:              userID,
+		Name:                "val-" + label + "-" + fmt.Sprintf("%d", time.Now().UnixNano()),
+		InstitutionSlug:     "fixture",
+		AccountType:         "checking",
+		Currency:            currency,
+		PrimaryQuoteAssetID: testutil.LookupAssetID(t, g, currency, "fiat"),
+		IsActive:            true,
+	}
+	if err := g.Create(a).Error; err != nil {
+		t.Fatalf("seed account: %v", err)
+	}
+	t.Cleanup(func() { g.Unscoped().Delete(&model.Account{}, a.ID) })
+	return a
+}
+
+func upsertPosition(t *testing.T, g *gorm.DB, userID, accountID, assetID int64, quantity string) *model.Position {
+	t.Helper()
+	q, _ := decimal.NewFromString(quantity)
+	p := &model.Position{UserID: userID, AccountID: accountID, AssetID: assetID, Quantity: q}
+	if err := g.Create(p).Error; err != nil {
+		t.Fatalf("seed position: %v", err)
+	}
+	t.Cleanup(func() { g.Unscoped().Delete(&model.Position{}, p.ID) })
+	return p
+}
+
+func insertPrice(t *testing.T, g *gorm.DB, assetID, quoteAssetID int64, price string, asOf time.Time) {
+	t.Helper()
+	pr, _ := decimal.NewFromString(price)
+	p := &model.Price{AssetID: assetID, QuoteAssetID: quoteAssetID, Price: pr, AsOf: asOf, Source: "test"}
+	if err := g.Create(p).Error; err != nil {
+		t.Fatalf("seed price: %v", err)
+	}
+	t.Cleanup(func() { g.Unscoped().Delete(&model.Price{}, p.ID) })
+}
+
+// TestValue_SameAsset returns quantity directly — the cheapest hop, with no
+// price lookup and never stale.
+func TestValue_SameAsset(t *testing.T) {
+	svc, g := newSvc(t)
+	ctx := context.Background()
+	usd := testutil.LookupUSDAssetID(t, g)
+	userID := seedUser(t, g, "same")
+	acct := seedAccount(t, g, userID, "chk", "USD")
+
+	pos := upsertPosition(t, g, userID, acct.ID, usd, "1234.56")
+	got, err := svc.Value(ctx, *pos, time.Now(), usd)
+	if err != nil {
+		t.Fatalf("Value: %v", err)
+	}
+	if got.String() != "1234.56" {
+		t.Errorf("Value = %q, want 1234.56", got.String())
+	}
+}
+
+// TestValue_DirectPrice takes the asset → quote price as-is.
+func TestValue_DirectPrice(t *testing.T) {
+	svc, g := newSvc(t)
+	ctx := context.Background()
+	usd := testutil.LookupUSDAssetID(t, g)
+	eur := testutil.LookupAssetID(t, g, "EUR", "fiat")
+	userID := seedUser(t, g, "direct")
+	acct := seedAccount(t, g, userID, "eur", "EUR")
+
+	pos := upsertPosition(t, g, userID, acct.ID, eur, "100")
+	insertPrice(t, g, eur, usd, "1.10", time.Now().Add(-time.Hour))
+
+	got, err := svc.Value(ctx, *pos, time.Now(), usd)
+	if err != nil {
+		t.Fatalf("Value: %v", err)
+	}
+	if got.String() != "110" {
+		t.Errorf("Value = %q, want 110 (100 EUR × 1.10)", got.String())
+	}
+}
+
+// TestValue_TwoHopFX walks asset → native quote → user quote when no direct
+// price exists. AAPL is quoted natively in USD; we ask for the value in EUR.
+func TestValue_TwoHopFX(t *testing.T) {
+	svc, g := newSvc(t)
+	ctx := context.Background()
+	usd := testutil.LookupUSDAssetID(t, g)
+	eur := testutil.LookupAssetID(t, g, "EUR", "fiat")
+	// AAPL with native quote USD.
+	aapl := &model.Asset{Symbol: "AAPL-VAL", Kind: model.AssetKindEquity, QuoteCurrencyAssetID: &usd, Precision: 8}
+	if err := g.Create(aapl).Error; err != nil {
+		t.Fatalf("seed AAPL: %v", err)
+	}
+	t.Cleanup(func() { g.Unscoped().Delete(&model.Asset{}, aapl.ID) })
+
+	userID := seedUser(t, g, "twohop")
+	acct := seedAccount(t, g, userID, "brk", "EUR")
+
+	pos := upsertPosition(t, g, userID, acct.ID, aapl.ID, "10")
+	asOf := time.Now()
+	// AAPL → USD = 200; USD → EUR = 0.9. Value in EUR = 10 × 200 × 0.9 = 1800.
+	insertPrice(t, g, aapl.ID, usd, "200", asOf.Add(-time.Hour))
+	insertPrice(t, g, usd, eur, "0.9", asOf.Add(-time.Hour))
+
+	got, err := svc.Value(ctx, *pos, asOf, eur)
+	if err != nil {
+		t.Fatalf("Value: %v", err)
+	}
+	if got.String() != "1800" {
+		t.Errorf("Value = %q, want 1800", got.String())
+	}
+}
+
+// TestValue_StalePrice returns ErrStalePrice when the freshest observation
+// is older than the configured window.
+func TestValue_StalePrice(t *testing.T) {
+	svc, g := newSvc(t)
+	svc.WithStaleWindow(24 * time.Hour) // tight window so we can construct staleness
+	ctx := context.Background()
+	usd := testutil.LookupUSDAssetID(t, g)
+	eur := testutil.LookupAssetID(t, g, "EUR", "fiat")
+	userID := seedUser(t, g, "stale")
+	acct := seedAccount(t, g, userID, "eur", "EUR")
+
+	pos := upsertPosition(t, g, userID, acct.ID, eur, "100")
+	// Price from 30 days ago — well outside 24h window.
+	insertPrice(t, g, eur, usd, "1.10", time.Now().Add(-30*24*time.Hour))
+
+	_, err := svc.Value(ctx, *pos, time.Now(), usd)
+	if !errors.Is(err, valuation.ErrStalePrice) {
+		t.Fatalf("Value err = %v, want ErrStalePrice", err)
+	}
+}
+
+// TestValue_NoPriceChain returns ErrStalePrice when neither direct nor
+// two-hop pricing yields any observation. (Same sentinel — "no fresh
+// chain" subsumes "no chain at all" for caller semantics.)
+func TestValue_NoPriceChain(t *testing.T) {
+	svc, g := newSvc(t)
+	ctx := context.Background()
+	usd := testutil.LookupUSDAssetID(t, g)
+	// Asset with no quote currency and no prices anywhere.
+	tk := &model.Asset{Symbol: "ZZZ-VAL", Kind: model.AssetKindOther, Precision: 8}
+	if err := g.Create(tk).Error; err != nil {
+		t.Fatalf("seed ZZZ: %v", err)
+	}
+	t.Cleanup(func() { g.Unscoped().Delete(&model.Asset{}, tk.ID) })
+
+	userID := seedUser(t, g, "nochain")
+	acct := seedAccount(t, g, userID, "any", "USD")
+	pos := upsertPosition(t, g, userID, acct.ID, tk.ID, "5")
+
+	_, err := svc.Value(ctx, *pos, time.Now(), usd)
+	if !errors.Is(err, valuation.ErrStalePrice) {
+		t.Fatalf("Value err = %v, want ErrStalePrice", err)
+	}
+}
+
+// TestAccountBalance_SumsPositions sums all positions in an account, with
+// fresh prices returning a clean total and no stale-asset list.
+func TestAccountBalance_SumsPositions(t *testing.T) {
+	svc, g := newSvc(t)
+	ctx := context.Background()
+	usd := testutil.LookupUSDAssetID(t, g)
+	eur := testutil.LookupAssetID(t, g, "EUR", "fiat")
+	userID := seedUser(t, g, "balance-sum")
+	acct := seedAccount(t, g, userID, "mixed", "USD")
+
+	upsertPosition(t, g, userID, acct.ID, usd, "500.00")
+	upsertPosition(t, g, userID, acct.ID, eur, "100")
+	insertPrice(t, g, eur, usd, "1.20", time.Now().Add(-time.Hour))
+
+	total, stale, err := svc.AccountBalance(ctx, userID, acct.ID, time.Now())
+	if err != nil {
+		t.Fatalf("AccountBalance: %v", err)
+	}
+	if total.String() != "620" {
+		t.Errorf("total = %q, want 620 (500 USD + 100 EUR × 1.20)", total.String())
+	}
+	if len(stale) != 0 {
+		t.Errorf("stale = %v, want empty", stale)
+	}
+}
+
+// TestAccountBalance_StaleContributesZero — a stale-priced position
+// contributes 0 to the total but appears in the stale list so the UI
+// can warn.
+func TestAccountBalance_StaleContributesZero(t *testing.T) {
+	svc, g := newSvc(t)
+	svc.WithStaleWindow(24 * time.Hour)
+	ctx := context.Background()
+	usd := testutil.LookupUSDAssetID(t, g)
+	eur := testutil.LookupAssetID(t, g, "EUR", "fiat")
+	userID := seedUser(t, g, "balance-stale")
+	acct := seedAccount(t, g, userID, "mixed", "USD")
+
+	upsertPosition(t, g, userID, acct.ID, usd, "500.00")
+	upsertPosition(t, g, userID, acct.ID, eur, "100")
+	// Stale EUR price.
+	insertPrice(t, g, eur, usd, "1.20", time.Now().Add(-30*24*time.Hour))
+
+	total, stale, err := svc.AccountBalance(ctx, userID, acct.ID, time.Now())
+	if err != nil {
+		t.Fatalf("AccountBalance: %v", err)
+	}
+	if total.String() != "500" {
+		t.Errorf("total = %q, want 500 (stale EUR contributes 0)", total.String())
+	}
+	if len(stale) != 1 || stale[0] != eur {
+		t.Errorf("stale = %v, want [%d]", stale, eur)
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `service/valuation` with `Value(position, asOf, quoteAsset)` (direct → one-hop FX) and `AccountBalance` (per-account sum with stale-asset reporting). Default stale window 7d, configurable.
- Adds `Aggregator.Allocation` / `NetWorthTrend` / `AccountSummaries` on the household aggregator, all honoring private-vs-shared and live-vs-grace lifecycle rules.
- Adds `GET /h/insights/{allocation,net-worth,accounts}` handlers — closes the M9 #225 household-allocation gap.

## Test plan
- [x] `command make verify` (backend vet + lint + test) green locally
- [x] New valuation unit suite (same-asset, direct, two-hop FX, stale, no-chain, AccountBalance sum + stale fallback)
- [x] New aggregator privacy tests for Allocation, NetWorthTrend, AccountSummaries (private excluded; in-grace excluded from live)
- [x] Reflection no-raw-txn check extended to the three new return types
- [ ] Frontend lint+build (no FE changes; CI verifies)

Closes part 2 of #237. Trade ingestion + cost-basis follow in #238.

🤖 Generated with [Claude Code](https://claude.com/claude-code)