### PR TITLE
M10b part 2: Plaid investment transactions + holdings reconciliation

### DIFF
--- a/backend/internal/handler/plaid_handler.go
+++ b/backend/internal/handler/plaid_handler.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"net/http"
 	"strconv"
+	"time"
 
 	"github.com/gin-gonic/gin"
 
@@ -30,6 +31,8 @@ func (h *PlaidHandler) Register(g *gin.RouterGroup) {
 	g.DELETE("/plaid/items/:item_id", h.DisconnectItem)
 	g.POST("/plaid/items/:item_id/sync-accounts", h.SyncAccounts)
 	g.POST("/plaid/items/:item_id/sync-transactions", h.SyncTransactions)
+	g.POST("/plaid/items/:item_id/sync-investment-transactions", h.SyncInvestmentTransactions)
+	g.POST("/plaid/items/:item_id/sync-holdings", h.SyncHoldings)
 	g.GET("/plaid/items/:item_id/errors", h.ListSyncErrors)
 	g.POST("/plaid/errors/:error_id/retry", h.RetrySyncError)
 	g.POST("/plaid/errors/:error_id/dismiss", h.DismissSyncError)
@@ -127,6 +130,42 @@ func (h *PlaidHandler) SyncTransactions(c *gin.Context) {
 			"failed":   result.Failed,
 		},
 	})
+}
+
+// SyncInvestmentTransactions drains /investments/transactions/get for
+// the item, writing paired-row trades or single-leg cash rows (#238).
+// Response mirrors SyncTransactions: a narrow counts envelope.
+func (h *PlaidHandler) SyncInvestmentTransactions(c *gin.Context) {
+	plaidItemID := c.Param("item_id")
+	if plaidItemID == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "item_id is required", "code": "INVALID_REQUEST"})
+		return
+	}
+	userID := auth.MustUserID(c.Request.Context())
+	// Empty from/to → service default (2-year lookback).
+	result, err := h.svc.SyncInvestmentTransactions(c.Request.Context(), userID, plaidItemID, time.Time{}, time.Time{})
+	if err != nil {
+		h.writeError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"data": result})
+}
+
+// SyncHoldings pulls a /investments/holdings/get snapshot and adjusts
+// positions on disagreement (ADR-0013 §3 — no synthetic transactions).
+func (h *PlaidHandler) SyncHoldings(c *gin.Context) {
+	plaidItemID := c.Param("item_id")
+	if plaidItemID == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "item_id is required", "code": "INVALID_REQUEST"})
+		return
+	}
+	userID := auth.MustUserID(c.Request.Context())
+	result, err := h.svc.SyncHoldings(c.Request.Context(), userID, plaidItemID)
+	if err != nil {
+		h.writeError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"data": result})
 }
 
 // ListItems returns the user's linked Plaid items for the Settings page,

--- a/backend/internal/service/plaid/client.go
+++ b/backend/internal/service/plaid/client.go
@@ -40,6 +40,82 @@ type Client interface {
 	// changed since that cursor. Callers paginate by re-calling with
 	// page.NextCursor while page.HasMore is true.
 	SyncTransactions(ctx context.Context, accessToken, cursor string) (SyncTransactionsPage, error)
+
+	// FetchInvestmentTransactions wraps /investments/transactions/get for
+	// the [from, to] date window. Plaid's API is not cursor-based here —
+	// it accepts a date range and returns the matching rows. Callers
+	// page by passing the response's TotalCount + Offset on subsequent
+	// calls; this client method fans out the pagination and returns the
+	// flattened result.
+	FetchInvestmentTransactions(ctx context.Context, accessToken string, from, to time.Time) (InvestmentTransactionsResult, error)
+
+	// FetchHoldings wraps /investments/holdings/get. The response is a
+	// point-in-time snapshot — the reconciliation layer compares it to
+	// our derived positions and adjusts on mismatch (never synthesizes
+	// transactions to bridge a gap; see ADR-0013 §3).
+	FetchHoldings(ctx context.Context, accessToken string) (HoldingsResult, error)
+}
+
+// InvestmentTransactionsResult is the flattened output of one
+// /investments/transactions/get drain. Securities and Accounts are
+// returned alongside transactions because each row references them by
+// plaid id; the service-side mapper resolves the joins.
+type InvestmentTransactionsResult struct {
+	Transactions []PlaidInvestmentTransaction
+	Securities   []PlaidSecurity
+}
+
+// HoldingsResult is one /investments/holdings/get snapshot. Securities
+// is the same shape as in InvestmentTransactionsResult so the same
+// resolver works for both surfaces.
+type HoldingsResult struct {
+	Holdings   []PlaidHolding
+	Securities []PlaidSecurity
+}
+
+// PlaidInvestmentTransaction is the slim view of one investment
+// transaction. Sign convention matches Plaid's: positive Amount =
+// money LEAVING the account (buy outflow); positive Quantity = shares
+// flowing IN (buy inflow). The mapper flips signs for project storage.
+type PlaidInvestmentTransaction struct {
+	PlaidTransactionID  string
+	CancelTransactionID *string // when Type == "cancel", names the row being cancelled
+	PlaidAccountID      string
+	PlaidSecurityID     *string // nil for cash-only legs (some dividends, fees)
+	Date                string  // "YYYY-MM-DD"
+	Name                string
+	Quantity            decimal.Decimal
+	Amount              decimal.Decimal // in IsoCurrencyCode
+	Price               decimal.Decimal
+	Fees                decimal.Decimal
+	Type                string // "buy" | "sell" | "cancel" | "cash" | "fee" | "transfer"
+	Subtype             string // "dividend", "interest", "buy", etc.
+	IsoCurrencyCode     string
+}
+
+// PlaidSecurity is the slim view of one security. Used to resolve a
+// transaction or holding's SecurityID to (symbol, kind) for the asset
+// table. TickerSymbol is preferred; we fall back to ISIN/CUSIP/name
+// when blank.
+type PlaidSecurity struct {
+	PlaidSecurityID  string
+	TickerSymbol     string
+	Name             string
+	Type             string // 'equity', 'mutual fund', 'etf', 'fixed income', 'cash', 'cryptocurrency', …
+	IsoCurrencyCode  string
+	IsCashEquivalent bool
+	ClosePrice       decimal.Decimal
+}
+
+// PlaidHolding is the slim view of one position snapshot.
+type PlaidHolding struct {
+	PlaidAccountID   string
+	PlaidSecurityID  string
+	Quantity         decimal.Decimal
+	InstitutionPrice decimal.Decimal
+	InstitutionValue decimal.Decimal
+	CostBasis        decimal.Decimal // 0 when Plaid returns null
+	IsoCurrencyCode  string
 }
 
 // SyncTransactionsPage is one page of /transactions/sync output. The cursor
@@ -300,6 +376,150 @@ func (c *SDKClient) SyncTransactions(ctx context.Context, accessToken, cursor st
 		}
 	}
 	return page, nil
