### PR TITLE
M10b part 1: manual trade ingestion + cost basis + asset_id rules

### DIFF
--- a/backend/internal/handler/categorization_rule_handler.go
+++ b/backend/internal/handler/categorization_rule_handler.go
@@ -53,6 +53,7 @@ type createRuleRequest struct {
 	Pattern    string `json:"pattern"`
 	MatchType  string `json:"match_type"`
 	CategoryID int64  `json:"category_id"`
+	AssetID    *int64 `json:"asset_id"`
 	Priority   int    `json:"priority"`
 	IsActive   *bool  `json:"is_active"`
 }
@@ -67,6 +68,7 @@ func (h *CategorizationRuleHandler) Create(c *gin.Context) {
 		Pattern:    req.Pattern,
 		MatchType:  req.MatchType,
 		CategoryID: req.CategoryID,
+		AssetID:    req.AssetID,
 		Priority:   req.Priority,
 		IsActive:   req.IsActive,
 	})
@@ -100,11 +102,13 @@ func (h *CategorizationRuleHandler) List(c *gin.Context) {
 }
 
 type updateRuleRequest struct {
-	Pattern    *string `json:"pattern"`
-	MatchType  *string `json:"match_type"`
-	CategoryID *int64  `json:"category_id"`
-	Priority   *int    `json:"priority"`
-	IsActive   *bool   `json:"is_active"`
+	Pattern      *string `json:"pattern"`
+	MatchType    *string `json:"match_type"`
+	CategoryID   *int64  `json:"category_id"`
+	AssetID      *int64  `json:"asset_id"`
+	ClearAssetID bool    `json:"clear_asset_id"`
+	Priority     *int    `json:"priority"`
+	IsActive     *bool   `json:"is_active"`
 }
 
 func (h *CategorizationRuleHandler) Update(c *gin.Context) {
@@ -117,7 +121,15 @@ func (h *CategorizationRuleHandler) Update(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error(), "code": "INVALID_REQUEST"})
 		return
 	}
-	r, err := h.svc.Update(c.Request.Context(), auth.MustUserID(c.Request.Context()), id, service.UpdateRuleInput(req))
+	r, err := h.svc.Update(c.Request.Context(), auth.MustUserID(c.Request.Context()), id, service.UpdateRuleInput{
+		Pattern:      req.Pattern,
+		MatchType:    req.MatchType,
+		CategoryID:   req.CategoryID,
+		AssetID:      req.AssetID,
+		ClearAssetID: req.ClearAssetID,
+		Priority:     req.Priority,
+		IsActive:     req.IsActive,
+	})
 	if err != nil {
 		h.writeServiceError(c, err)
 		return

--- a/backend/internal/handler/trade_handler.go
+++ b/backend/internal/handler/trade_handler.go
@@ -1,0 +1,97 @@
+package handler
+
+import (
+	"errors"
+	"net/http"
+	"strconv"
+
+	"github.com/gin-gonic/gin"
+	"github.com/shopspring/decimal"
+
+	"github.com/gregwym/offbook/backend/internal/service"
+	"github.com/gregwym/offbook/backend/internal/service/auth"
+)
+
+// TradeHandler exposes the manual trade-entry surface introduced in
+// #238. It lives under /accounts/:id/trades because trades belong to a
+// specific account — the account scopes both authorization (the
+// session user must own it) and the cash leg's asset.
+type TradeHandler struct {
+	svc *service.TradeService
+}
+
+func NewTradeHandler(s *service.TradeService) *TradeHandler {
+	return &TradeHandler{svc: s}
+}
+
+func (h *TradeHandler) Register(g *gin.RouterGroup) {
+	g.POST("/accounts/:id/trades", h.Create)
+}
+
+type createTradeRequest struct {
+	Kind      string           `json:"kind"`
+	AssetID   int64            `json:"asset_id"`
+	Quantity  *decimal.Decimal `json:"quantity"`
+	Price     *decimal.Decimal `json:"price"`
+	TradeDate string           `json:"trade_date"`
+	Notes     *string          `json:"notes"`
+}
+
+func (h *TradeHandler) Create(c *gin.Context) {
+	idStr := c.Param("id")
+	accountID, err := strconv.ParseInt(idStr, 10, 64)
+	if err != nil || accountID <= 0 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid account id", "code": "INVALID_REQUEST"})
+		return
+	}
+	var req createTradeRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error(), "code": "INVALID_REQUEST"})
+		return
+	}
+	if req.Quantity == nil || req.Price == nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "quantity and price are required", "code": "INVALID_REQUEST"})
+		return
+	}
+	tradeDate, ok := parseFlexibleDate(c, req.TradeDate, "trade_date")
+	if !ok {
+		return
+	}
+	in := service.RecordTradeInput{
+		Kind:      req.Kind,
+		AssetID:   req.AssetID,
+		Quantity:  *req.Quantity,
+		Price:     *req.Price,
+		TradeDate: tradeDate,
+		Notes:     req.Notes,
+	}
+	rec, err := h.svc.Record(c.Request.Context(), auth.MustUserID(c.Request.Context()), accountID, in)
+	if err != nil {
+		h.writeError(c, err)
+		return
+	}
+	c.JSON(http.StatusCreated, gin.H{"data": rec})
+}
+
+func (h *TradeHandler) writeError(c *gin.Context, err error) {
+	switch {
+	case errors.Is(err, service.ErrAccountNotFound):
+		c.JSON(http.StatusNotFound, gin.H{"error": err.Error(), "code": "ACCOUNT_NOT_FOUND"})
+	case errors.Is(err, service.ErrUnknownAsset):
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error(), "code": "UNKNOWN_ASSET"})
+	case errors.Is(err, service.ErrUnsupportedAccount):
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error(), "code": "UNSUPPORTED_ACCOUNT"})
+	case errors.Is(err, service.ErrInvalidTradeKind),
+		errors.Is(err, service.ErrInvalidQuantity),
+		errors.Is(err, service.ErrInvalidPrice),
+		errors.Is(err, service.ErrSecurityEqualsQuote),
+		errors.Is(err, service.ErrMissingDate):
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error(), "code": "INVALID_TRADE"})
+	case errors.Is(err, service.ErrSellExceedsHoldings):
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error(), "code": "INSUFFICIENT_HOLDING"})
+	case errors.Is(err, service.ErrTradeFXUnavailable):
+		c.JSON(http.StatusUnprocessableEntity, gin.H{"error": err.Error(), "code": "FX_UNAVAILABLE"})
+	default:
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error(), "code": "INTERNAL"})
+	}
+}

--- a/backend/internal/model/categorization_rule.go
+++ b/backend/internal/model/categorization_rule.go
@@ -7,18 +7,23 @@ import (
 )
 
 type CategorizationRule struct {
-	ID         int64          `gorm:"primaryKey" json:"id"`
-	UserID     int64          `gorm:"not null;index" json:"user_id"`
-	Pattern    string         `gorm:"not null" json:"pattern"`
-	CategoryID int64          `gorm:"not null" json:"category_id"`
-	MatchType  string         `gorm:"not null" json:"match_type"`
-	Priority   int            `gorm:"not null;default:0" json:"priority"`
-	IsActive   bool           `gorm:"not null;default:true" json:"is_active"`
-	CreatedAt  time.Time      `json:"created_at"`
-	UpdatedAt  time.Time      `json:"updated_at"`
-	DeletedAt  gorm.DeletedAt `gorm:"index" json:"-"`
+	ID         int64  `gorm:"primaryKey" json:"id"`
+	UserID     int64  `gorm:"not null;index" json:"user_id"`
+	Pattern    string `gorm:"not null" json:"pattern"`
+	CategoryID int64  `gorm:"not null" json:"category_id"`
+	MatchType  string `gorm:"not null" json:"match_type"`
+	Priority   int    `gorm:"not null;default:0" json:"priority"`
+	IsActive   bool   `gorm:"not null;default:true" json:"is_active"`
+	// AssetID, when non-nil, narrows the rule to transactions whose
+	// asset_id matches. Combined (AND) with the text matcher. NULL keeps
+	// the rule asset-agnostic — the M2-era behavior.
+	AssetID   *int64         `json:"asset_id,omitempty"`
+	CreatedAt time.Time      `json:"created_at"`
+	UpdatedAt time.Time      `json:"updated_at"`
+	DeletedAt gorm.DeletedAt `gorm:"index" json:"-"`
 
 	Category *Category `gorm:"foreignKey:CategoryID" json:"-"`
+	Asset    *Asset    `gorm:"foreignKey:AssetID" json:"-"`
 }
 
 func (CategorizationRule) TableName() string { return "categorization_rules" }

--- a/backend/internal/repository/dashboard_repo.go
+++ b/backend/internal/repository/dashboard_repo.go
@@ -98,6 +98,21 @@ type DashboardRepository interface {
 	// the current persisted balance; older months back-derive by undoing
 	// transactions between the row's month-end and now.
 	NetWorthByMonth(ctx context.Context, userID int64, now time.Time, months int) ([]NetWorthMonth, error)
+	// TradeSummaryByKind aggregates security-leg counts and gross
+	// notional (|security qty × latest_price_to_primary|) over [from, to),
+	// grouped by the asset's kind ('equity', 'crypto', …). Fiat legs are
+	// excluded by construction (a trade's security leg is never fiat).
+	// Returns rows ordered by gross DESC.
+	TradeSummaryByKind(ctx context.Context, userID int64, from, to time.Time) ([]TradeKindAggregate, error)
+}
+
+// TradeKindAggregate is one row of the trade rollup surfaced to the AI
+// context builder. Values are user-primary-currency strings to preserve
+// NUMERIC precision across the wire; the LLM sees stable decimal text.
+type TradeKindAggregate struct {
+	Kind       string
+	LegCount   int64
+	GrossValue decimal.Decimal
 }
 
 type dashboardRepo struct {
@@ -369,6 +384,55 @@ func (r *dashboardRepo) NetWorthByMonth(ctx context.Context, userID int64, now t
 			}
 		}
 		out[i].Total = curD.Sub(undo)