+}
+
+// FetchInvestmentTransactions pulls /investments/transactions/get for
+// the date window and paginates until the response totals are
+// exhausted. Plaid limits one response to 500 rows; we use 250 to stay
+// well under and tolerate occasional slow pages. The transactions and
+// securities slices come back flattened across all pages.
+func (c *SDKClient) FetchInvestmentTransactions(ctx context.Context, accessToken string, from, to time.Time) (InvestmentTransactionsResult, error) {
+	const pageSize = int32(250)
+	startDate := from.UTC().Format("2006-01-02")
+	endDate := to.UTC().Format("2006-01-02")
+
+	var out InvestmentTransactionsResult
+	seenSecurities := map[string]struct{}{}
+	offset := int32(0)
+	for {
+		req := plaid.NewInvestmentsTransactionsGetRequest(accessToken, startDate, endDate)
+		opts := plaid.NewInvestmentsTransactionsGetRequestOptions()
+		opts.SetCount(pageSize)
+		opts.SetOffset(offset)
+		req.SetOptions(*opts)
+
+		resp, _, err := c.api.PlaidApi.InvestmentsTransactionsGet(ctx).
+			InvestmentsTransactionsGetRequest(*req).Execute()
+		if err != nil {
+			return InvestmentTransactionsResult{}, fmt.Errorf("plaid: investments/transactions/get: %w", err)
+		}
+		for _, it := range resp.GetInvestmentTransactions() {
+			out.Transactions = append(out.Transactions, convertPlaidInvestmentTransaction(it))
+		}
+		for _, s := range resp.GetSecurities() {
+			id := s.GetSecurityId()
+			if _, dup := seenSecurities[id]; dup {
+				continue
+			}
+			seenSecurities[id] = struct{}{}
+			out.Securities = append(out.Securities, convertPlaidSecurity(s))
+		}
+
+		total := int(resp.GetTotalInvestmentTransactions())
+		offset += pageSize
+		if int(offset) >= total {
+			break
+		}
+	}
+	return out, nil
+}
+
+// FetchHoldings wraps /investments/holdings/get. One call returns the
+// full snapshot — no pagination.
+func (c *SDKClient) FetchHoldings(ctx context.Context, accessToken string) (HoldingsResult, error) {
+	req := plaid.NewInvestmentsHoldingsGetRequest(accessToken)
+	resp, _, err := c.api.PlaidApi.InvestmentsHoldingsGet(ctx).
+		InvestmentsHoldingsGetRequest(*req).Execute()
+	if err != nil {
+		return HoldingsResult{}, fmt.Errorf("plaid: investments/holdings/get: %w", err)
+	}
+	out := HoldingsResult{
+		Holdings:   make([]PlaidHolding, 0, len(resp.GetHoldings())),
+		Securities: make([]PlaidSecurity, 0, len(resp.GetSecurities())),
+	}
+	for _, h := range resp.GetHoldings() {
+		costBasis := decimal.Zero
+		if cb, ok := h.GetCostBasisOk(); ok && cb != nil {
+			costBasis = decimal.NewFromFloat(*cb)
+		}
+		currency := ""
+		if iso, ok := h.GetIsoCurrencyCodeOk(); ok && iso != nil && *iso != "" {
+			currency = *iso
+		}
+		out.Holdings = append(out.Holdings, PlaidHolding{
+			PlaidAccountID:   h.GetAccountId(),
+			PlaidSecurityID:  h.GetSecurityId(),
+			Quantity:         decimal.NewFromFloat(h.GetQuantity()),
+			InstitutionPrice: decimal.NewFromFloat(h.GetInstitutionPrice()),
+			InstitutionValue: decimal.NewFromFloat(h.GetInstitutionValue()),
+			CostBasis:        costBasis,
+			IsoCurrencyCode:  currency,
+		})
+	}
+	for _, s := range resp.GetSecurities() {
+		out.Securities = append(out.Securities, convertPlaidSecurity(s))
+	}
+	return out, nil
+}
+
+func convertPlaidInvestmentTransaction(it plaid.InvestmentTransaction) PlaidInvestmentTransaction {
+	out := PlaidInvestmentTransaction{
+		PlaidTransactionID: it.GetInvestmentTransactionId(),
+		PlaidAccountID:     it.GetAccountId(),
+		Date:               it.GetDate(),
+		Name:               it.GetName(),
+		Quantity:           decimal.NewFromFloat(it.GetQuantity()),
+		Amount:             decimal.NewFromFloat(it.GetAmount()),
+		Price:              decimal.NewFromFloat(it.GetPrice()),
+		Type:               string(it.GetType()),
+		Subtype:            string(it.GetSubtype()),
+	}
+	if sid, ok := it.GetSecurityIdOk(); ok && sid != nil && *sid != "" {
+		v := *sid
+		out.PlaidSecurityID = &v
+	}
+	if c, ok := it.GetCancelTransactionIdOk(); ok && c != nil && *c != "" {
+		v := *c
+		out.CancelTransactionID = &v
+	}
+	if fees, ok := it.GetFeesOk(); ok && fees != nil {
+		out.Fees = decimal.NewFromFloat(*fees)
+	}
+	if iso, ok := it.GetIsoCurrencyCodeOk(); ok && iso != nil {
+		out.IsoCurrencyCode = *iso
+	}
+	if out.IsoCurrencyCode == "" {
+		out.IsoCurrencyCode = "USD"
+	}
+	return out
+}
+
+func convertPlaidSecurity(s plaid.Security) PlaidSecurity {
+	out := PlaidSecurity{
+		PlaidSecurityID: s.GetSecurityId(),
+	}
+	if v, ok := s.GetTickerSymbolOk(); ok && v != nil {
+		out.TickerSymbol = *v
+	}
+	if v, ok := s.GetNameOk(); ok && v != nil {
+		out.Name = *v
+	}
+	if v, ok := s.GetTypeOk(); ok && v != nil {
+		out.Type = *v
+	}
+	if v, ok := s.GetIsoCurrencyCodeOk(); ok && v != nil {
+		out.IsoCurrencyCode = *v
+	}
+	if out.IsoCurrencyCode == "" {
+		out.IsoCurrencyCode = "USD"
+	}
+	if v, ok := s.GetIsCashEquivalentOk(); ok && v != nil {
+		out.IsCashEquivalent = *v
+	}
+	if v, ok := s.GetClosePriceOk(); ok && v != nil {
+		out.ClosePrice = decimal.NewFromFloat(*v)
+	}
+	return out
 }
 
 // convertPlaidTransaction reshapes the SDK type into our slim struct.

--- a/backend/internal/service/plaid/holdings_reconcile_test.go
+++ b/backend/internal/service/plaid/holdings_reconcile_test.go
@@ -1,0 +1,205 @@
+package plaid_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/shopspring/decimal"
+	"gorm.io/gorm"
+
+	"github.com/gregwym/offbook/backend/internal/crypto"
+	"github.com/gregwym/offbook/backend/internal/model"
+	"github.com/gregwym/offbook/backend/internal/repository"
+	"github.com/gregwym/offbook/backend/internal/service"
+	plaidsvc "github.com/gregwym/offbook/backend/internal/service/plaid"
+	"github.com/gregwym/offbook/backend/internal/testutil"
+)
+
+// fakePlaidClient implements plaidsvc.Client with hand-set return
+// values, so reconciliation tests can drive specific snapshots without
+// standing up an httptest server.
+type fakePlaidClient struct {
+	holdings plaidsvc.HoldingsResult
+	invTxns  plaidsvc.InvestmentTransactionsResult
+}
+
+func (f *fakePlaidClient) CreateLinkToken(context.Context, int64) (plaidsvc.LinkToken, error) {
+	return plaidsvc.LinkToken{}, fmt.Errorf("not used in test")
+}
+func (f *fakePlaidClient) ExchangePublicToken(context.Context, string) (plaidsvc.Item, error) {
+	return plaidsvc.Item{}, fmt.Errorf("not used in test")
+}
+func (f *fakePlaidClient) FetchAccounts(context.Context, string) (plaidsvc.AccountsResult, error) {
+	return plaidsvc.AccountsResult{}, fmt.Errorf("not used in test")
+}
+func (f *fakePlaidClient) SyncTransactions(context.Context, string, string) (plaidsvc.SyncTransactionsPage, error) {
+	return plaidsvc.SyncTransactionsPage{}, fmt.Errorf("not used in test")
+}
+func (f *fakePlaidClient) FetchInvestmentTransactions(context.Context, string, time.Time, time.Time) (plaidsvc.InvestmentTransactionsResult, error) {
+	return f.invTxns, nil
+}
+func (f *fakePlaidClient) FetchHoldings(context.Context, string) (plaidsvc.HoldingsResult, error) {
+	return f.holdings, nil
+}
+
+// seedHoldingsFixture provisions a user + brokerage account + AAPL
+// asset + a starting AAPL position of 10 shares, and returns the
+// plaid item so the test can call SyncHoldings.
+func seedHoldingsFixture(t *testing.T, g *gorm.DB, snapshotQty decimal.Decimal) (svc *plaidsvc.Service, userID int64, accountID int64, aaplID int64, item *model.PlaidItem) {
+	t.Helper()
+	userID = seedPlaidTestUser(t, g)
+	usdID := testutil.LookupUSDAssetID(t, g)
+
+	displayName := "Apple Inc"
+	aapl := &model.Asset{
+		Symbol: "AAPL-recon-" + time.Now().Format("150405.000000000"),
+		Kind:   model.AssetKindEquity, DisplayName: &displayName, Precision: 4,
+	}
+	if err := g.Create(aapl).Error; err != nil {
+		t.Fatalf("seed asset: %v", err)
+	}
+	t.Cleanup(func() { g.Unscoped().Delete(&model.Asset{}, aapl.ID) })
+	aaplID = aapl.ID
+
+	plaidAcct := "pacct-recon-" + time.Now().Format("150405.000000000")
+	acct := &model.Account{
+		UserID: userID, Name: "BrokerageRecon", InstitutionSlug: "fixture",
+		AccountType: "investment", Currency: "USD", PrimaryQuoteAssetID: usdID,
+		PlaidAccountID: &plaidAcct,
+	}
+	if err := g.Create(acct).Error; err != nil {
+		t.Fatalf("seed account: %v", err)
+	}
+	accountID = acct.ID
+
+	// Starting position: 10 shares of AAPL. The reconciliation test
+	// will assert this gets adjusted to match Plaid's snapshot.
+	if err := g.Exec(`
+		INSERT INTO positions (user_id, account_id, asset_id, quantity, updated_at)
+		VALUES (?, ?, ?, ?, NOW())
+		ON CONFLICT (account_id, asset_id) WHERE deleted_at IS NULL
+		DO UPDATE SET quantity = EXCLUDED.quantity, updated_at = NOW()
+	`, userID, accountID, aaplID, decimal.NewFromInt(10)).Error; err != nil {
+		t.Fatalf("seed position: %v", err)
+	}
+
+	// Build the fake Plaid client with the supplied snapshot quantity.
+	plaidItemID := "pitem-recon-" + time.Now().Format("150405.000000000")
+	plaidSecID := "psec-recon-" + time.Now().Format("150405.000000000")
+	fake := &fakePlaidClient{
+		holdings: plaidsvc.HoldingsResult{
+			Holdings: []plaidsvc.PlaidHolding{
+				{
+					PlaidAccountID:   plaidAcct,
+					PlaidSecurityID:  plaidSecID,
+					Quantity:         snapshotQty,
+					InstitutionPrice: decimal.NewFromInt(195),
+					InstitutionValue: snapshotQty.Mul(decimal.NewFromInt(195)),
+					CostBasis:        decimal.Zero,
+					IsoCurrencyCode:  "USD",
+				},
+			},
+			Securities: []plaidsvc.PlaidSecurity{
+				{
+					PlaidSecurityID: plaidSecID,
+					TickerSymbol:    aapl.Symbol,
+					Name:            "Apple Inc",
+					Type:            "equity",
+					IsoCurrencyCode: "USD",
+				},
+			},
+		},
+	}
+
+	// Persist a Plaid item so the service can find the access token.
+	box, err := crypto.NewSecretBox(make([]byte, 32))
+	if err != nil {
+		t.Fatalf("secretbox: %v", err)
+	}
+	enc, err := box.Encrypt([]byte("access-token-recon"))
+	if err != nil {
+		t.Fatalf("encrypt: %v", err)
+	}
+	item = &model.PlaidItem{
+		UserID:         userID,
+		PlaidItemID:    plaidItemID,
+		AccessTokenEnc: enc,
+		Status:         "active",
+	}
+	if err := g.Create(item).Error; err != nil {
+		t.Fatalf("seed item: %v", err)
+	}
+	t.Cleanup(func() { g.Unscoped().Delete(&model.PlaidItem{}, item.ID) })
+
+	piiSvc := service.NewPIIService(repository.NewPIIRepository(g), nil)
+	svc = plaidsvc.NewService(
+		fake, box,
+		repository.NewPlaidItemRepository(g),
+		repository.NewAccountRepository(g),
+		repository.NewTransactionRepository(g),
+		repository.NewPlaidSyncErrorRepository(g),
+		repository.NewAssetRepository(g),
+		repository.NewPositionRepository(g),
+		piiSvc,
+		nil, // catMapper unused
+		g,
+	)
+	return svc, userID, accountID, aaplID, item
+}
+
+// TestSyncHoldings_AdjustsPositionWithoutSyntheticTxns covers the
+// ADR-0013 §3 invariant: when Plaid's snapshot disagrees with our
+// derived position, we update the position to match Plaid but
+// DO NOT insert any synthetic trade rows to bridge the gap.
+func TestSyncHoldings_AdjustsPositionWithoutSyntheticTxns(t *testing.T) {
+	g := openPlaidTestDB(t)
+	svc, userID, accountID, aaplID, item := seedHoldingsFixture(t, g, decimal.NewFromInt(8))
+	ctx := context.Background()
+
+	// Before: 0 transactions for this user on this account.
+	var beforeCount int64
+	g.Model(&model.Transaction{}).Where("user_id = ?", userID).Count(&beforeCount)
+	if beforeCount != 0 {
+		t.Fatalf("fixture leak: %d transactions before sync, want 0", beforeCount)
+	}
+
+	res, err := svc.SyncHoldings(ctx, userID, item.PlaidItemID)
+	if err != nil {
+		t.Fatalf("SyncHoldings: %v", err)
+	}
+	if res.Holdings != 1 {
+		t.Errorf("Holdings = %d, want 1", res.Holdings)
+	}
+	if res.PositionsAdjusted != 1 {
+		t.Errorf("PositionsAdjusted = %d, want 1 (10 → 8)", res.PositionsAdjusted)
+	}
+	if res.PricesObserved != 1 {
+		t.Errorf("PricesObserved = %d, want 1", res.PricesObserved)
+	}
+
+	// Position should now reflect Plaid's snapshot.
+	var pos model.Position
+	if err := g.Where("user_id = ? AND account_id = ? AND asset_id = ?", userID, accountID, aaplID).
+		First(&pos).Error; err != nil {
+		t.Fatalf("load position: %v", err)
+	}
+	if !pos.Quantity.Equal(decimal.NewFromInt(8)) {
+		t.Errorf("quantity = %s, want 8 (Plaid snapshot wins)", pos.Quantity)
+	}
+
+	// Critical invariant: NO synthetic transactions inserted.
+	var afterCount int64
+	g.Model(&model.Transaction{}).Where("user_id = ?", userID).Count(&afterCount)
+	if afterCount != 0 {
+		t.Errorf("synthesized %d transactions during reconciliation — invariant violation", afterCount)
+	}
+
+	// A price observation was written.
+	var priceCount int64
+	g.Model(&model.Price{}).Where("asset_id = ?", aaplID).Count(&priceCount)
+	if priceCount != 1 {
+		t.Errorf("price observations for asset %d = %d, want 1", aaplID, priceCount)
+	}
+}