+	}
+	return out, nil
+}
+
+// TradeSummaryByKind walks paired trade rows (security legs only, fiat
+// excluded) in [from, to) and rolls them up by asset kind. Gross value
+// is |security qty × latest_price_to_primary| — i.e. the security
+// leg's notional expressed in the user's primary currency. Trades
+// without a fresh price land in the row but contribute 0 to gross
+// (same soft-fallback as net worth).
+func (r *dashboardRepo) TradeSummaryByKind(ctx context.Context, userID int64, from, to time.Time) ([]TradeKindAggregate, error) {
+	type row struct {
+		Kind     string
+		LegCount int64
+		Gross    string
+	}
+	var rows []row
+	if err := r.db.WithContext(ctx).Raw(`
+		SELECT
+			a.kind AS kind,
+			COUNT(*) AS leg_count,
+			COALESCE(SUM(
+				ABS(t.amount) * COALESCE((
+					SELECT pr.price FROM prices pr
+					WHERE pr.asset_id = t.asset_id
+					  AND pr.quote_asset_id = u.primary_currency_asset_id
+					  AND pr.as_of <= NOW()
+					ORDER BY pr.as_of DESC
+					LIMIT 1
+				), 0)
+			), 0)::text AS gross
+		FROM transactions t
+		JOIN assets a ON a.id = t.asset_id
+		JOIN users  u ON u.id = t.user_id
+		WHERE t.deleted_at IS NULL
+		  AND t.user_id = ?
+		  AND t.transfer_pair_id IS NOT NULL
+		  AND a.kind <> 'fiat'
+		  AND t.transaction_date >= ?
+		  AND t.transaction_date <  ?
+		GROUP BY a.kind
+		ORDER BY gross DESC
+	`, userID, from, to).Scan(&rows).Error; err != nil {
+		return nil, err
+	}
+	out := make([]TradeKindAggregate, 0, len(rows))
+	for _, r := range rows {
+		gross, _ := decimal.NewFromString(r.Gross)
+		out = append(out, TradeKindAggregate{Kind: r.Kind, LegCount: r.LegCount, GrossValue: gross})
 	}
 	return out, nil
 }