--- a/backend/internal/service/plaid/investment_mapping.go
+++ b/backend/internal/service/plaid/investment_mapping.go
@@ -1,0 +1,186 @@
+package plaid
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/gregwym/offbook/backend/internal/model"
+)
+
+// InvestmentAction is the decoded intent of one Plaid investment-
+// transaction row. The service applies it inside its DB transaction:
+//
+//   - ActionPair → writes both legs via CreateTradePair.
+//   - ActionSingleCash → writes only CashLeg.
+//   - ActionCancel → soft-deletes a previously-ingested row keyed by
+//     CancelPlaidTransactionID (and its partner, if paired).
+//   - ActionIgnore → no-op (fee-on-cash with zero amount, unknown
+//     subtype with no actionable signal).
+type InvestmentAction int
+
+const (
+	ActionIgnore InvestmentAction = iota
+	ActionPair
+	ActionSingleCash
+	ActionCancel
+)
+
+// InvestmentPlan is the structured output of MapInvestmentTransaction.
+// Exposes only the fields the service needs to act — keeps the mapper
+// independent of repository and gorm types.
+type InvestmentPlan struct {
+	Action InvestmentAction
+
+	// Populated for ActionPair and ActionSingleCash. Security and Cash
+	// share TransactionDate, Source, PlaidTransactionID, ExternalID.
+	Security *model.Transaction // nil when ActionSingleCash
+	Cash     *model.Transaction
+
+	// Populated for ActionCancel — the Plaid id of the row being
+	// cancelled. Service soft-deletes by this id + clears its partner.
+	CancelPlaidTransactionID string
+}
+
+// MapInvestmentTransaction translates one Plaid investment-transaction
+// row into an InvestmentPlan. The mapper is pure: no DB, no I/O. The
+// asset id for the security leg is resolved by the caller via
+// assetRepo.EnsureBySymbolKind ahead of time — passed as securityAssetID.
+// For non-security legs (cash, fee, dividend without security_id),
+// securityAssetID may be 0.
+//
+// Sign convention from Plaid (per the API docs):
+//   - Amount  > 0  → money LEFT the account (e.g. buy, fee)
+//   - Quantity > 0 → shares ENTERED the account (e.g. buy)
+//
+// Project convention is the opposite for Amount (positive = inflow).
+// We sign-flip Amount at the boundary so downstream (budgets,
+// dashboard, AI) sees one consistent convention.
+func MapInvestmentTransaction(
+	pit PlaidInvestmentTransaction,
+	userID, accountID, cashAssetID, securityAssetID int64,
+) (InvestmentPlan, error) {
+	if pit.PlaidTransactionID == "" {
+		return InvestmentPlan{}, fmt.Errorf("plaid: investment transaction_id empty")
+	}
+	if pit.PlaidAccountID == "" {
+		return InvestmentPlan{}, fmt.Errorf("plaid: account_id empty for investment txn %s", pit.PlaidTransactionID)
+	}
+
+	if strings.EqualFold(pit.Type, "cancel") {
+		if pit.CancelTransactionID == nil || *pit.CancelTransactionID == "" {
+			// Cancel row with no target — nothing to undo. Treat as
+			// ignore rather than error so the cursor still advances.
+			return InvestmentPlan{Action: ActionIgnore}, nil
+		}
+		return InvestmentPlan{
+			Action:                   ActionCancel,
+			CancelPlaidTransactionID: *pit.CancelTransactionID,
+		}, nil
+	}
+
+	txDate, err := time.Parse("2006-01-02", pit.Date)
+	if err != nil {
+		return InvestmentPlan{}, fmt.Errorf("plaid: parse investment date %q: %w", pit.Date, err)
+	}
+
+	plaidID := pit.PlaidTransactionID
+	externalID := plaidID
+	source := "plaid"
+	desc := pit.Name
+	descPtr := &desc
+
+	// Cash leg amount in project convention: Plaid's amount is positive
+	// when money leaves the account; we store negative for outflow.
+	cashAmount := pit.Amount.Neg()
+
+	switch strings.ToLower(pit.Type) {
+	case "buy", "sell":
+		if securityAssetID == 0 {
+			return InvestmentPlan{}, fmt.Errorf("plaid: %s row has no resolvable security (txn %s)", pit.Type, plaidID)
+		}
+		// Plaid Quantity is positive for buy, negative for sell already —
+		// matches the project's "positive = inflow into the account"
+		// convention for the security leg. No sign flip on quantity.
+		securityAmount := pit.Quantity
+		sec := &model.Transaction{
+			UserID:             userID,
+			AccountID:          accountID,
+			AssetID:            securityAssetID,
+			Amount:             securityAmount,
+			Description:        descPtr,
+			TransactionDate:    txDate,
+			Source:             source,
+			ExternalID:         strPtr(externalID + ":sec"),
+			PlaidTransactionID: strPtr(plaidID),
+		}
+		cash := &model.Transaction{
+			UserID:             userID,
+			AccountID:          accountID,
+			AssetID:            cashAssetID,
+			Amount:             cashAmount,
+			Description:        descPtr,
+			TransactionDate:    txDate,
+			Source:             source,
+			ExternalID:         strPtr(externalID + ":cash"),
+			PlaidTransactionID: strPtr(plaidID + ":cash"),
+		}
+		return InvestmentPlan{Action: ActionPair, Security: sec, Cash: cash}, nil
+
+	case "cash", "fee", "transfer":
+		// Single cash leg — dividends, interest, account fees, cash
+		// transfers in/out. The plaid_transaction_id stays canonical so
+		// future modifies/cancels still address this row.
+		cash := &model.Transaction{
+			UserID:             userID,
+			AccountID:          accountID,
+			AssetID:            cashAssetID,
+			Amount:             cashAmount,
+			Description:        descPtr,
+			TransactionDate:    txDate,
+			Source:             source,
+			ExternalID:         strPtr(externalID),
+			PlaidTransactionID: strPtr(plaidID),
+		}
+		return InvestmentPlan{Action: ActionSingleCash, Cash: cash}, nil
+
+	default:
+		// Unknown type — skip rather than error so a future Plaid type
+		// rollout doesn't poison every sync. The DLQ in service.go
+		// catches genuine mapping errors raised above.
+		return InvestmentPlan{Action: ActionIgnore}, nil
+	}
+}
+
+// SecurityKind maps Plaid's `securities.type` taxonomy to the project's
+// asset kind enum (model.AssetKind*). Falls back to "other" for values
+// we don't recognize — keeps the asset row writable without erroring.
+func SecurityKind(plaidType string, isCashEquivalent bool) string {
+	if isCashEquivalent {
+		return model.AssetKindFiat
+	}
+	switch strings.ToLower(strings.TrimSpace(plaidType)) {
+	case "equity":
+		return model.AssetKindEquity
+	case "mutual fund", "etf":
+		return model.AssetKindFund
+	case "fixed income":
+		return model.AssetKindBond
+	case "cryptocurrency":
+		return model.AssetKindCrypto
+	case "cash":
+		return model.AssetKindFiat
+	default:
+		return model.AssetKindOther
+	}
+}
+
+// SecuritySymbol picks the best identifier for an asset row. Prefers
+// the ticker; falls back to the security name. Empty string when both
+// are blank (the caller should treat as an unmappable security).
+func SecuritySymbol(s PlaidSecurity) string {
+	if v := strings.TrimSpace(s.TickerSymbol); v != "" {
+		return v
+	}
+	return strings.TrimSpace(s.Name)
+}

--- a/backend/internal/service/plaid/investment_mapping_test.go
+++ b/backend/internal/service/plaid/investment_mapping_test.go
@@ -1,0 +1,176 @@
+package plaid_test
+
+import (
+	"testing"
+
+	"github.com/shopspring/decimal"
+
+	plaidsvc "github.com/gregwym/offbook/backend/internal/service/plaid"
+)
+
+func TestMapInvestmentTransaction_Buy_WritesPair(t *testing.T) {
+	in := plaidsvc.PlaidInvestmentTransaction{
+		PlaidTransactionID: "ptx-buy-1",
+		PlaidAccountID:     "pacct-1",
+		PlaidSecurityID:    ptr("sec-aapl"),
+		Date:               "2026-05-10",
+		Name:               "BUY AAPL",
+		Quantity:           decimal.NewFromInt(10),   // 10 shares in
+		Amount:             decimal.NewFromInt(1500), // $1500 left the account
+		Price:              decimal.NewFromInt(150),
+		Type:               "buy",
+		Subtype:            "buy",
+		IsoCurrencyCode:    "USD",
+	}
+	plan, err := plaidsvc.MapInvestmentTransaction(in, 1, 42 /*cashAsset*/, 7 /*securityAsset*/, 9)
+	if err != nil {
+		t.Fatalf("map: %v", err)
+	}
+	if plan.Action != plaidsvc.ActionPair {
+		t.Fatalf("action = %v, want ActionPair", plan.Action)
+	}
+	if !plan.Security.Amount.Equal(decimal.NewFromInt(10)) {
+		t.Errorf("security amount = %s, want +10", plan.Security.Amount)
+	}
+	if !plan.Cash.Amount.Equal(decimal.NewFromInt(-1500)) {
+		t.Errorf("cash amount = %s, want -1500 (Plaid +1500 → project -1500)", plan.Cash.Amount)
+	}
+	if plan.Security.AssetID != 9 || plan.Cash.AssetID != 7 {
+		t.Errorf("asset ids: sec=%d cash=%d, want 9/7", plan.Security.AssetID, plan.Cash.AssetID)
+	}
+}
+
+func TestMapInvestmentTransaction_Sell_WritesInversePair(t *testing.T) {
+	in := plaidsvc.PlaidInvestmentTransaction{
+		PlaidTransactionID: "ptx-sell-1",
+		PlaidAccountID:     "pacct-1",
+		PlaidSecurityID:    ptr("sec-aapl"),
+		Date:               "2026-05-10",
+		Name:               "SELL AAPL",
+		// Plaid sign for sell: Quantity negative (shares out), Amount negative
+		// (money in — Plaid uses positive=outflow for cash, so a sell is
+		// negative amount).
+		Quantity:        decimal.NewFromInt(-5),
+		Amount:          decimal.NewFromInt(-800),
+		Price:           decimal.NewFromInt(160),
+		Type:            "sell",
+		Subtype:         "sell",
+		IsoCurrencyCode: "USD",
+	}
+	plan, err := plaidsvc.MapInvestmentTransaction(in, 1, 42, 7, 9)
+	if err != nil {
+		t.Fatalf("map: %v", err)
+	}
+	if plan.Action != plaidsvc.ActionPair {
+		t.Fatalf("action = %v, want ActionPair", plan.Action)
+	}
+	if !plan.Security.Amount.Equal(decimal.NewFromInt(-5)) {
+		t.Errorf("security amount = %s, want -5 (sell outflow)", plan.Security.Amount)
+	}
+	if !plan.Cash.Amount.Equal(decimal.NewFromInt(800)) {
+		t.Errorf("cash amount = %s, want +800 (sale proceeds in)", plan.Cash.Amount)
+	}
+}
+
+func TestMapInvestmentTransaction_Dividend_SingleCashLeg(t *testing.T) {
+	in := plaidsvc.PlaidInvestmentTransaction{
+		PlaidTransactionID: "ptx-div-1",
+		PlaidAccountID:     "pacct-1",
+		Date:               "2026-05-10",
+		Name:               "Dividend AAPL",
+		// Cash dividend: Plaid uses Type=cash with subtype=dividend.
+		// Quantity is 0; Amount is negative (money entering account).
+		Quantity:        decimal.Zero,
+		Amount:          decimal.NewFromInt(-25),
+		Type:            "cash",
+		Subtype:         "dividend",
+		IsoCurrencyCode: "USD",
+	}
+	plan, err := plaidsvc.MapInvestmentTransaction(in, 1, 42, 7, 0)
+	if err != nil {
+		t.Fatalf("map: %v", err)
+	}
+	if plan.Action != plaidsvc.ActionSingleCash {
+		t.Fatalf("action = %v, want ActionSingleCash", plan.Action)
+	}
+	if plan.Security != nil {
+		t.Error("Security leg should be nil for cash/dividend")
+	}
+	if !plan.Cash.Amount.Equal(decimal.NewFromInt(25)) {
+		t.Errorf("cash amount = %s, want +25", plan.Cash.Amount)
+	}
+}
+
+func TestMapInvestmentTransaction_Cancel_ReturnsCancelAction(t *testing.T) {
+	in := plaidsvc.PlaidInvestmentTransaction{
+		PlaidTransactionID:  "ptx-cancel",
+		CancelTransactionID: ptr("ptx-buy-1"),
+		PlaidAccountID:      "pacct-1",
+		Date:                "2026-05-11",
+		Type:                "cancel",
+	}
+	plan, err := plaidsvc.MapInvestmentTransaction(in, 1, 42, 7, 9)
+	if err != nil {
+		t.Fatalf("map: %v", err)
+	}
+	if plan.Action != plaidsvc.ActionCancel {
+		t.Fatalf("action = %v, want ActionCancel", plan.Action)
+	}
+	if plan.CancelPlaidTransactionID != "ptx-buy-1" {
+		t.Errorf("cancel target = %q, want ptx-buy-1", plan.CancelPlaidTransactionID)
+	}
+}
+
+func TestMapInvestmentTransaction_UnknownType_Ignored(t *testing.T) {
+	in := plaidsvc.PlaidInvestmentTransaction{
+		PlaidTransactionID: "ptx-weird",
+		PlaidAccountID:     "pacct-1",
+		Date:               "2026-05-10",
+		Type:               "stocksplit", // future Plaid enum
+	}
+	plan, err := plaidsvc.MapInvestmentTransaction(in, 1, 42, 7, 9)
+	if err != nil {
+		t.Fatalf("map: %v", err)
+	}
+	if plan.Action != plaidsvc.ActionIgnore {
+		t.Errorf("action = %v, want ActionIgnore for unknown type", plan.Action)
+	}
+}
+
+func TestMapInvestmentTransaction_BuyWithoutSecurityID_Errors(t *testing.T) {
+	in := plaidsvc.PlaidInvestmentTransaction{
+		PlaidTransactionID: "ptx-bad",
+		PlaidAccountID:     "pacct-1",
+		Date:               "2026-05-10",
+		Type:               "buy",
+		Quantity:           decimal.NewFromInt(1),
+		Amount:             decimal.NewFromInt(100),
+	}
+	// securityAssetID = 0 — caller couldn't resolve.
+	if _, err := plaidsvc.MapInvestmentTransaction(in, 1, 42, 7, 0); err == nil {
+		t.Error("expected error when buy row has no resolvable security")
+	}
+}
+
+func TestSecurityKind_Mapping(t *testing.T) {
+	cases := []struct {
+		plaidType string
+		isCash    bool
+		want      string
+	}{
+		{"equity", false, "equity"},
+		{"mutual fund", false, "fund"},
+		{"etf", false, "fund"},
+		{"fixed income", false, "bond"},
+		{"cryptocurrency", false, "crypto"},
+		{"cash", false, "fiat"},
+		{"derivative", true, "fiat"}, // is_cash_equivalent wins
+		{"", false, "other"},
+	}
+	for _, tc := range cases {
+		got := plaidsvc.SecurityKind(tc.plaidType, tc.isCash)
+		if got != tc.want {
+			t.Errorf("SecurityKind(%q, %v) = %q, want %q", tc.plaidType, tc.isCash, got, tc.want)
+		}
+	}
+}