--- a/backend/internal/repository/transaction_repo.go
+++ b/backend/internal/repository/transaction_repo.go
@@ -64,6 +64,28 @@ type TransactionRepository interface {
 	// (live or soft-deleted) for the key. The caller is expected to pass a
 	// row produced by plaid.MergePlaidUpdate so user-edited fields survive.
 	ResurrectByPlaidTransactionID(ctx context.Context, userID int64, plaidTxnID string, merged model.Transaction) error
+	// CreateTradePair inserts two paired transaction rows in one DB
+	// transaction, generating a shared transfer_pair_id pointing at both
+	// rows' IDs. Used by manual trade entry and Plaid investment-
+	// transactions ingestion (#238). Both legs must already carry the
+	// same UserID; the repo does NOT enforce that the pair makes
+	// accounting sense (signs/quantities/assets) — that's the service's
+	// job. On success the supplied legs are populated with their assigned
+	// IDs and the shared TransferPairID.
+	//
+	// The pairing scheme stores legA.TransferPairID = legB.ID and
+	// legB.TransferPairID = legA.ID — symmetric, so either side can find
+	// its partner with one indexed lookup.
+	CreateTradePair(ctx context.Context, legA, legB *model.Transaction) error
+	// ListByTransferPairID returns the two (or rarely one — e.g. mid-
+	// migration) live transactions sharing a transfer_pair_id, scoped to
+	// the supplied user. Returns ErrNotFound when neither row exists.
+	ListByTransferPairID(ctx context.Context, userID, pairID int64) ([]model.Transaction, error)
+	// ListByAccountAndAsset returns every non-deleted transaction for the
+	// (account, asset) pair ordered by transaction_date ASC, id ASC. Used
+	// by the cost-basis recompute, which walks the entire trade history
+	// per (account, asset) and folds quantities + cash legs together.
+	ListByAccountAndAsset(ctx context.Context, userID, accountID, assetID int64) ([]model.Transaction, error)
 	// ListForCategorizationScope returns a chunk of non-deleted transactions
 	// for the user, ordered by id ASC for cursor-style pagination. Callers
 	// drive a loop by passing the last returned row's id as afterID on the
@@ -310,6 +332,65 @@ func (r *transactionRepo) ListForCategorizationScope(ctx context.Context, userID
 	}
 	var out []model.Transaction
 	if err := q.Order("id ASC").Limit(limit).Find(&out).Error; err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (r *transactionRepo) CreateTradePair(ctx context.Context, legA, legB *model.Transaction) error {
+	if legA == nil || legB == nil {
+		return errors.New("trade pair requires two legs")
+	}
+	if legA.UserID == 0 || legB.UserID == 0 || legA.UserID != legB.UserID {
+		return errors.New("trade pair legs must share a user_id")
+	}
+	// Wrap both inserts in one DB transaction so a mid-flight failure
+	// rolls back the partner row. Use a tx-bound repo for both writes.
+	return r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		if err := tx.Create(legA).Error; err != nil {
+			return err
+		}
+		if err := tx.Create(legB).Error; err != nil {
+			return err
+		}
+		// Cross-link by ID: legA points at legB, legB points at legA.
+		legA.TransferPairID = &legB.ID
+		legB.TransferPairID = &legA.ID
+		if err := tx.Model(legA).Where("id = ?", legA.ID).
+			Update("transfer_pair_id", legB.ID).Error; err != nil {
+			return err
+		}
+		if err := tx.Model(legB).Where("id = ?", legB.ID).
+			Update("transfer_pair_id", legA.ID).Error; err != nil {
+			return err
+		}
+		return nil
+	})
+}
+
+func (r *transactionRepo) ListByTransferPairID(ctx context.Context, userID, pairID int64) ([]model.Transaction, error) {
+	if pairID <= 0 {
+		return nil, ErrNotFound
+	}
+	var out []model.Transaction
+	if err := r.db.WithContext(ctx).
+		Where("user_id = ? AND (id = ? OR transfer_pair_id = ?)", userID, pairID, pairID).
+		Order("id ASC").
+		Find(&out).Error; err != nil {
+		return nil, err
+	}
+	if len(out) == 0 {
+		return nil, ErrNotFound
+	}
+	return out, nil
+}
+
+func (r *transactionRepo) ListByAccountAndAsset(ctx context.Context, userID, accountID, assetID int64) ([]model.Transaction, error) {
+	var out []model.Transaction
+	if err := r.db.WithContext(ctx).
+		Where("user_id = ? AND account_id = ? AND asset_id = ?", userID, accountID, assetID).
+		Order("transaction_date ASC, id ASC").
+		Find(&out).Error; err != nil {
 		return nil, err
 	}
 	return out, nil

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -33,6 +33,7 @@ func New(cfg config.Config, gormDB *gorm.DB) *gin.Engine {
 	)
 	authHandler := handler.NewAuthHandler(authSvc)
 
+	userRepo := repository.NewUserRepository(gormDB)
 	accountRepo := repository.NewAccountRepository(gormDB)
 	plaidItemRepo := repository.NewPlaidItemRepository(gormDB)
 	assetRepo := repository.NewAssetRepository(gormDB)
@@ -51,6 +52,10 @@ func New(cfg config.Config, gormDB *gorm.DB) *gin.Engine {
 	ruleRepo := repository.NewCategorizationRuleRepository(gormDB)
 	transactionSvc := service.NewTransactionService(transactionRepo, accountRepo, categoryRepo).WithRuleRepo(ruleRepo)
 	transactionHandler := handler.NewTransactionHandler(transactionSvc)
+
+	priceRepo := repository.NewPriceRepository(gormDB)
+	tradeSvc := service.NewTradeService(gormDB, accountRepo, assetRepo, transactionRepo, positionRepo, priceRepo, userRepo)
+	tradeHandler := handler.NewTradeHandler(tradeSvc)
 
 	categorySvc := service.NewCategoryService(categoryRepo)
 	categoryHandler := handler.NewCategoryHandler(categorySvc)
@@ -76,7 +81,6 @@ func New(cfg config.Config, gormDB *gorm.DB) *gin.Engine {
 
 	householdRepo := repository.NewHouseholdRepository(gormDB)
 	memberRepo := repository.NewHouseholdMemberRepository(gormDB)
-	userRepo := repository.NewUserRepository(gormDB)
 	householdSvc := household.NewService(
 		householdRepo,
 		memberRepo,
@@ -151,6 +155,7 @@ func New(cfg config.Config, gormDB *gorm.DB) *gin.Engine {
 		accountHandler.Register(secured)
 		piiHandler.RegisterAccountRoutes(secured)
 		transactionHandler.Register(secured)
+		tradeHandler.Register(secured)
 		categoryHandler.Register(secured)
 		ruleHandler.Register(secured)
 		dashboardHandler.Register(secured)

--- a/backend/internal/service/ai/context_builder.go
+++ b/backend/internal/service/ai/context_builder.go
@@ -26,6 +26,23 @@ type Context struct {
 	Budgets         []BudgetSnapshot `json:"budgets"`
 	SavingsGoals    []GoalSnapshot   `json:"savings_goals"`
 	Holdings        HoldingsSummary  `json:"holdings"`
+	Trades          TradesSummary    `json:"trades"`
+}
+
+// TradesSummary is the LLM-facing view of trade activity over the
+// same trailing window used for SpendByCategory. Per ADR-0013 §4 the
+// LLM sees notional value in the user's primary currency only — no
+// per-trade quantities, no tickers, just counts and gross by asset
+// kind.
+type TradesSummary struct {
+	TotalLegs int64                 `json:"total_legs"`
+	ByKind    []TradeKindSummaryRow `json:"by_kind"`
+}
+
+type TradeKindSummaryRow struct {
+	Kind       string `json:"kind"`
+	LegCount   int64  `json:"leg_count"`
+	GrossValue string `json:"gross_value"`
 }
 
 // ContextPeriod is the [from, to) window summarized by SpendByCategory.
@@ -150,6 +167,7 @@ func (b *ContextBuilder) Build(ctx context.Context, userID int64) (*Context, err
 			TotalCostBasis:   "0",
 			ByAssetClass:     []AssetClassWeight{},
 		},
+		Trades: TradesSummary{ByKind: []TradeKindSummaryRow{}},
 	}
 
 	if b.dashboard != nil {
@@ -218,7 +236,24 @@ func (b *ContextBuilder) Build(ctx context.Context, userID int64) (*Context, err
 
 	// Holdings summary intentionally left empty post-ADR-0013. The
 	// snapshot-based PortfolioSummary is gone; the positions-based
-	// replacement lands in #238 alongside trade ingestion.
+	// replacement lands in a follow-up.
+
+	// Trade activity rollup — count + gross-in-primary by asset kind
+	// over the same window as SpendByCategory.
+	if b.dashboard != nil {
+		ts, err := b.dashboard.Trades(ctx, userID, from, to)
+		if err != nil {
+			return nil, fmt.Errorf("ai: trade summary: %w", err)
+		}
+		out.Trades.TotalLegs = ts.TotalLegs
+		for _, r := range ts.ByKind {
+			out.Trades.ByKind = append(out.Trades.ByKind, TradeKindSummaryRow{
+				Kind:       r.Kind,
+				LegCount:   r.LegCount,
+				GrossValue: r.GrossValue,
+			})
+		}
+	}
 
 	return out, nil
 }

--- a/backend/internal/service/categorization/engine.go
+++ b/backend/internal/service/categorization/engine.go
@@ -21,12 +21,15 @@ import (
 const MethodRule = "rule"
 
 // CompiledRule pairs a stored rule with its precompiled regex (when the
-// match_type is "regex"). Re is nil for contains/exact rules.
+// match_type is "regex"). Re is nil for contains/exact rules. AssetID,
+// when non-nil, narrows the rule to transactions whose asset_id matches
+// — see Categorize.
 type CompiledRule struct {
 	ID         int64
 	CategoryID int64
 	MatchType  string
 	Pattern    string
+	AssetID    *int64
 	patternCI  string // pattern uppercased once, for contains/exact fast path
 	Re         *regexp.Regexp
 }
@@ -54,6 +57,7 @@ func Compile(rules []model.CategorizationRule) []CompiledRule {
 			CategoryID: r.CategoryID,
 			MatchType:  r.MatchType,
 			Pattern:    r.Pattern,
+			AssetID:    r.AssetID,
 			patternCI:  strings.ToUpper(r.Pattern),
 		}
 		if r.MatchType == "regex" {
@@ -72,15 +76,32 @@ func Compile(rules []model.CategorizationRule) []CompiledRule {
 // matcher considers, in order: description_clean, description, merchant_name.
 // "contains" and "exact" are case-insensitive; "regex" uses the pattern as
 // authored (callers can prefix `(?i)` if they want case-insensitivity).
-func Categorize(rules []CompiledRule, descriptionClean, description, merchantName *string) (Decision, bool) {
+//
+// assetID, when non-zero, narrows the candidate set: rules with a non-nil
+// CompiledRule.AssetID only fire on a matching assetID. Rules with a nil
+// AssetID stay asset-agnostic. Pass 0 to skip the asset filter entirely
+// (matches the M2-era behavior for callers that pre-date the column).
+func Categorize(rules []CompiledRule, assetID int64, descriptionClean, description, merchantName *string) (Decision, bool) {
 	if len(rules) == 0 {
 		return Decision{}, false
 	}
 	fields := collectFields(descriptionClean, description, merchantName)
-	if len(fields) == 0 {
-		return Decision{}, false
-	}
 	for _, r := range rules {
+		if r.AssetID != nil {
+			if assetID == 0 || *r.AssetID != assetID {
+				continue
+			}
+		}
+		// Asset-bound rules with no pattern match purely on asset_id —
+		// useful for "all AAPL legs → Investments". collectFields can
+		// return empty for trade legs (which have no merchant text);
+		// don't reject them up-front.
+		if len(fields) == 0 {
+			if r.AssetID != nil && r.Pattern == "" {
+				return Decision{RuleID: r.ID, CategoryID: r.CategoryID}, true
+			}
+			continue
+		}
 		if matches(r, fields) {
 			return Decision{RuleID: r.ID, CategoryID: r.CategoryID}, true
 		}
@@ -97,7 +118,7 @@ func Apply(tx *model.Transaction, rules []CompiledRule) (Decision, bool) {
 	if tx == nil {
 		return Decision{}, false
 	}
-	d, ok := Categorize(rules, tx.DescriptionClean, tx.Description, tx.MerchantName)
+	d, ok := Categorize(rules, tx.AssetID, tx.DescriptionClean, tx.Description, tx.MerchantName)
 	if !ok {
 		return Decision{}, false
 	}

--- a/backend/internal/service/categorization/engine_test.go
+++ b/backend/internal/service/categorization/engine_test.go
@@ -36,7 +36,7 @@ func TestCategorize_FirstMatchWins(t *testing.T) {
 		{ID: 2, CategoryID: 20, MatchType: "contains", Pattern: "FOODS", IsActive: true}, // would also match
 	})
 
-	d, ok := categorization.Categorize(rules, nil, ptr("WHOLE FOODS MARKET #123"), nil)
+	d, ok := categorization.Categorize(rules, 0, nil, ptr("WHOLE FOODS MARKET #123"), nil)
 	if !ok {
 		t.Fatal("expected match")
 	}
@@ -78,7 +78,7 @@ func TestCategorize_MatchTypes(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			rs := categorization.Compile([]model.CategorizationRule{tc.rule})
-			_, ok := categorization.Categorize(rs, nil, tc.desc, tc.merchant)
+			_, ok := categorization.Categorize(rs, 0, nil, tc.desc, tc.merchant)
 			if ok != tc.wantMatch {
 				t.Errorf("Categorize matched=%v, want %v", ok, tc.wantMatch)
 			}
@@ -90,12 +90,38 @@ func TestCategorize_NoFieldsNoMatch(t *testing.T) {
 	rs := categorization.Compile([]model.CategorizationRule{
 		{ID: 1, CategoryID: 9, MatchType: "contains", Pattern: "X", IsActive: true},
 	})
-	if _, ok := categorization.Categorize(rs, nil, nil, nil); ok {
+	if _, ok := categorization.Categorize(rs, 0, nil, nil, nil); ok {
 		t.Error("expected no match with all-nil fields")
 	}
 	emptyStr := "   "
-	if _, ok := categorization.Categorize(rs, nil, &emptyStr, nil); ok {
+	if _, ok := categorization.Categorize(rs, 0, nil, &emptyStr, nil); ok {
 		t.Error("expected no match with whitespace-only field")
+	}
+}
+
+func TestCategorize_AssetIDFilter(t *testing.T) {
+	aapl := int64(101)
+	other := int64(202)
+	rs := categorization.Compile([]model.CategorizationRule{
+		// Asset-bound rule with no pattern — matches any AAPL leg.
+		{ID: 1, CategoryID: 11, MatchType: "contains", Pattern: "", AssetID: &aapl, IsActive: true},
+		// Asset-agnostic rule — matches anything with "DIVIDEND".
+		{ID: 2, CategoryID: 22, MatchType: "contains", Pattern: "DIVIDEND", IsActive: true},
+	})
+
+	// AAPL leg with no text → first rule fires on asset alone.
+	d, ok := categorization.Categorize(rs, aapl, nil, ptr("Bought 10 @ 150"), nil)
+	if !ok || d.RuleID != 1 {
+		t.Errorf("AAPL leg: got rule=%d match=%v, want rule=1 match=true", d.RuleID, ok)
+	}
+	// Non-AAPL leg with no matching text → no match (rule 1 filters on asset).
+	if _, ok := categorization.Categorize(rs, other, nil, ptr("Misc"), nil); ok {
+		t.Error("non-AAPL leg should NOT match an AAPL-bound rule")
+	}
+	// Non-AAPL leg with matching text → rule 2 (asset-agnostic) fires.
+	d, ok = categorization.Categorize(rs, other, nil, ptr("Quarterly DIVIDEND"), nil)
+	if !ok || d.RuleID != 2 {
+		t.Errorf("agnostic rule: got rule=%d match=%v, want 2/true", d.RuleID, ok)
 	}
 }
 

--- a/backend/internal/service/categorization_rule_service.go
+++ b/backend/internal/service/categorization_rule_service.go
@@ -34,17 +34,25 @@ type CreateRuleInput struct {
 	Pattern    string
 	MatchType  string
 	CategoryID int64
-	Priority   int
-	IsActive   *bool
+	// AssetID, when set, narrows the rule to transactions whose
+	// asset_id matches. Either Pattern OR AssetID must be supplied —
+	// a rule with neither has nothing to match on.
+	AssetID  *int64
+	Priority int
+	IsActive *bool
 }
 
 // UpdateRuleInput is a sparse patch. Nil pointer = leave alone.
+// ClearAssetID drops asset binding without losing the difference between
+// "leave alone" and "clear" the way a nil AssetID would.
 type UpdateRuleInput struct {
-	Pattern    *string
-	MatchType  *string
-	CategoryID *int64
-	Priority   *int
-	IsActive   *bool
+	Pattern      *string
+	MatchType    *string
+	CategoryID   *int64
+	AssetID      *int64
+	ClearAssetID bool
+	Priority     *int
+	IsActive     *bool
 }
 
 // CategorizationRuleService owns rule validation and CRUD. It depends on
@@ -85,6 +93,7 @@ func (s *CategorizationRuleService) Create(ctx context.Context, userID int64, in
 		Pattern:    strings.TrimSpace(in.Pattern),
 		MatchType:  strings.TrimSpace(in.MatchType),
 		CategoryID: in.CategoryID,
+		AssetID:    in.AssetID,
 		Priority:   in.Priority,
 		IsActive:   true,
 	}
@@ -131,6 +140,12 @@ func (s *CategorizationRuleService) Update(ctx context.Context, userID, id int64
 	}
 	if in.CategoryID != nil {
 		r.CategoryID = *in.CategoryID
+	}
+	switch {
+	case in.ClearAssetID:
+		r.AssetID = nil
+	case in.AssetID != nil:
+		r.AssetID = in.AssetID
 	}
 	if in.Priority != nil {
 		r.Priority = *in.Priority
@@ -227,7 +242,7 @@ func (s *CategorizationRuleService) Apply(ctx context.Context, userID int64, sco
 				if len(rules) == 0 {
 					continue
 				}
-				d, ok := categorization.Categorize(rules, row.DescriptionClean, row.Description, row.MerchantName)
+				d, ok := categorization.Categorize(rules, row.AssetID, row.DescriptionClean, row.Description, row.MerchantName)
 				if !ok {
 					continue
 				}
@@ -261,15 +276,22 @@ func (s *CategorizationRuleService) Apply(ctx context.Context, userID int64, sco
 }
 
 func (s *CategorizationRuleService) validate(ctx context.Context, r *model.CategorizationRule) error {
-	if r.Pattern == "" {
+	// A rule needs *something* to match on. Asset-only rules are valid
+	// (e.g. "every AAPL leg → Investments"); pattern-only rules are the
+	// original M4 shape. A rule with neither has nothing to match.
+	if r.Pattern == "" && r.AssetID == nil {
 		return ErrEmptyPattern
 	}
-	if _, ok := validMatchTypes[r.MatchType]; !ok {
-		return ErrInvalidMatchType
-	}
-	if r.MatchType == "regex" {
-		if _, err := regexp.Compile(r.Pattern); err != nil {
-			return ErrInvalidRegex
+	// MatchType is still required when there's a pattern; ignored when
+	// the rule is purely asset-bound.
+	if r.Pattern != "" {
+		if _, ok := validMatchTypes[r.MatchType]; !ok {
+			return ErrInvalidMatchType
+		}
+		if r.MatchType == "regex" {
+			if _, err := regexp.Compile(r.Pattern); err != nil {
+				return ErrInvalidRegex
+			}
 		}
 	}
 	if r.Priority < 0 {

--- a/backend/internal/service/dashboard_service.go
+++ b/backend/internal/service/dashboard_service.go
@@ -184,6 +184,51 @@ func (s *DashboardService) NetWorth(ctx context.Context, userID int64, months in
 	return out, nil
 }
 
+// TradeSummary is the AI-context view of a user's trade activity over
+// a window. Per-asset detail intentionally rolls up to asset kind so
+// the LLM sees the shape of the portfolio's activity without per-row
+// quantities or tickers — keeps the prompt budget small and shields
+// fingerprintable precision from the provider.
+type TradeSummary struct {
+	From      time.Time           `json:"from"`
+	To        time.Time           `json:"to"`
+	TotalLegs int64               `json:"total_legs"`
+	ByKind    []TradeKindSnapshot `json:"by_kind"`
+}
+
+// TradeKindSnapshot is one row of TradeSummary.
+type TradeKindSnapshot struct {
+	Kind       string `json:"kind"`
+	LegCount   int64  `json:"leg_count"`
+	GrossValue string `json:"gross_value"`
+}
+
+// Trades returns the trade-activity rollup over [from, to). Used by
+// the AI context builder; produces aggregates only — no raw rows, no
+// tickers, no per-trade quantities.
+func (s *DashboardService) Trades(ctx context.Context, userID int64, from, to time.Time) (*TradeSummary, error) {
+	if from.IsZero() {
+		from = s.now().AddDate(0, -3, 0)
+	}
+	if to.IsZero() {
+		to = s.now().AddDate(0, 0, 1)
+	}
+	rows, err := s.repo.TradeSummaryByKind(ctx, userID, from, to)
+	if err != nil {
+		return nil, err
+	}
+	out := &TradeSummary{From: from, To: to}
+	for _, r := range rows {
+		out.TotalLegs += r.LegCount
+		out.ByKind = append(out.ByKind, TradeKindSnapshot{
+			Kind:       r.Kind,
+			LegCount:   r.LegCount,
+			GrossValue: r.GrossValue.String(),
+		})
+	}
+	return out, nil
+}
+
 // resolvePeriod returns the [from, to) window for the named period.
 // All boundaries are computed in the local time zone of `now` — the dashboard
 // is a user-facing view, not an audit log, so DST handling tracks the user's

--- a/backend/internal/service/household/aggregator_trade_privacy_test.go
+++ b/backend/internal/service/household/aggregator_trade_privacy_test.go
@@ -1,0 +1,130 @@
+package household_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/shopspring/decimal"
+
+	"github.com/gregwym/offbook/backend/internal/model"
+	"github.com/gregwym/offbook/backend/internal/repository"
+	"github.com/gregwym/offbook/backend/internal/service/household"
+)
+
+// TestAggregator_TradeLegs_HiddenFromBalanceOnly — issue #238 privacy
+// criterion: when an account is shared at `balance_only`, paired trade
+// legs (both the security and the cash leg) must NOT leak into
+// transaction-touching aggregates (transaction_count, by_category).
+// The position-driven net-worth still reflects the trade — that's the
+// whole point of balance_only — but per-row visibility stays gated.
+func TestAggregator_TradeLegs_HiddenFromBalanceOnly(t *testing.T) {
+	agg, g := newAggregator(t)
+	ctx := context.Background()
+
+	ownerID := seedUser(t, g, "trade-priv-owner")
+	hh := seedHouseholdRow(t, g, ownerID, "Trade Privacy", 30)
+	addMember(t, g, hh.ID, ownerID, model.RoleOwner, nil)
+
+	acct := seedAccount(t, g, ownerID, "brokerage")
+	setBalance(t, g, acct, "10000")
+	setShare(t, g, acct.ID, hh.ID, model.VisibilityBalanceOnly)
+
+	// Spawn an AAPL asset and write a paired trade directly via the repo
+	// (mirroring what the trade service would do).
+	displayName := "Apple"
+	aapl := &model.Asset{
+		Symbol: "AAPL-priv-" + time.Now().Format("150405.000000000"),
+		Kind:   model.AssetKindEquity, DisplayName: &displayName, Precision: 4,
+	}
+	if err := g.Create(aapl).Error; err != nil {
+		t.Fatalf("seed asset: %v", err)
+	}
+	t.Cleanup(func() { g.Unscoped().Delete(&model.Asset{}, aapl.ID) })
+
+	when := time.Now().Add(-time.Hour)
+	secLeg := &model.Transaction{
+		UserID: ownerID, AccountID: acct.ID, AssetID: aapl.ID,
+		Amount: decimal.NewFromInt(10), TransactionDate: when, Source: "manual",
+	}
+	cashLeg := &model.Transaction{
+		UserID: ownerID, AccountID: acct.ID, AssetID: acct.PrimaryQuoteAssetID,
+		Amount: decimal.NewFromInt(-1500), TransactionDate: when, Source: "manual",
+	}
+	repo := repository.NewTransactionRepository(g)
+	if err := repo.CreateTradePair(ctx, secLeg, cashLeg); err != nil {
+		t.Fatalf("create trade pair: %v", err)
+	}
+	t.Cleanup(func() {
+		g.Unscoped().Delete(&model.Transaction{}, secLeg.ID)
+		g.Unscoped().Delete(&model.Transaction{}, cashLeg.ID)
+	})
+
+	d, err := agg.Dashboard(ctx, hh.ID, household.PeriodCurrentMonth)
+	if err != nil {
+		t.Fatalf("Dashboard: %v", err)
+	}
+	if d.TransactionCount != 0 {
+		t.Errorf("TransactionCount = %d, want 0 (trade legs must not leak from balance_only)", d.TransactionCount)
+	}
+	for _, row := range d.ByCategory {
+		if row.Amount == "1500" || row.Amount == "-1500" {
+			t.Errorf("trade cash leg leaked into ByCategory: %+v", row)
+		}
+	}
+	// Net worth still reflects the account balance — balance_only's contract.
+	if d.NetWorth != "10000" {
+		t.Errorf("NetWorth = %q, want 10000 (balance_only still surfaces totals)", d.NetWorth)
+	}
+}
+
+// TestAggregator_TradeLegs_VisibleWithFullVisibility — counterpart to
+// the test above: with `balance_and_txns`, trade legs DO contribute to
+// transaction_count (per-tenant visibility is fully consented).
+func TestAggregator_TradeLegs_VisibleWithFullVisibility(t *testing.T) {
+	agg, g := newAggregator(t)
+	ctx := context.Background()
+
+	ownerID := seedUser(t, g, "trade-vis-owner")
+	hh := seedHouseholdRow(t, g, ownerID, "Trade Visible", 30)
+	addMember(t, g, hh.ID, ownerID, model.RoleOwner, nil)
+
+	acct := seedAccount(t, g, ownerID, "brokerage")
+	setBalance(t, g, acct, "10000")
+	setShare(t, g, acct.ID, hh.ID, model.VisibilityBalanceAndTxns)
+
+	displayName := "Apple"
+	aapl := &model.Asset{
+		Symbol: "AAPL-vis-" + time.Now().Format("150405.000000000"),
+		Kind:   model.AssetKindEquity, DisplayName: &displayName, Precision: 4,
+	}
+	if err := g.Create(aapl).Error; err != nil {
+		t.Fatalf("seed asset: %v", err)
+	}
+	t.Cleanup(func() { g.Unscoped().Delete(&model.Asset{}, aapl.ID) })
+
+	when := time.Now().Add(-time.Hour)
+	secLeg := &model.Transaction{
+		UserID: ownerID, AccountID: acct.ID, AssetID: aapl.ID,
+		Amount: decimal.NewFromInt(10), TransactionDate: when, Source: "manual",
+	}
+	cashLeg := &model.Transaction{
+		UserID: ownerID, AccountID: acct.ID, AssetID: acct.PrimaryQuoteAssetID,
+		Amount: decimal.NewFromInt(-1500), TransactionDate: when, Source: "manual",
+	}
+	if err := repository.NewTransactionRepository(g).CreateTradePair(ctx, secLeg, cashLeg); err != nil {
+		t.Fatalf("create trade pair: %v", err)
+	}
+	t.Cleanup(func() {
+		g.Unscoped().Delete(&model.Transaction{}, secLeg.ID)
+		g.Unscoped().Delete(&model.Transaction{}, cashLeg.ID)
+	})
+
+	d, err := agg.Dashboard(ctx, hh.ID, household.PeriodCurrentMonth)
+	if err != nil {
+		t.Fatalf("Dashboard: %v", err)
+	}
+	if d.TransactionCount != 2 {
+		t.Errorf("TransactionCount = %d, want 2 (both trade legs visible)", d.TransactionCount)
+	}
+}

--- a/backend/internal/service/trade_service.go
+++ b/backend/internal/service/trade_service.go
@@ -1,0 +1,277 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/shopspring/decimal"
+	"gorm.io/gorm"
+
+	"github.com/gregwym/offbook/backend/internal/model"
+	"github.com/gregwym/offbook/backend/internal/repository"
+	"github.com/gregwym/offbook/backend/internal/service/valuation"
+)
+
+// Domain errors for the trade entry surface.
+var (
+	ErrInvalidTradeKind    = errors.New("trade kind must be 'buy' or 'sell'")
+	ErrInvalidQuantity     = errors.New("quantity must be > 0")
+	ErrInvalidPrice        = errors.New("price must be > 0")
+	ErrUnsupportedAccount  = errors.New("trades may only be recorded on brokerage-type accounts")
+	ErrUnknownAsset        = errors.New("asset not found")
+	ErrTradeFXUnavailable  = errors.New("no FX rate available for trade date — set the rate in prices first")
+	ErrCashAssetMismatch   = errors.New("cash leg must be in the account's primary quote asset")
+	ErrSellExceedsHoldings = errors.New("sell quantity exceeds current holding")
+	ErrSecurityEqualsQuote = errors.New("trade asset must differ from the account's cash asset")
+)
+
+// Brokerage-style accounts are the only ones that accept trades. The
+// list mirrors the position-model intent: bank-style accounts hold a
+// single cash position and don't need trade pairing.
+var brokerageAccountTypes = map[string]struct{}{
+	"investment": {},
+	"crypto":     {},
+}
+
+// RecordTradeInput is the validated payload for POST /accounts/:id/trades.
+// Kind ∈ {"buy", "sell"}. Quantity and Price are always supplied positive;
+// the service handles sign and pairing.
+//
+// Price is denominated in the parent account's primary quote asset
+// (i.e. the cash sleeve). Multi-currency trades (security price quoted
+// in a non-account currency) are out of scope for the manual form —
+// users can record them by entering the cash leg manually.
+type RecordTradeInput struct {
+	Kind      string          // "buy" | "sell"
+	AssetID   int64           // security being traded
+	Quantity  decimal.Decimal // always positive; service flips sign per kind
+	Price     decimal.Decimal // per-unit, in account's quote currency
+	TradeDate time.Time
+	Notes     *string
+}
+
+// TradeRecord bundles the persisted pair + updated positions so the
+// handler can return both in a single response without extra fetches.
+type TradeRecord struct {
+	SecurityLeg      *model.Transaction `json:"security_leg"`
+	CashLeg          *model.Transaction `json:"cash_leg"`
+	SecurityPosition *model.Position    `json:"security_position"`
+	CashPosition     *model.Position    `json:"cash_position"`
+}
+
+// TradeService owns the manual "Record a trade" flow and is the entry
+// point for future ingestion sources that want to write paired-row
+// trades (e.g. Plaid investment-transactions, CSV imports).
+type TradeService struct {
+	db        *gorm.DB
+	accounts  repository.AccountRepository
+	assets    repository.AssetRepository
+	txns      repository.TransactionRepository
+	positions repository.PositionRepository
+	prices    repository.PriceRepository
+	users     repository.UserRepository
+}
+
+func NewTradeService(
+	db *gorm.DB,
+	accounts repository.AccountRepository,
+	assets repository.AssetRepository,
+	txns repository.TransactionRepository,
+	positions repository.PositionRepository,
+	prices repository.PriceRepository,
+	users repository.UserRepository,
+) *TradeService {
+	return &TradeService{
+		db:        db,
+		accounts:  accounts,
+		assets:    assets,
+		txns:      txns,
+		positions: positions,
+		prices:    prices,
+		users:     users,
+	}
+}
+
+// Record validates the input, writes the paired transaction rows in one
+// DB transaction, updates the security + cash positions, and recomputes
+// cost basis on the security position from the full trade history. The
+// invariant from ADR-0013 — "the app never invents transactions" — still
+// holds: this method is itself a real event (the user typed it).
+func (s *TradeService) Record(ctx context.Context, userID, accountID int64, in RecordTradeInput) (*TradeRecord, error) {
+	kind := strings.ToLower(strings.TrimSpace(in.Kind))
+	switch kind {
+	case "buy", "sell":
+	default:
+		return nil, ErrInvalidTradeKind
+	}
+	if !in.Quantity.IsPositive() {
+		return nil, ErrInvalidQuantity
+	}
+	if !in.Price.IsPositive() {
+		return nil, ErrInvalidPrice
+	}
+	if in.TradeDate.IsZero() {
+		return nil, ErrMissingDate
+	}
+
+	acct, err := s.accounts.GetByID(ctx, userID, accountID)
+	if err != nil {
+		if errors.Is(err, repository.ErrNotFound) {
+			return nil, ErrAccountNotFound
+		}
+		return nil, fmt.Errorf("trade: load account: %w", err)
+	}
+	if _, ok := brokerageAccountTypes[acct.AccountType]; !ok {
+		return nil, ErrUnsupportedAccount
+	}
+	if in.AssetID == acct.PrimaryQuoteAssetID {
+		return nil, ErrSecurityEqualsQuote
+	}
+	if _, err := s.assets.GetByID(ctx, in.AssetID); err != nil {
+		if errors.Is(err, repository.ErrNotFound) {
+			return nil, ErrUnknownAsset
+		}
+		return nil, fmt.Errorf("trade: load asset: %w", err)
+	}
+
+	// Derive signed amounts. Sign convention matches the rest of the app:
+	// positive = inflow into the account, negative = outflow. For a buy,
+	// the security flows IN, cash flows OUT. For a sell, opposite.
+	cashTotal := in.Price.Mul(in.Quantity)
+	var secAmount, cashAmount decimal.Decimal
+	switch kind {
+	case "buy":
+		secAmount = in.Quantity
+		cashAmount = cashTotal.Neg()
+	case "sell":
+		secAmount = in.Quantity.Neg()
+		cashAmount = cashTotal
+	}
+
+	// Pre-check: a sell can't exceed the current holding. Read the
+	// security position first (cheap; one indexed row).
+	if kind == "sell" {
+		positions, err := s.positions.ListByAccountID(ctx, userID, accountID)
+		if err != nil {
+			return nil, fmt.Errorf("trade: load positions: %w", err)
+		}
+		held := decimal.Zero
+		for _, p := range positions {
+			if p.AssetID == in.AssetID {
+				held = p.Quantity
+				break
+			}
+		}
+		if in.Quantity.GreaterThan(held) {
+			return nil, ErrSellExceedsHoldings
+		}
+	}
+
+	descSec := tradeDescription(kind, in.Quantity, in.Price)
+	descCash := descSec // mirror on both legs so the transaction list reads
+	method := "manual"
+	source := "manual"
+
+	secLeg := &model.Transaction{
+		UserID:               userID,
+		AccountID:            accountID,
+		AssetID:              in.AssetID,
+		Amount:               secAmount,
+		Description:          &descSec,
+		TransactionDate:      in.TradeDate,
+		Source:               source,
+		CategorizationMethod: &method,
+		Notes:                in.Notes,
+	}
+	cashLeg := &model.Transaction{
+		UserID:               userID,
+		AccountID:            accountID,
+		AssetID:              acct.PrimaryQuoteAssetID,
+		Amount:               cashAmount,
+		Description:          &descCash,
+		TransactionDate:      in.TradeDate,
+		Source:               source,
+		CategorizationMethod: &method,
+		Notes:                in.Notes,
+	}
+
+	user, err := s.users.GetByID(ctx, userID)
+	if err != nil {
+		return nil, fmt.Errorf("trade: load user: %w", err)
+	}
+
+	var record TradeRecord
+	err = s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		txRepo := repository.NewTransactionRepository(tx)
+		posRepo := repository.NewPositionRepository(tx)
+
+		if err := txRepo.CreateTradePair(ctx, secLeg, cashLeg); err != nil {
+			return fmt.Errorf("create trade pair: %w", err)
+		}
+
+		// Recompute the security position from history (quantity + cost
+		// basis). The recompute is canonical; we don't trust deltas.
+		secResult, err := valuation.Recompute(ctx, txRepo, s.prices, userID, accountID, in.AssetID, user.PrimaryCurrencyAssetID)
+		if err != nil {
+			if errors.Is(err, valuation.ErrFXUnavailable) {
+				return ErrTradeFXUnavailable
+			}
+			return fmt.Errorf("recompute security: %w", err)
+		}
+		secPos := &model.Position{
+			UserID:    userID,
+			AccountID: accountID,
+			AssetID:   in.AssetID,
+			Quantity:  secResult.Quantity,
+		}
+		if secResult.HasCostBasis {
+			cb := secResult.CostBasis
+			secPos.CostBasis = &cb
+		}
+		if err := posRepo.Upsert(ctx, secPos); err != nil {
+			return fmt.Errorf("upsert security position: %w", err)
+		}
+
+		// Cash position: quantity-only recompute (cost basis on the
+		// primary cash sleeve is meaningless — see Recompute fast path).
+		cashResult, err := valuation.Recompute(ctx, txRepo, s.prices, userID, accountID, acct.PrimaryQuoteAssetID, user.PrimaryCurrencyAssetID)
+		if err != nil {
+			return fmt.Errorf("recompute cash: %w", err)
+		}
+		cashPos := &model.Position{
+			UserID:    userID,
+			AccountID: accountID,
+			AssetID:   acct.PrimaryQuoteAssetID,
+			Quantity:  cashResult.Quantity,
+		}
+		if err := posRepo.Upsert(ctx, cashPos); err != nil {
+			return fmt.Errorf("upsert cash position: %w", err)
+		}
+
+		record = TradeRecord{
+			SecurityLeg:      secLeg,
+			CashLeg:          cashLeg,
+			SecurityPosition: secPos,
+			CashPosition:     cashPos,
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &record, nil
+}
+
+// tradeDescription renders the canonical "Bought N AAPL @ $P" / "Sold
+// …" string used on both legs. The transaction list collapses the pair
+// using the matching description, so keep this stable.
+func tradeDescription(kind string, qty, price decimal.Decimal) string {
+	verb := "Bought"
+	if kind == "sell" {
+		verb = "Sold"
+	}
+	return fmt.Sprintf("%s %s @ %s", verb, qty.String(), price.String())
+}

--- a/backend/internal/service/trade_service_test.go
+++ b/backend/internal/service/trade_service_test.go
@@ -1,0 +1,184 @@
+package service_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/shopspring/decimal"
+	"gorm.io/gorm"
+
+	"github.com/gregwym/offbook/backend/internal/model"
+	"github.com/gregwym/offbook/backend/internal/repository"
+	"github.com/gregwym/offbook/backend/internal/service"
+	"github.com/gregwym/offbook/backend/internal/testutil"
+)
+
+// seedTradeFixture provisions a user, brokerage account, and AAPL asset
+// for trade-service tests. Returns the trade service wired against the
+// real DB, plus the ids the tests need.
+func seedTradeFixture(t *testing.T) (svc *service.TradeService, userID, accountID, aaplID int64, g *gorm.DB) {
+	t.Helper()
+	g = openTestDB(t)
+	userID = seedTestUser(t, g)
+	usdID := testutil.LookupUSDAssetID(t, g)
+
+	displayName := "Apple"
+	aapl := &model.Asset{
+		Symbol:               "AAPL-" + time.Now().Format("150405.000000000"),
+		Kind:                 model.AssetKindEquity,
+		DisplayName:          &displayName,
+		Precision:            4,
+		QuoteCurrencyAssetID: &usdID,
+	}
+	if err := g.Create(aapl).Error; err != nil {
+		t.Fatalf("seed asset: %v", err)
+	}
+	t.Cleanup(func() { g.Unscoped().Delete(&model.Asset{}, aapl.ID) })
+
+	acct := &model.Account{
+		UserID: userID, Name: "Brokerage-" + time.Now().Format("150405.000000000"),
+		InstitutionSlug: "fixture", AccountType: "investment", Currency: "USD",
+		PrimaryQuoteAssetID: usdID,
+	}
+	if err := g.Create(acct).Error; err != nil {
+		t.Fatalf("seed account: %v", err)
+	}
+
+	svc = service.NewTradeService(
+		g,
+		repository.NewAccountRepository(g),
+		repository.NewAssetRepository(g),
+		repository.NewTransactionRepository(g),
+		repository.NewPositionRepository(g),
+		repository.NewPriceRepository(g),
+		repository.NewUserRepository(g),
+	)
+	return svc, userID, acct.ID, aapl.ID, g
+}
+
+func TestTradeService_Record_Buy_WritesPairAndPositions(t *testing.T) {
+	svc, userID, accountID, aapl, g := seedTradeFixture(t)
+	ctx := context.Background()
+
+	rec, err := svc.Record(ctx, userID, accountID, service.RecordTradeInput{
+		Kind:      "buy",
+		AssetID:   aapl,
+		Quantity:  decimal.NewFromInt(10),
+		Price:     decimal.NewFromInt(150),
+		TradeDate: time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC),
+	})
+	if err != nil {
+		t.Fatalf("record: %v", err)
+	}
+
+	if rec.SecurityLeg.TransferPairID == nil || rec.CashLeg.TransferPairID == nil {
+		t.Fatal("legs missing transfer_pair_id")
+	}
+	if *rec.SecurityLeg.TransferPairID != rec.CashLeg.ID || *rec.CashLeg.TransferPairID != rec.SecurityLeg.ID {
+		t.Errorf("legs not cross-linked: sec.pair=%v cash.pair=%v sec.id=%d cash.id=%d",
+			rec.SecurityLeg.TransferPairID, rec.CashLeg.TransferPairID, rec.SecurityLeg.ID, rec.CashLeg.ID)
+	}
+
+	if !rec.SecurityLeg.Amount.Equal(decimal.NewFromInt(10)) {
+		t.Errorf("security amount = %s, want +10", rec.SecurityLeg.Amount)
+	}
+	if !rec.CashLeg.Amount.Equal(decimal.NewFromInt(-1500)) {
+		t.Errorf("cash amount = %s, want -1500", rec.CashLeg.Amount)
+	}
+	if rec.SecurityPosition == nil || !rec.SecurityPosition.Quantity.Equal(decimal.NewFromInt(10)) {
+		t.Errorf("security position qty = %v, want 10", rec.SecurityPosition)
+	}
+	if rec.SecurityPosition.CostBasis == nil || !rec.SecurityPosition.CostBasis.Equal(decimal.NewFromInt(1500)) {
+		t.Errorf("security cost basis = %v, want 1500", rec.SecurityPosition.CostBasis)
+	}
+
+	// Two transactions written, one per leg.
+	var n int64
+	g.Model(&model.Transaction{}).
+		Where("user_id = ? AND account_id = ?", userID, accountID).Count(&n)
+	if n != 2 {
+		t.Errorf("got %d transactions, want 2", n)
+	}
+}
+
+func TestTradeService_Record_RejectsNonBrokerageAccount(t *testing.T) {
+	g := openTestDB(t)
+	userID := seedTestUser(t, g)
+	usdID := testutil.LookupUSDAssetID(t, g)
+	displayName := "Apple"
+	aapl := &model.Asset{
+		Symbol: "AAPL-nb-" + time.Now().Format("150405.000000000"),
+		Kind:   model.AssetKindEquity, DisplayName: &displayName, Precision: 4,
+		QuoteCurrencyAssetID: &usdID,
+	}
+	if err := g.Create(aapl).Error; err != nil {
+		t.Fatalf("seed asset: %v", err)
+	}
+	t.Cleanup(func() { g.Unscoped().Delete(&model.Asset{}, aapl.ID) })
+
+	acct := &model.Account{
+		UserID: userID, Name: "Checking-" + time.Now().Format("150405.000000000"),
+		InstitutionSlug: "fixture", AccountType: "checking", Currency: "USD",
+		PrimaryQuoteAssetID: usdID,
+	}
+	if err := g.Create(acct).Error; err != nil {
+		t.Fatalf("seed account: %v", err)
+	}
+	svc := service.NewTradeService(g,
+		repository.NewAccountRepository(g),
+		repository.NewAssetRepository(g),
+		repository.NewTransactionRepository(g),
+		repository.NewPositionRepository(g),
+		repository.NewPriceRepository(g),
+		repository.NewUserRepository(g),
+	)
+	_, err := svc.Record(context.Background(), userID, acct.ID, service.RecordTradeInput{
+		Kind: "buy", AssetID: aapl.ID,
+		Quantity: decimal.NewFromInt(1), Price: decimal.NewFromInt(150),
+		TradeDate: time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC),
+	})
+	if !errors.Is(err, service.ErrUnsupportedAccount) {
+		t.Fatalf("err = %v, want ErrUnsupportedAccount", err)
+	}
+}
+
+func TestTradeService_Record_SellExceedsHoldings(t *testing.T) {
+	svc, userID, accountID, aapl, _ := seedTradeFixture(t)
+	ctx := context.Background()
+	// Buy 5.
+	if _, err := svc.Record(ctx, userID, accountID, service.RecordTradeInput{
+		Kind: "buy", AssetID: aapl,
+		Quantity: decimal.NewFromInt(5), Price: decimal.NewFromInt(100),
+		TradeDate: time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC),
+	}); err != nil {
+		t.Fatalf("buy: %v", err)
+	}
+	// Sell 10 — too many.
+	_, err := svc.Record(ctx, userID, accountID, service.RecordTradeInput{
+		Kind: "sell", AssetID: aapl,
+		Quantity: decimal.NewFromInt(10), Price: decimal.NewFromInt(120),
+		TradeDate: time.Date(2026, 5, 2, 0, 0, 0, 0, time.UTC),
+	})
+	if !errors.Is(err, service.ErrSellExceedsHoldings) {
+		t.Fatalf("err = %v, want ErrSellExceedsHoldings", err)
+	}
+}
+
+func TestTradeService_Record_TenantIsolation(t *testing.T) {
+	svc, userA, accountA, aapl, g := seedTradeFixture(t)
+	userB := seedTestUser(t, g)
+	ctx := context.Background()
+
+	// User B should not be able to write into user A's account.
+	_, err := svc.Record(ctx, userB, accountA, service.RecordTradeInput{
+		Kind: "buy", AssetID: aapl,
+		Quantity: decimal.NewFromInt(1), Price: decimal.NewFromInt(100),
+		TradeDate: time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC),
+	})
+	if !errors.Is(err, service.ErrAccountNotFound) {
+		t.Fatalf("err = %v, want ErrAccountNotFound (cross-tenant attempt)", err)
+	}
+	_ = userA
+}

--- a/backend/internal/service/valuation/cost_basis.go
+++ b/backend/internal/service/valuation/cost_basis.go
@@ -1,0 +1,206 @@
+package valuation
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/shopspring/decimal"
+
+	"github.com/gregwym/offbook/backend/internal/model"
+	"github.com/gregwym/offbook/backend/internal/repository"
+)
+
+// ErrFXUnavailable is returned by Recompute when the trade-date FX rate
+// needed to convert a cash leg into the user's primary currency isn't
+// present in `prices`. Surface to the caller so they can fall back to
+// "cost basis unknown" rather than booking a wrong number.
+var ErrFXUnavailable = errors.New("cost basis: no FX rate for trade date")
+
+// RecomputeResult is what Recompute returns for one (account × asset)
+// after walking the full trade history. Quantity always reflects the
+// sum of `transactions.amount` for the (account, asset) pair —
+// canonical, never approximated. CostBasis is denominated in the
+// user's primary currency.
+//
+// HasCostBasis reports whether any trade contributed to the running
+// cost basis. If false, callers should store position.cost_basis as
+// NULL — "unknown" is the honest answer when we have only transfer
+// rows with no priced cash partner.
+type RecomputeResult struct {
+	Quantity     decimal.Decimal
+	CostBasis    decimal.Decimal
+	HasCostBasis bool
+}
+
+// Recompute walks every non-deleted transaction for (userID, accountID,
+// assetID) in chronological order and re-derives quantity + average-
+// cost basis from scratch. Pure-ish — reads only; never writes.
+//
+// Method (per ADR-0013 §4):
+//   - Buy (security leg amount > 0, paired cash leg):
+//     cost_basis += |cash_leg.amount| × fx(cash_asset → primary, trade_date)
+//   - Sell (security leg amount < 0, paired cash leg):
+//     cost_basis -= (cost_basis / quantity_before) × |sold_qty|
+//   - Unpaired inflow (transfer in, dividend-as-shares): quantity++,
+//     cost basis is unknown for the added units — leave running basis
+//     untouched; the per-unit basis dilutes naturally on the next sell.
+//   - Unpaired outflow (transfer out): proportional cost-basis removal,
+//     same shape as a sell.
+//
+// FX uses prices.LatestPriceAt at the trade date with no stale-window
+// gate — trade-date FX is the canonical lookup. If no price row exists
+// for the (cash_asset → primary) pair at-or-before the trade date,
+// Recompute returns ErrFXUnavailable. When cash_asset == primary the
+// hop is skipped entirely.
+//
+// userID + assetID are required for tenant scoping; primaryAssetID is
+// the user's primary_currency_asset_id (read once by the caller).
+// txRepo, prices, and an asset-loader for partner lookups are injected.
+func Recompute(
+	ctx context.Context,
+	txRepo repository.TransactionRepository,
+	prices repository.PriceRepository,
+	userID, accountID, assetID, primaryAssetID int64,
+) (RecomputeResult, error) {
+	if assetID == primaryAssetID {
+		// Cash position in the primary currency — cost basis is the
+		// running quantity itself, but no cost-basis concept applies.
+		qty, err := sumQty(ctx, txRepo, userID, accountID, assetID)
+		if err != nil {
+			return RecomputeResult{}, err
+		}
+		return RecomputeResult{Quantity: qty}, nil
+	}
+
+	txns, err := txRepo.ListByAccountAndAsset(ctx, userID, accountID, assetID)
+	if err != nil {
+		return RecomputeResult{}, fmt.Errorf("cost basis: list txns: %w", err)
+	}
+
+	qty := decimal.Zero
+	cb := decimal.Zero
+	hasCB := false
+
+	for _, t := range txns {
+		if t.Amount.IsZero() {
+			continue
+		}
+		// Paired trade — try to derive a priced cash leg.
+		if t.TransferPairID != nil {
+			cashAmtPrimary, hadCash, err := pairedCashInPrimary(ctx, txRepo, prices, t, primaryAssetID)
+			if err != nil {
+				return RecomputeResult{}, err
+			}
+			if hadCash {
+				switch {
+				case t.Amount.IsPositive():
+					// Buy: add cash to cost basis, qty up.
+					cb = cb.Add(cashAmtPrimary)
+					qty = qty.Add(t.Amount)
+					hasCB = true
+				case t.Amount.IsNegative():
+					// Sell: proportional cost-basis removal.
+					if qty.IsPositive() {
+						perUnit := cb.Div(qty)
+						removed := perUnit.Mul(t.Amount.Abs())
+						cb = cb.Sub(removed)
+						if cb.IsNegative() {
+							cb = decimal.Zero
+						}
+					}
+					qty = qty.Add(t.Amount)
+					hasCB = true
+				}
+				continue
+			}
+			// Paired with a non-cash row (e.g. share-for-share swap).
+			// Fall through to the unpaired path: quantity only.
+		}
+		// Unpaired leg: quantity-only update with proportional cost-basis
+		// removal on outflow (we know lots are leaving even without a cash
+		// partner).
+		if t.Amount.IsNegative() && qty.IsPositive() && hasCB {
+			perUnit := cb.Div(qty)
+			removed := perUnit.Mul(t.Amount.Abs())
+			cb = cb.Sub(removed)
+			if cb.IsNegative() {
+				cb = decimal.Zero
+			}
+		}
+		qty = qty.Add(t.Amount)
+	}
+
+	// Quantity bottomed out — reset basis. Otherwise rounding noise can
+	// leave a few satoshi of basis sitting on a closed position.
+	if qty.IsZero() {
+		cb = decimal.Zero
+	}
+
+	return RecomputeResult{Quantity: qty, CostBasis: cb, HasCostBasis: hasCB}, nil
+}
+
+// pairedCashInPrimary loads `t`'s partner transaction and, if the
+// partner is a same-account row in a fiat asset, returns |partner|
+// converted to the user's primary currency at the trade date. Returns
+// (_, false, nil) when the partner is not a recognizable cash leg —
+// caller should treat as unpaired.
+func pairedCashInPrimary(
+	ctx context.Context,
+	txRepo repository.TransactionRepository,
+	prices repository.PriceRepository,
+	t model.Transaction,
+	primaryAssetID int64,
+) (decimal.Decimal, bool, error) {
+	if t.TransferPairID == nil {
+		return decimal.Zero, false, nil
+	}
+	pair, err := txRepo.GetByID(ctx, t.UserID, *t.TransferPairID)
+	if err != nil {
+		if errors.Is(err, repository.ErrNotFound) {
+			return decimal.Zero, false, nil
+		}
+		return decimal.Zero, false, err
+	}
+	if pair.AccountID != t.AccountID || pair.AssetID == t.AssetID {
+		return decimal.Zero, false, nil
+	}
+	amtAbs := pair.Amount.Abs()
+	if pair.AssetID == primaryAssetID {
+		return amtAbs, true, nil
+	}
+	rate, err := prices.LatestPriceAt(ctx, pair.AssetID, primaryAssetID, atEndOfDay(t.TransactionDate))
+	if err != nil {
+		if errors.Is(err, repository.ErrNotFound) {
+			return decimal.Zero, false, fmt.Errorf("%w: %d → %d on %s",
+				ErrFXUnavailable, pair.AssetID, primaryAssetID, t.TransactionDate.Format("2006-01-02"))
+		}
+		return decimal.Zero, false, fmt.Errorf("cost basis: fx lookup: %w", err)
+	}
+	return amtAbs.Mul(rate.Price), true, nil
+}
+
+// sumQty totals `transactions.amount` for the (user, account, asset)
+// trio — the canonical quantity for a position. Used in the fast path
+// when the asset equals the user's primary currency (cost basis is
+// trivially "quantity" and we don't need the full walk).
+func sumQty(ctx context.Context, txRepo repository.TransactionRepository, userID, accountID, assetID int64) (decimal.Decimal, error) {
+	rows, err := txRepo.ListByAccountAndAsset(ctx, userID, accountID, assetID)
+	if err != nil {
+		return decimal.Zero, fmt.Errorf("cost basis: list txns: %w", err)
+	}
+	total := decimal.Zero
+	for _, r := range rows {
+		total = total.Add(r.Amount)
+	}
+	return total, nil
+}
+
+// atEndOfDay returns the supplied date with time set to 23:59:59 UTC.
+// Price lookups use the most-recent price at-or-before this instant, so
+// a trade dated 2026-05-15 picks up any FX observation written during
+// that same calendar day (e.g. ECB's daily fix).
+func atEndOfDay(d time.Time) time.Time {
+	return time.Date(d.Year(), d.Month(), d.Day(), 23, 59, 59, 0, time.UTC)
+}

--- a/backend/internal/service/valuation/cost_basis_test.go
+++ b/backend/internal/service/valuation/cost_basis_test.go
@@ -1,0 +1,327 @@
+package valuation_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/shopspring/decimal"
+	"gorm.io/gorm"
+
+	"github.com/gregwym/offbook/backend/internal/model"
+	"github.com/gregwym/offbook/backend/internal/repository"
+	"github.com/gregwym/offbook/backend/internal/service/valuation"
+	"github.com/gregwym/offbook/backend/internal/testutil"
+)
+
+// seedTradeAccount creates a user + brokerage account + AAPL asset and
+// returns ids needed by the cost-basis tests. Cleanup is registered for
+// every row.
+func seedTradeAccount(t *testing.T, g *gorm.DB) (userID, accountID, usdID, aaplID int64) {
+	t.Helper()
+	usdID = testutil.LookupUSDAssetID(t, g)
+	u := &model.User{
+		Email:                  "cb-" + time.Now().Format("150405.000000000") + "@example.test",
+		PasswordHash:           "x",
+		LastScope:              model.ScopePersonal,
+		DefaultScope:           model.ScopePersonal,
+		PrimaryCurrencyAssetID: usdID,
+	}
+	if err := g.Create(u).Error; err != nil {
+		t.Fatalf("seed user: %v", err)
+	}
+	t.Cleanup(func() {
+		g.Unscoped().Where("user_id = ?", u.ID).Delete(&model.Transaction{})
+		g.Unscoped().Where("user_id = ?", u.ID).Delete(&model.Position{})
+		g.Unscoped().Where("user_id = ?", u.ID).Delete(&model.Account{})
+		g.Unscoped().Delete(&model.User{}, u.ID)
+	})
+
+	displayName := "Apple"
+	aapl := &model.Asset{Symbol: "AAPL-" + time.Now().Format("150405.000000000"), Kind: model.AssetKindEquity, DisplayName: &displayName, Precision: 4}
+	if err := g.Create(aapl).Error; err != nil {
+		t.Fatalf("seed AAPL: %v", err)
+	}
+	t.Cleanup(func() { g.Unscoped().Delete(&model.Asset{}, aapl.ID) })
+
+	acct := &model.Account{
+		UserID: u.ID, Name: "Brokerage-" + time.Now().Format("150405.000000000"),
+		InstitutionSlug: "fixture", AccountType: "investment", Currency: "USD",
+		PrimaryQuoteAssetID: usdID,
+	}
+	if err := g.Create(acct).Error; err != nil {
+		t.Fatalf("seed account: %v", err)
+	}
+	return u.ID, acct.ID, usdID, aapl.ID
+}
+
+// createPair builds a buy or sell trade pair as the trade_service would.
+// kind ∈ {"buy","sell"}; qty/price are positive magnitudes. Returns the
+// (security_leg, cash_leg) IDs for downstream assertions.
+func createPair(t *testing.T, g *gorm.DB, userID, accountID, secAsset, cashAsset int64, kind string, qty, price decimal.Decimal, date time.Time) {
+	t.Helper()
+	var secAmt, cashAmt decimal.Decimal
+	switch kind {
+	case "buy":
+		secAmt = qty
+		cashAmt = price.Mul(qty).Neg()
+	case "sell":
+		secAmt = qty.Neg()
+		cashAmt = price.Mul(qty)
+	default:
+		t.Fatalf("bad kind %q", kind)
+	}
+	repo := repository.NewTransactionRepository(g)
+	secLeg := &model.Transaction{UserID: userID, AccountID: accountID, AssetID: secAsset, Amount: secAmt, TransactionDate: date, Source: "manual"}
+	cashLeg := &model.Transaction{UserID: userID, AccountID: accountID, AssetID: cashAsset, Amount: cashAmt, TransactionDate: date, Source: "manual"}
+	if err := repo.CreateTradePair(context.Background(), secLeg, cashLeg); err != nil {
+		t.Fatalf("create pair: %v", err)
+	}
+}
+
+func TestRecompute_BuyOnly(t *testing.T) {
+	g := openTestDB(t)
+	userID, accountID, usd, aapl := seedTradeAccount(t, g)
+	ctx := context.Background()
+
+	// Buy 10 AAPL @ $150 = $1500 cost basis.
+	createPair(t, g, userID, accountID, aapl, usd, "buy",
+		decimal.NewFromInt(10), decimal.NewFromInt(150),
+		time.Date(2026, 1, 10, 0, 0, 0, 0, time.UTC))
+
+	res, err := valuation.Recompute(ctx,
+		repository.NewTransactionRepository(g),
+		repository.NewPriceRepository(g),
+		userID, accountID, aapl, usd,
+	)
+	if err != nil {
+		t.Fatalf("recompute: %v", err)
+	}
+	if !res.Quantity.Equal(decimal.NewFromInt(10)) {
+		t.Errorf("qty = %s, want 10", res.Quantity)
+	}
+	if !res.CostBasis.Equal(decimal.NewFromInt(1500)) {
+		t.Errorf("cost basis = %s, want 1500", res.CostBasis)
+	}
+	if !res.HasCostBasis {
+		t.Error("HasCostBasis = false, want true")
+	}
+}
+
+func TestRecompute_AverageCost_TwoBuysOneSell(t *testing.T) {
+	g := openTestDB(t)
+	userID, accountID, usd, aapl := seedTradeAccount(t, g)
+	ctx := context.Background()
+
+	// 10 @ $100 + 10 @ $200 = 20 shares, $3000 cost basis.
+	createPair(t, g, userID, accountID, aapl, usd, "buy",
+		decimal.NewFromInt(10), decimal.NewFromInt(100),
+		time.Date(2026, 1, 10, 0, 0, 0, 0, time.UTC))
+	createPair(t, g, userID, accountID, aapl, usd, "buy",
+		decimal.NewFromInt(10), decimal.NewFromInt(200),
+		time.Date(2026, 2, 10, 0, 0, 0, 0, time.UTC))
+	// Sell 5 → proportional reduction: per-unit = 3000/20 = 150.
+	// Removed = 150 * 5 = 750. New cb = 2250 over 15 shares.
+	createPair(t, g, userID, accountID, aapl, usd, "sell",
+		decimal.NewFromInt(5), decimal.NewFromInt(180),
+		time.Date(2026, 3, 10, 0, 0, 0, 0, time.UTC))
+
+	res, err := valuation.Recompute(ctx,
+		repository.NewTransactionRepository(g),
+		repository.NewPriceRepository(g),
+		userID, accountID, aapl, usd,
+	)
+	if err != nil {
+		t.Fatalf("recompute: %v", err)
+	}
+	if !res.Quantity.Equal(decimal.NewFromInt(15)) {
+		t.Errorf("qty = %s, want 15", res.Quantity)
+	}
+	if !res.CostBasis.Equal(decimal.NewFromInt(2250)) {
+		t.Errorf("cost basis = %s, want 2250", res.CostBasis)
+	}
+}
+
+func TestRecompute_SellAll_ResetsBasis(t *testing.T) {
+	g := openTestDB(t)
+	userID, accountID, usd, aapl := seedTradeAccount(t, g)
+	ctx := context.Background()
+
+	createPair(t, g, userID, accountID, aapl, usd, "buy",
+		decimal.NewFromInt(10), decimal.NewFromInt(100),
+		time.Date(2026, 1, 10, 0, 0, 0, 0, time.UTC))
+	createPair(t, g, userID, accountID, aapl, usd, "sell",
+		decimal.NewFromInt(10), decimal.NewFromInt(120),
+		time.Date(2026, 2, 10, 0, 0, 0, 0, time.UTC))
+
+	res, err := valuation.Recompute(ctx,
+		repository.NewTransactionRepository(g),
+		repository.NewPriceRepository(g),
+		userID, accountID, aapl, usd,
+	)
+	if err != nil {
+		t.Fatalf("recompute: %v", err)
+	}
+	if !res.Quantity.IsZero() {
+		t.Errorf("qty = %s, want 0", res.Quantity)
+	}
+	if !res.CostBasis.IsZero() {
+		t.Errorf("cost basis = %s, want 0 after full liquidation", res.CostBasis)
+	}
+}
+
+func TestRecompute_FXAcrossPrimary(t *testing.T) {
+	g := openTestDB(t)
+	usd := testutil.LookupUSDAssetID(t, g)
+	eur := testutil.LookupAssetID(t, g, "EUR", "fiat")
+
+	// User's primary currency is USD; account holds EUR cash + an EUR-
+	// quoted "Bund" position. Cost basis should land in USD via the
+	// EUR→USD trade-date price.
+	u := &model.User{
+		Email:                  "cb-fx-" + time.Now().Format("150405.000000000") + "@example.test",
+		PasswordHash:           "x",
+		LastScope:              model.ScopePersonal,
+		DefaultScope:           model.ScopePersonal,
+		PrimaryCurrencyAssetID: usd,
+	}
+	if err := g.Create(u).Error; err != nil {
+		t.Fatalf("seed user: %v", err)
+	}
+	t.Cleanup(func() {
+		g.Unscoped().Where("user_id = ?", u.ID).Delete(&model.Transaction{})
+		g.Unscoped().Where("user_id = ?", u.ID).Delete(&model.Account{})
+		g.Unscoped().Delete(&model.User{}, u.ID)
+	})
+	bundName := "German Bund"
+	bund := &model.Asset{Symbol: "BUND-" + time.Now().Format("150405.000000000"), Kind: model.AssetKindBond, DisplayName: &bundName, Precision: 4, QuoteCurrencyAssetID: &eur}
+	if err := g.Create(bund).Error; err != nil {
+		t.Fatalf("seed BUND: %v", err)
+	}
+	t.Cleanup(func() { g.Unscoped().Delete(&model.Asset{}, bund.ID) })
+
+	acct := &model.Account{
+		UserID: u.ID, Name: "EUR-Brokerage-" + time.Now().Format("150405.000000000"),
+		InstitutionSlug: "fixture", AccountType: "investment", Currency: "EUR",
+		PrimaryQuoteAssetID: eur,
+	}
+	if err := g.Create(acct).Error; err != nil {
+		t.Fatalf("seed account: %v", err)
+	}
+
+	// Trade-date EUR→USD = 1.10 (i.e. 100 EUR = 110 USD).
+	tradeDate := time.Date(2026, 1, 10, 0, 0, 0, 0, time.UTC)
+	if err := repository.NewPriceRepository(g).Insert(context.Background(), &model.Price{
+		AssetID:      eur,
+		QuoteAssetID: usd,
+		AsOf:         tradeDate,
+		Price:        decimal.NewFromFloat(1.10),
+		Source:       "manual",
+	}); err != nil {
+		t.Fatalf("seed price: %v", err)
+	}
+	t.Cleanup(func() {
+		g.Unscoped().Where("asset_id = ? AND quote_asset_id = ?", eur, usd).Delete(&model.Price{})
+	})
+
+	// Buy 10 BUND @ 100 EUR = 1000 EUR cash out = 1100 USD cost basis.
+	createPair(t, g, u.ID, acct.ID, bund.ID, eur, "buy",
+		decimal.NewFromInt(10), decimal.NewFromInt(100), tradeDate)
+
+	res, err := valuation.Recompute(context.Background(),
+		repository.NewTransactionRepository(g),
+		repository.NewPriceRepository(g),
+		u.ID, acct.ID, bund.ID, usd,
+	)
+	if err != nil {
+		t.Fatalf("recompute: %v", err)
+	}
+	if !res.Quantity.Equal(decimal.NewFromInt(10)) {
+		t.Errorf("qty = %s, want 10", res.Quantity)
+	}
+	if !res.CostBasis.Equal(decimal.NewFromInt(1100)) {
+		t.Errorf("cost basis = %s, want 1100 USD", res.CostBasis)
+	}
+}
+
+func TestRecompute_FXUnavailable_ReturnsErr(t *testing.T) {
+	g := openTestDB(t)
+	usd := testutil.LookupUSDAssetID(t, g)
+	eur := testutil.LookupAssetID(t, g, "EUR", "fiat")
+
+	u := &model.User{
+		Email:        "cb-nofx-" + time.Now().Format("150405.000000000") + "@example.test",
+		PasswordHash: "x", LastScope: model.ScopePersonal, DefaultScope: model.ScopePersonal,
+		PrimaryCurrencyAssetID: usd,
+	}
+	if err := g.Create(u).Error; err != nil {
+		t.Fatalf("seed user: %v", err)
+	}
+	t.Cleanup(func() {
+		g.Unscoped().Where("user_id = ?", u.ID).Delete(&model.Transaction{})
+		g.Unscoped().Where("user_id = ?", u.ID).Delete(&model.Account{})
+		g.Unscoped().Delete(&model.User{}, u.ID)
+	})
+	stockName := "Hypothetical EU Stock"
+	stk := &model.Asset{Symbol: "EUSTK-" + time.Now().Format("150405.000000000"), Kind: model.AssetKindEquity, DisplayName: &stockName, Precision: 4, QuoteCurrencyAssetID: &eur}
+	if err := g.Create(stk).Error; err != nil {
+		t.Fatalf("seed asset: %v", err)
+	}
+	t.Cleanup(func() { g.Unscoped().Delete(&model.Asset{}, stk.ID) })
+	acct := &model.Account{
+		UserID: u.ID, Name: "EU-" + time.Now().Format("150405.000000000"),
+		InstitutionSlug: "fixture", AccountType: "investment", Currency: "EUR",
+		PrimaryQuoteAssetID: eur,
+	}
+	if err := g.Create(acct).Error; err != nil {
+		t.Fatalf("seed account: %v", err)
+	}
+
+	// No EUR→USD price seeded.
+	createPair(t, g, u.ID, acct.ID, stk.ID, eur, "buy",
+		decimal.NewFromInt(5), decimal.NewFromInt(50),
+		time.Date(2026, 1, 10, 0, 0, 0, 0, time.UTC))
+
+	_, err := valuation.Recompute(context.Background(),
+		repository.NewTransactionRepository(g),
+		repository.NewPriceRepository(g),
+		u.ID, acct.ID, stk.ID, usd,
+	)
+	if !errors.Is(err, valuation.ErrFXUnavailable) {
+		t.Fatalf("err = %v, want ErrFXUnavailable", err)
+	}
+}
+
+func TestRecompute_TransferInOut_QuantityOnly(t *testing.T) {
+	// Inflow without a paired cash leg → quantity rises but cost basis
+	// stays "unknown" for the added units. Outflow without a paired cash
+	// leg → proportional cost-basis removal (we know lots leave).
+	g := openTestDB(t)
+	userID, accountID, _, aapl := seedTradeAccount(t, g)
+	ctx := context.Background()
+
+	// Transfer in 5 shares (unpaired).
+	if err := g.Create(&model.Transaction{
+		UserID: userID, AccountID: accountID, AssetID: aapl,
+		Amount: decimal.NewFromInt(5), TransactionDate: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		Source: "manual",
+	}).Error; err != nil {
+		t.Fatalf("seed transfer-in: %v", err)
+	}
+
+	res, err := valuation.Recompute(ctx,
+		repository.NewTransactionRepository(g),
+		repository.NewPriceRepository(g),
+		userID, accountID, aapl, testutil.LookupUSDAssetID(t, g),
+	)
+	if err != nil {
+		t.Fatalf("recompute: %v", err)
+	}
+	if !res.Quantity.Equal(decimal.NewFromInt(5)) {
+		t.Errorf("qty = %s, want 5", res.Quantity)
+	}
+	if res.HasCostBasis {
+		t.Error("HasCostBasis = true, want false (no priced source)")
+	}
+}

--- a/backend/migrations/000015_categorization_rules_asset_id.down.sql
+++ b/backend/migrations/000015_categorization_rules_asset_id.down.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS ix_categorization_rules_asset_id;
+ALTER TABLE categorization_rules DROP COLUMN IF EXISTS asset_id;

--- a/backend/migrations/000015_categorization_rules_asset_id.up.sql
+++ b/backend/migrations/000015_categorization_rules_asset_id.up.sql
@@ -1,0 +1,17 @@
+-- #238 (M10b): let categorization rules target a specific asset.
+--
+-- Trade ingestion (#238) writes paired transaction rows where the security
+-- leg carries the security's asset_id (AAPL, BTC, …). A rule like
+-- "all AAPL buys → Investments category" needs to match on asset_id, not
+-- only on description/merchant text.
+--
+-- asset_id is nullable: NULL keeps the rule asset-agnostic (existing
+-- behavior). When set, the rule only fires on transactions whose
+-- asset_id matches — combined with the text matcher if a pattern is
+-- supplied.
+ALTER TABLE categorization_rules
+    ADD COLUMN asset_id BIGINT REFERENCES assets(id);
+
+CREATE INDEX ix_categorization_rules_asset_id
+    ON categorization_rules (asset_id)
+    WHERE deleted_at IS NULL AND asset_id IS NOT NULL;


### PR DESCRIPTION
## Summary

Backend half of M10b trade ingestion (#238). Lands manual trade entry,
cost-basis recompute, asset-targeted categorization rules, AI-context
trade summaries, and household-aggregator privacy tests. Plaid
investment-transactions ingestion + frontend land in follow-up PRs to
keep the diff reviewable.

- **TransactionRepo.CreateTradePair**: atomic two-row insert with
  cross-linked \`transfer_pair_id\`; plus \`ListByTransferPairID\` and
  \`ListByAccountAndAsset\` for cost-basis walks.
- **\`service/valuation/cost_basis.go\`**: pure-ish \`Recompute\` walks paired
  trades for (account, asset) and folds quantity + average-cost basis in
  the user's primary currency. Handles one-hop FX via prices at the
  trade date; returns \`ErrFXUnavailable\` when the rate is missing.
- **\`TradeService\` + \`POST /api/v1/accounts/:id/trades\`**: validated
  manual buy/sell entry. Writes paired rows, recomputes positions +
  cost basis. Brokerage-only; rejects oversells.
- **\`categorization_rules.asset_id\`** (migration 000015) + engine
  updates so rules can target a specific asset (e.g. \"all AAPL legs →
  Investments\"). Asset-bound rules with no pattern are valid.
- **AI context**: \`TradesSummary\` by asset kind (count +
  gross-in-primary). Per ADR-0013 §4, no tickers / per-trade
  quantities leak to the LLM.
- **Privacy tests**: trade legs respect \`account_shares\` visibility —
  \`balance_only\` excludes both legs from txn aggregates;
  \`balance_and_txns\` surfaces both.

Closes part 1 of #238 — Plaid invest-txns + holdings reconciliation and
the frontend trade form follow.

## Test plan

- [x] \`command make verify\` (backend vet+race+test, frontend lint+build)
- [x] Cost-basis unit tests: buy-only, average-cost over multi-buy +
      sell, full-liquidation reset, EUR→USD FX hop, \`ErrFXUnavailable\`,
      unpaired transfer-in.
- [x] Trade-service tests: buy writes pair + position + cost basis;
      non-brokerage rejection; oversell rejection; cross-tenant
      isolation.
- [x] Engine test: asset-bound rule matches AAPL leg, skips non-AAPL,
      agnostic rule still fires on text.
- [x] Aggregator: trade legs hidden from \`balance_only\`; visible at
      \`balance_and_txns\`.

## Deferred (separate PRs)

- **Part 2** (#238): Plaid \`investments/transactions/get\` ingestion;
  holdings-snapshot reconciliation (adjust positions, never synthesize
  trades).
- **Part 3** (#238): Frontend \"Record a trade\" form and collapsed
  paired-row rendering on the transaction list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)