--- a/backend/internal/service/plaid/investments_service.go
+++ b/backend/internal/service/plaid/investments_service.go
@@ -1,0 +1,463 @@
+// Package plaid: investments surfaces — issue #238 part 2.
+//
+// SyncInvestmentTransactions and SyncHoldings extend the M3 cash-only
+// sync to brokerage accounts. The cash-sleeve write path established by
+// SyncTransactions is intentionally NOT reused: investment transactions
+// don't ride the /transactions/sync cursor — Plaid exposes them via
+// /investments/transactions/get keyed by a date range. Cancellations
+// come through as their own rows with cancel_transaction_id pointing
+// at the original.
+package plaid
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/shopspring/decimal"
+	"gorm.io/gorm"
+
+	"github.com/gregwym/offbook/backend/internal/model"
+	"github.com/gregwym/offbook/backend/internal/repository"
+	"github.com/gregwym/offbook/backend/internal/service/valuation"
+)
+
+// SyncInvestmentTransactionsResult summarizes one /investments/
+// transactions/get drain.
+//   - PairedInserted: paired buy/sell rows where BOTH legs landed.
+//   - CashInserted: single-leg cash rows (dividends, interest, fees).
+//   - Cancelled: cancel rows that removed a previously-ingested trade
+//     pair or single leg.
+//   - Skipped: rows the mapper deliberately ignored (e.g. unknown type).
+//   - Failed: rows that hit a mapping error and DLQ'd to
+//     plaid_sync_errors.
+type SyncInvestmentTransactionsResult struct {
+	PairedInserted int `json:"paired_inserted"`
+	CashInserted   int `json:"cash_inserted"`
+	Cancelled      int `json:"cancelled"`
+	Skipped        int `json:"skipped"`
+	Failed         int `json:"failed"`
+}
+
+// HoldingsReconcileResult summarizes a /investments/holdings/get
+// reconciliation. PositionsAdjusted counts (account, asset) pairs
+// where Plaid's snapshot quantity disagreed with our derived position
+// — we wrote the Plaid number (per ADR-0013 §3) without inserting any
+// synthetic transactions.
+type HoldingsReconcileResult struct {
+	Holdings          int `json:"holdings"`
+	PositionsAdjusted int `json:"positions_adjusted"`
+	PricesObserved    int `json:"prices_observed"`
+}
+
+// DefaultInvestmentLookback is the trailing window pulled when the
+// caller doesn't supply one. Two years matches Plaid's max supported
+// range for investments/transactions and is generous enough that an
+// initial pull captures the user's tax-relevant history without
+// piling on cost.
+const DefaultInvestmentLookback = 730 * 24 * time.Hour
+
+// SyncInvestmentTransactions drains /investments/transactions/get for
+// the item over [from, to]. Mirrors SyncTransactions' two-phase
+// approach (fetch all → one DB transaction with per-row savepoints).
+//
+// Per the "app never invents transactions" invariant: a row only lands
+// if Plaid sent it. The cancel branch removes prior rows rather than
+// generating reversing entries; the reconciliation path adjusts
+// positions but does not synthesize trades.
+func (s *Service) SyncInvestmentTransactions(ctx context.Context, userID int64, plaidItemID string, from, to time.Time) (result SyncInvestmentTransactionsResult, retErr error) {
+	if !s.Configured() || s.acctRepo == nil || s.txRepo == nil || s.assetRepo == nil || s.positionRepo == nil || s.db == nil {
+		return SyncInvestmentTransactionsResult{}, ErrNotConfigured
+	}
+	item, err := s.itemRepo.GetByPlaidItemID(ctx, userID, plaidItemID)
+	if err != nil {
+		if errors.Is(err, repository.ErrNotFound) {
+			return SyncInvestmentTransactionsResult{}, ErrItemNotFound
+		}
+		return SyncInvestmentTransactionsResult{}, fmt.Errorf("plaid: lookup item: %w", err)
+	}
+
+	if to.IsZero() {
+		to = time.Now().UTC()
+	}
+	if from.IsZero() {
+		from = to.Add(-DefaultInvestmentLookback)
+	}
+
+	tokenBytes, err := s.box.Decrypt(item.AccessTokenEnc)
+	if err != nil {
+		return SyncInvestmentTransactionsResult{}, fmt.Errorf("plaid: decrypt access_token: %w", err)
+	}
+	defer zeroBytes(tokenBytes)
+
+	fetched, err := s.client.FetchInvestmentTransactions(ctx, string(tokenBytes), from, to)
+	if err != nil {
+		return SyncInvestmentTransactionsResult{}, err
+	}
+
+	// Resolve securities to assets up front, outside the DB transaction.
+	// EnsureBySymbolKind creates rows on first encounter; we don't want
+	// to do that inside a long-running savepoint loop.
+	assetBySecurity := map[string]int64{}
+	for _, sec := range fetched.Securities {
+		symbol := SecuritySymbol(sec)
+		if symbol == "" {
+			continue
+		}
+		kind := SecurityKind(sec.Type, sec.IsCashEquivalent)
+		display := sec.Name
+		if display == "" {
+			display = symbol
+		}
+		asset, err := s.assetRepo.EnsureBySymbolKind(ctx, symbol, kind, display)
+		if err != nil {
+			return SyncInvestmentTransactionsResult{}, fmt.Errorf("plaid: ensure asset %s/%s: %w", symbol, kind, err)
+		}
+		assetBySecurity[sec.PlaidSecurityID] = asset.ID
+	}
+
+	err = s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		txRepo := repository.NewTransactionRepository(tx)
+		acctRepo := repository.NewAccountRepository(tx)
+		posRepo := repository.NewPositionRepository(tx)
+		syncErrRepo := repository.NewPlaidSyncErrorRepository(tx)
+		accountIDCache := map[string]accountRef{}
+		spIdx := 0
+
+		// Track which (accountID, securityAssetID) pairs were touched so
+		// we recompute positions/cost basis once at the end.
+		type touchedKey struct{ accountID, assetID int64 }
+		touched := map[touchedKey]struct{}{}
+
+		withSavepoint := func(fn func() error) error {
+			spIdx++
+			name := fmt.Sprintf("plaid_inv_%d", spIdx)
+			if err := tx.SavePoint(name).Error; err != nil {
+				return fmt.Errorf("plaid: savepoint %s: %w", name, err)
+			}
+			if err := fn(); err != nil {
+				if rErr := tx.RollbackTo(name).Error; rErr != nil {
+					return fmt.Errorf("plaid: rollback to %s: %w (orig: %v)", name, rErr, err)
+				}
+				return err
+			}
+			return nil
+		}
+		recordDLQ := func(pit PlaidInvestmentTransaction, code string, cause error) error {
+			row := &model.PlaidSyncError{
+				UserID:             userID,
+				PlaidItemID:        item.ID,
+				PlaidTransactionID: strPtr(pit.PlaidTransactionID),
+				RawPayload:         []byte(`{}`),
+				ErrorCode:          code,
+				ErrorMessage:       capErrorMessage(cause.Error()),
+				OccurredAt:         time.Now().UTC(),
+			}
+			if err := syncErrRepo.Create(ctx, row); err != nil {
+				return fmt.Errorf("plaid: write DLQ row: %w", err)
+			}
+			result.Failed++
+			return nil
+		}
+
+		for _, pit := range fetched.Transactions {
+			perRowErr := withSavepoint(func() error {
+				ref, err := resolveAccount(ctx, acctRepo, userID, pit.PlaidAccountID, accountIDCache)
+				if err != nil {
+					return err
+				}
+				var securityAssetID int64
+				if pit.PlaidSecurityID != nil {
+					if id, ok := assetBySecurity[*pit.PlaidSecurityID]; ok {
+						securityAssetID = id
+					}
+				}
+				plan, err := MapInvestmentTransaction(pit, userID, ref.ID, ref.AssetID, securityAssetID)
+				if err != nil {
+					return err
+				}
+				switch plan.Action {
+				case ActionIgnore:
+					result.Skipped++
+				case ActionPair:
+					if err := txRepo.CreateTradePair(ctx, plan.Security, plan.Cash); err != nil {
+						return err
+					}
+					result.PairedInserted++
+					touched[touchedKey{ref.ID, plan.Security.AssetID}] = struct{}{}
+				case ActionSingleCash:
+					if _, err := txRepo.CreateBatch(ctx, []model.Transaction{*plan.Cash}); err != nil {
+						return err
+					}
+					result.CashInserted++
+				case ActionCancel:
+					// Soft-delete the original row and (if it was paired)
+					// its partner. Locate by plaid_transaction_id; the
+					// pair-extension we wrote was "<orig>:cash".
+					orig, err := lookupByPlaidTxnID(ctx, tx, userID, plan.CancelPlaidTransactionID)
+					if err != nil {
+						return err
+					}
+					if orig != nil {
+						if orig.TransferPairID != nil {
+							if err := tx.WithContext(ctx).Where("user_id = ?", userID).
+								Delete(&model.Transaction{}, *orig.TransferPairID).Error; err != nil {
+								return err
+							}
+						}
+						if err := tx.WithContext(ctx).Where("user_id = ?", userID).
+							Delete(&model.Transaction{}, orig.ID).Error; err != nil {
+							return err
+						}
+						result.Cancelled++
+						if orig.AssetID != ref.AssetID {
+							touched[touchedKey{orig.AccountID, orig.AssetID}] = struct{}{}
+						}
+					}
+				}
+				return nil
+			})
+			if perRowErr != nil {
+				if err := recordDLQ(pit, model.PlaidSyncErrorCodeMapping, perRowErr); err != nil {
+					return err
+				}
+			}
+		}
+
+		// Recompute positions + cost basis for every touched (account,
+		// asset) pair, then rebase each account's cash sleeve once. Same
+		// canonical recompute the manual-trade flow uses; we don't trust
+		// deltas.
+		user, err := repository.NewUserRepository(tx).GetByID(ctx, userID)
+		if err != nil {
+			return fmt.Errorf("plaid: load user: %w", err)
+		}
+		priceRepo := repository.NewPriceRepository(tx)
+		cashTouched := map[int64]int64{} // accountID → cash asset id
+		for key := range touched {
+			res, err := valuation.Recompute(ctx, txRepo, priceRepo, userID, key.accountID, key.assetID, user.PrimaryCurrencyAssetID)
+			if err != nil {
+				if errors.Is(err, valuation.ErrFXUnavailable) {
+					log.Printf("plaid: cost basis FX unavailable for (acct=%d asset=%d): %v", key.accountID, key.assetID, err)
+				} else {
+					return fmt.Errorf("recompute position: %w", err)
+				}
+			}
+			pos := &model.Position{
+				UserID:    userID,
+				AccountID: key.accountID,
+				AssetID:   key.assetID,
+				Quantity:  res.Quantity,
+			}
+			if res.HasCostBasis {
+				cb := res.CostBasis
+				pos.CostBasis = &cb
+			}
+			if err := posRepo.Upsert(ctx, pos); err != nil {
+				return fmt.Errorf("upsert position: %w", err)
+			}
+			// Note the account's cash asset so we rebase it below.
+			if _, ok := cashTouched[key.accountID]; !ok {
+				acct, err := acctRepo.GetByID(ctx, userID, key.accountID)
+				if err != nil {
+					return fmt.Errorf("load account for cash rebase: %w", err)
+				}
+				cashTouched[key.accountID] = acct.PrimaryQuoteAssetID
+			}
+		}
+		// Cash sleeve rebase per touched account.
+		for accountID, cashAssetID := range cashTouched {
+			res, err := valuation.Recompute(ctx, txRepo, priceRepo, userID, accountID, cashAssetID, user.PrimaryCurrencyAssetID)
+			if err != nil {
+				return fmt.Errorf("recompute cash: %w", err)
+			}
+			pos := &model.Position{
+				UserID:    userID,
+				AccountID: accountID,
+				AssetID:   cashAssetID,
+				Quantity:  res.Quantity,
+			}
+			if err := posRepo.Upsert(ctx, pos); err != nil {
+				return fmt.Errorf("upsert cash position: %w", err)
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return SyncInvestmentTransactionsResult{}, err
+	}
+	return result, nil
+}
+
+// lookupByPlaidTxnID fetches a transaction by user_id + plaid_transaction_id
+// — used by the cancel path to find the row to soft-delete. Returns
+// (nil, nil) when no row exists (idempotent cancel).
+func lookupByPlaidTxnID(ctx context.Context, tx *gorm.DB, userID int64, plaidTxnID string) (*model.Transaction, error) {
+	var t model.Transaction
+	err := tx.WithContext(ctx).
+		Where("user_id = ? AND plaid_transaction_id = ?", userID, plaidTxnID).
+		First(&t).Error
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return &t, nil
+}
+
+// SyncHoldings pulls /investments/holdings/get and reconciles each
+// (account × security) snapshot row against our derived positions:
+//   - quantity differs → adjust the position row (Plaid wins).
+//   - cost_basis present and ours is null → adopt Plaid's value.
+//   - institution_price → write a price observation tagged source='plaid'.
+//
+// Per ADR-0013 §3, snapshot disagreements DO NOT spawn synthetic
+// transactions. The function emits a log warning on every adjustment
+// so an operator review can spot drift.
+func (s *Service) SyncHoldings(ctx context.Context, userID int64, plaidItemID string) (HoldingsReconcileResult, error) {
+	if !s.Configured() || s.acctRepo == nil || s.assetRepo == nil || s.positionRepo == nil || s.db == nil {
+		return HoldingsReconcileResult{}, ErrNotConfigured
+	}
+	item, err := s.itemRepo.GetByPlaidItemID(ctx, userID, plaidItemID)
+	if err != nil {
+		if errors.Is(err, repository.ErrNotFound) {
+			return HoldingsReconcileResult{}, ErrItemNotFound
+		}
+		return HoldingsReconcileResult{}, fmt.Errorf("plaid: lookup item: %w", err)
+	}
+	tokenBytes, err := s.box.Decrypt(item.AccessTokenEnc)
+	if err != nil {
+		return HoldingsReconcileResult{}, fmt.Errorf("plaid: decrypt access_token: %w", err)
+	}
+	defer zeroBytes(tokenBytes)
+
+	snapshot, err := s.client.FetchHoldings(ctx, string(tokenBytes))
+	if err != nil {
+		return HoldingsReconcileResult{}, err
+	}
+
+	// Resolve securities to assets outside the DB transaction.
+	assetBySecurity := map[string]int64{}
+	assetCurrency := map[string]string{}
+	for _, sec := range snapshot.Securities {
+		symbol := SecuritySymbol(sec)
+		if symbol == "" {
+			continue
+		}
+		kind := SecurityKind(sec.Type, sec.IsCashEquivalent)
+		display := sec.Name
+		if display == "" {
+			display = symbol
+		}
+		asset, err := s.assetRepo.EnsureBySymbolKind(ctx, symbol, kind, display)
+		if err != nil {
+			return HoldingsReconcileResult{}, fmt.Errorf("plaid: ensure asset %s: %w", symbol, err)
+		}
+		assetBySecurity[sec.PlaidSecurityID] = asset.ID
+		assetCurrency[sec.PlaidSecurityID] = sec.IsoCurrencyCode
+	}
+
+	result := HoldingsReconcileResult{Holdings: len(snapshot.Holdings)}
+	accountIDCache := map[string]accountRef{}
+
+	err = s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		acctRepo := repository.NewAccountRepository(tx)
+		posRepo := repository.NewPositionRepository(tx)
+		priceRepo := repository.NewPriceRepository(tx)
+
+		for _, h := range snapshot.Holdings {
+			ref, err := resolveAccount(ctx, acctRepo, userID, h.PlaidAccountID, accountIDCache)
+			if err != nil {
+				// No local account — caller should have run sync-accounts.
+				return fmt.Errorf("plaid: holdings: %w", err)
+			}
+			assetID, ok := assetBySecurity[h.PlaidSecurityID]
+			if !ok {
+				continue
+			}
+
+			// Compare with what's there now. Re-derive via Recompute
+			// only on disagreement; if Plaid agrees with our position
+			// row we skip the recompute.
+			existing, err := findLivePosition(ctx, tx, userID, ref.ID, assetID)
+			if err != nil {
+				return err
+			}
+			derivedQty := decimal.Zero
+			if existing != nil {
+				derivedQty = existing.Quantity
+			}
+			if !derivedQty.Equal(h.Quantity) {
+				log.Printf("plaid: holdings reconcile drift (acct=%d asset=%d derived=%s plaid=%s) — adopting Plaid; no synthetic txns",
+					ref.ID, assetID, derivedQty.String(), h.Quantity.String())
+				result.PositionsAdjusted++
+			}
+			pos := &model.Position{
+				UserID:    userID,
+				AccountID: ref.ID,
+				AssetID:   assetID,
+				Quantity:  h.Quantity,
+			}
+			if !h.CostBasis.IsZero() {
+				cb := h.CostBasis
+				pos.CostBasis = &cb
+			} else if existing != nil && existing.CostBasis != nil {
+				cb := *existing.CostBasis
+				pos.CostBasis = &cb
+			}
+			if err := posRepo.Upsert(ctx, pos); err != nil {
+				return fmt.Errorf("upsert position: %w", err)
+			}
+
+			// Persist a Plaid-fed price observation when present. Use
+			// the holding's currency (security's IsoCurrencyCode) as
+			// the quote asset; resolves via the account's fiat asset
+			// when matching.
+			if !h.InstitutionPrice.IsZero() {
+				currency := assetCurrency[h.PlaidSecurityID]
+				if currency == "" {
+					currency = "USD"
+				}
+				quoteAsset, err := s.assetRepo.EnsureBySymbolKind(ctx, currency, model.AssetKindFiat, currency)
+				if err != nil {
+					return fmt.Errorf("plaid: ensure quote asset %s: %w", currency, err)
+				}
+				if err := priceRepo.Insert(ctx, &model.Price{
+					AssetID:      assetID,
+					QuoteAssetID: quoteAsset.ID,
+					AsOf:         time.Now().UTC(),
+					Price:        h.InstitutionPrice,
+					Source:       "plaid",
+				}); err != nil {
+					return fmt.Errorf("insert price: %w", err)
+				}
+				result.PricesObserved++
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return HoldingsReconcileResult{}, err
+	}
+	return result, nil
+}
+
+// findLivePosition returns the position row for (user, account, asset)
+// or nil when none exists. Used by reconciliation to detect first-
+// encounter holdings (no existing row → no drift to log).
+func findLivePosition(ctx context.Context, tx *gorm.DB, userID, accountID, assetID int64) (*model.Position, error) {
+	var p model.Position
+	err := tx.WithContext(ctx).
+		Where("user_id = ? AND account_id = ? AND asset_id = ?", userID, accountID, assetID).
+		First(&p).Error
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return &p, nil
+}


### PR DESCRIPTION
## Summary

Brokerage-data half of #238. Lands the Plaid investment-transactions
ingestion path and the holdings-snapshot reconciliation loop. The
remaining acceptance criterion (FE trade form + collapsed paired-row
rendering on the transaction list) ships as part 3.

- **Client**: \`FetchInvestmentTransactions\` paginates
  \`/investments/transactions/get\` over a date window; \`FetchHoldings\`
  wraps \`/investments/holdings/get\`. Slim domain structs
  (\`PlaidInvestmentTransaction\`, \`PlaidHolding\`, \`PlaidSecurity\`) keep
  the SDK out of the service layer.
- **Pure mapper** (\`MapInvestmentTransaction\`): \`buy\` / \`sell\` → paired
  rows via \`CreateTradePair\`; \`cash\` / \`fee\` / \`transfer\` → single
  cash leg; \`cancel\` → soft-delete prior rows; unknown type →
  \`ActionIgnore\` so future Plaid enum rollouts don't poison sync.
- **\`Service.SyncInvestmentTransactions\`**: two-phase drain (fetch all →
  one DB txn with per-row \`SAVEPOINT\` + DLQ); resolves securities via
  \`assetRepo.EnsureBySymbolKind\`; recomputes positions + cost basis
  per touched (account, asset) and rebases the cash sleeve per
  touched account.
- **\`Service.SyncHoldings\`** — reconciliation: compares Plaid snapshot
  to derived positions. Mismatch → adjust the position to Plaid's
  number and log a warning. **Never** synthesizes a transaction to
  bridge the gap (ADR-0013 §3). Writes a Plaid-fed price observation
  alongside each holding.
- **Routes**: \`POST /api/v1/plaid/items/:item_id/sync-investment-transactions\`
  and \`POST /api/v1/plaid/items/:item_id/sync-holdings\`.

## Test plan

- [x] \`command make verify\`
- [x] Mapper: buy → pair (+10/-1500); sell → inverse pair (-5/+800);
      cash/dividend → single cash leg (+25, no security leg); cancel →
      ActionCancel with target id; unknown type → ActionIgnore;
      buy with no resolvable security → error.
- [x] Reconciliation integration test: Plaid snapshot quantity (8)
      disagrees with seeded position (10) → position adjusts to 8,
      price observation written, **zero** synthetic transactions
      inserted (ADR-0013 §3 invariant).

## Deferred to part 3

Frontend \"Record a trade\" form and collapsed paired-row rendering on
the transaction list — the last remaining acceptance criterion of #238.

🤖 Generated with [Claude Code](https://claude.com/claude-code)