### PR TITLE
M10b part 3: trade UI (manual record + paired-row rendering)

### DIFF
--- a/backend/internal/handler/asset_handler.go
+++ b/backend/internal/handler/asset_handler.go
@@ -1,0 +1,100 @@
+package handler
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/gregwym/offbook/backend/internal/model"
+	"github.com/gregwym/offbook/backend/internal/repository"
+)
+
+// AssetHandler exposes the global assets reference table to authenticated
+// users. Assets are not user-scoped — symbols like AAPL/USD/BTC are shared
+// across the instance — but the routes still live under /api/v1 so they
+// require a session. The trade form uses these endpoints to resolve an
+// asset_id for the request payload.
+type AssetHandler struct {
+	repo repository.AssetRepository
+}
+
+func NewAssetHandler(repo repository.AssetRepository) *AssetHandler {
+	return &AssetHandler{repo: repo}
+}
+
+func (h *AssetHandler) Register(g *gin.RouterGroup) {
+	g.GET("/assets", h.List)
+	g.POST("/assets/ensure", h.Ensure)
+}
+
+// validAssetKinds mirrors the enum in migration 000018 and the
+// model.AssetKind* constants.
+var validAssetKinds = map[string]struct{}{
+	model.AssetKindFiat:      {},
+	model.AssetKindEquity:    {},
+	model.AssetKindFund:      {},
+	model.AssetKindCrypto:    {},
+	model.AssetKindBond:      {},
+	model.AssetKindCommodity: {},
+	model.AssetKindOther:     {},
+}
+
+func (h *AssetHandler) List(c *gin.Context) {
+	kind := strings.TrimSpace(c.Query("kind"))
+	var (
+		assets []model.Asset
+		err    error
+	)
+	if kind == "" {
+		assets, err = h.repo.List(c.Request.Context())
+	} else {
+		if _, ok := validAssetKinds[kind]; !ok {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid kind", "code": "INVALID_REQUEST"})
+			return
+		}
+		assets, err = h.repo.ListByKind(c.Request.Context(), kind)
+	}
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error(), "code": "INTERNAL"})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"data": assets, "total": int64(len(assets))})
+}
+
+type ensureAssetRequest struct {
+	Symbol      string `json:"symbol"`
+	Kind        string `json:"kind"`
+	DisplayName string `json:"display_name"`
+}
+
+// Ensure is the find-or-create path the trade form uses when the user
+// enters a previously-unseen ticker. It is idempotent: repeated calls with
+// the same (symbol, kind) return the existing row.
+func (h *AssetHandler) Ensure(c *gin.Context) {
+	var req ensureAssetRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error(), "code": "INVALID_REQUEST"})
+		return
+	}
+	symbol := strings.ToUpper(strings.TrimSpace(req.Symbol))
+	if symbol == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "symbol is required", "code": "INVALID_REQUEST"})
+		return
+	}
+	kind := strings.TrimSpace(req.Kind)
+	if _, ok := validAssetKinds[kind]; !ok {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "kind is required and must be a known asset kind", "code": "INVALID_REQUEST"})
+		return
+	}
+	displayName := strings.TrimSpace(req.DisplayName)
+	if displayName == "" {
+		displayName = symbol
+	}
+	a, err := h.repo.EnsureBySymbolKind(c.Request.Context(), symbol, kind, displayName)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error(), "code": "INTERNAL"})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"data": a})
+}

--- a/backend/internal/repository/asset_repo.go
+++ b/backend/internal/repository/asset_repo.go
@@ -16,6 +16,9 @@ type AssetRepository interface {
 	GetByID(ctx context.Context, id int64) (*model.Asset, error)
 	GetBySymbolKind(ctx context.Context, symbol, kind string) (*model.Asset, error)
 	ListByKind(ctx context.Context, kind string) ([]model.Asset, error)
+	// List returns every asset ordered by symbol. Used by the trade-form
+	// asset picker; small reference table so no pagination yet.
+	List(ctx context.Context) ([]model.Asset, error)
 	// EnsureBySymbolKind returns the asset for (symbol, kind), creating it
 	// with the supplied displayName if absent. Used by Plaid sync and
 	// manual entry when a previously-unseen ticker shows up.
@@ -52,6 +55,16 @@ func (r *assetRepo) GetBySymbolKind(ctx context.Context, symbol, kind string) (*
 		return nil, err
 	}
 	return &a, nil
+}
+
+func (r *assetRepo) List(ctx context.Context) ([]model.Asset, error) {
+	var rows []model.Asset
+	if err := r.db.WithContext(ctx).
+		Order("kind, symbol").
+		Find(&rows).Error; err != nil {
+		return nil, err
+	}
+	return rows, nil
 }
 
 func (r *assetRepo) ListByKind(ctx context.Context, kind string) ([]model.Asset, error) {

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -56,6 +56,7 @@ func New(cfg config.Config, gormDB *gorm.DB) *gin.Engine {
 	priceRepo := repository.NewPriceRepository(gormDB)
 	tradeSvc := service.NewTradeService(gormDB, accountRepo, assetRepo, transactionRepo, positionRepo, priceRepo, userRepo)
 	tradeHandler := handler.NewTradeHandler(tradeSvc)
+	assetHandler := handler.NewAssetHandler(assetRepo)
 
 	categorySvc := service.NewCategoryService(categoryRepo)
 	categoryHandler := handler.NewCategoryHandler(categorySvc)
@@ -156,6 +157,7 @@ func New(cfg config.Config, gormDB *gorm.DB) *gin.Engine {
 		piiHandler.RegisterAccountRoutes(secured)
 		transactionHandler.Register(secured)
 		tradeHandler.Register(secured)
+		assetHandler.Register(secured)
 		categoryHandler.Register(secured)
 		ruleHandler.Register(secured)
 		dashboardHandler.Register(secured)

--- a/frontend/src/api/assets.ts
+++ b/frontend/src/api/assets.ts
@@ -1,0 +1,14 @@
+import { apiClient, type ApiItem, type ApiList } from './client'
+import type { Asset, AssetKind, EnsureAssetInput } from '../types/asset'
+
+export async function listAssets(kind?: AssetKind): Promise<Asset[]> {
+  const params: Record<string, string> = {}
+  if (kind) params.kind = kind
+  const res = await apiClient.get<ApiList<Asset>>('/assets', { params })
+  return res.data.data
+}
+
+export async function ensureAsset(input: EnsureAssetInput): Promise<Asset> {
+  const res = await apiClient.post<ApiItem<Asset>>('/assets/ensure', input)
+  return res.data.data
+}

--- a/frontend/src/api/trades.ts
+++ b/frontend/src/api/trades.ts
@@ -1,0 +1,13 @@
+import { apiClient, type ApiItem } from './client'
+import type { RecordTradeInput, TradeRecord } from '../types/trade'
+
+export async function recordTrade(
+  accountID: number,
+  input: RecordTradeInput,
+): Promise<TradeRecord> {
+  const res = await apiClient.post<ApiItem<TradeRecord>>(
+    `/accounts/${accountID}/trades`,
+    input,
+  )
+  return res.data.data
+}

--- a/frontend/src/components/TradeFormModal.tsx
+++ b/frontend/src/components/TradeFormModal.tsx
@@ -1,0 +1,229 @@
+// TradeFormModal records a paired-row trade against a single brokerage
+// account. Backend (POST /accounts/:id/trades — service.TradeService)
+// validates the rest: the account must be brokerage-type, the asset
+// cannot equal the account's cash sleeve, sells cannot exceed holdings.
+//
+// Asset resolution is symbol+kind based: the user picks from the known
+// list or types a new ticker — on submit we ensure (find-or-create) the
+// asset and feed the id to the trade endpoint. Fiat assets are filtered
+// out of the picker; the cash leg's asset is derived from the account.
+import { useEffect, useMemo, useState, type ReactNode } from 'react'
+import { recordTrade } from '../api/trades'
+import { useAssetsStore } from '../store/assetsStore'
+import type { Account } from '../types/account'
+import type { Asset, AssetKind } from '../types/asset'
+import type { TradeKind } from '../types/trade'
+
+type Props = {
+  account: Account
+  onClose: () => void
+  // Fires after a successful record so the host page can refetch its data.
+  onRecorded?: () => void
+}
+
+const TRADEABLE_KINDS: AssetKind[] = ['equity', 'fund', 'crypto', 'bond', 'commodity', 'other']
+
+export function TradeFormModal({ account, onClose, onRecorded }: Props) {
+  const { assets, loaded, fetch, ensure } = useAssetsStore()
+  const [kind, setKind] = useState<TradeKind>('buy')
+  const [symbol, setSymbol] = useState('')
+  const [assetKind, setAssetKind] = useState<AssetKind>('equity')
+  const [quantity, setQuantity] = useState('')
+  const [price, setPrice] = useState('')
+  const [tradeDate, setTradeDate] = useState(todayISO())
+  const [notes, setNotes] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    void fetch()
+  }, [fetch])
+
+  const tradeableAssets = useMemo(
+    () => assets.filter((a) => TRADEABLE_KINDS.includes(a.kind)),
+    [assets],
+  )
+
+  // Whenever the user picks/types a symbol, if it matches exactly one
+  // known asset, snap the kind dropdown to that asset's kind. Done in
+  // the change handler (not an effect) so we don't trigger cascading
+  // renders.
+  const handleSymbolChange = (next: string) => {
+    const up = next.toUpperCase()
+    setSymbol(up)
+    const sym = up.trim()
+    if (!sym) return
+    const matches = tradeableAssets.filter((a) => a.symbol === sym)
+    if (matches.length === 1) {
+      setAssetKind(matches[0].kind)
+    }
+  }
+
+  const submit = async () => {
+    setError(null)
+    const sym = symbol.trim().toUpperCase()
+    if (!sym) {
+      setError('Asset is required.')
+      return
+    }
+    if (!quantity.trim()) {
+      setError('Quantity is required.')
+      return
+    }
+    if (!price.trim()) {
+      setError('Price is required.')
+      return
+    }
+    if (!tradeDate) {
+      setError('Trade date is required.')
+      return
+    }
+    setSubmitting(true)
+    try {
+      // Find existing first to avoid hammering ensure for known assets.
+      let asset: Asset | undefined = tradeableAssets.find(
+        (a) => a.symbol === sym && a.kind === assetKind,
+      )
+      if (!asset) {
+        asset = await ensure({ symbol: sym, kind: assetKind })
+      }
+      await recordTrade(account.id, {
+        kind,
+        asset_id: asset.id,
+        quantity: quantity.trim(),
+        price: price.trim(),
+        trade_date: tradeDate,
+        notes: notes.trim() === '' ? null : notes.trim(),
+      })
+      onRecorded?.()
+      onClose()
+    } catch (err) {
+      setError(extractErr(err))
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-20 flex items-center justify-center bg-black/40 p-4">
+      <div className="w-full max-w-lg rounded-lg bg-white shadow-xl">
+        <div className="border-b border-gray-200 px-5 py-3 text-lg font-semibold text-gray-900">
+          Record trade — {account.name}
+        </div>
+        <div className="space-y-3 px-5 py-4">
+          {error && (
+            <div className="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
+              {error}
+            </div>
+          )}
+          <Field label="Side">
+            <div className="flex gap-3 text-sm">
+              <label className="inline-flex items-center gap-1.5">
+                <input type="radio" name="trade-kind" value="buy" checked={kind === 'buy'} onChange={() => setKind('buy')} />
+                Buy
+              </label>
+              <label className="inline-flex items-center gap-1.5">
+                <input type="radio" name="trade-kind" value="sell" checked={kind === 'sell'} onChange={() => setKind('sell')} />
+                Sell
+              </label>
+            </div>
+          </Field>
+          <div className="grid grid-cols-2 gap-3">
+            <Field label="Symbol">
+              <input
+                className={inputClass}
+                value={symbol}
+                onChange={(e) => handleSymbolChange(e.target.value)}
+                placeholder="AAPL"
+                list="trade-asset-symbols"
+                autoComplete="off"
+              />
+              <datalist id="trade-asset-symbols">
+                {tradeableAssets.map((a) => (
+                  <option key={a.id} value={a.symbol}>
+                    {a.display_name ? `${a.display_name} · ${a.kind}` : a.kind}
+                  </option>
+                ))}
+              </datalist>
+              {!loaded && <p className="mt-1 text-[11px] text-gray-400">Loading known assets…</p>}
+            </Field>
+            <Field label="Kind">
+              <select className={inputClass} value={assetKind} onChange={(e) => setAssetKind(e.target.value as AssetKind)}>
+                {TRADEABLE_KINDS.map((k) => (
+                  <option key={k} value={k}>{k}</option>
+                ))}
+              </select>
+            </Field>
+          </div>
+          <div className="grid grid-cols-2 gap-3">
+            <Field label="Quantity">
+              <input
+                className={inputClass}
+                value={quantity}
+                onChange={(e) => setQuantity(e.target.value)}
+                inputMode="decimal"
+                placeholder="10"
+              />
+            </Field>
+            <Field label={`Price per unit (${account.currency})`}>
+              <input
+                className={inputClass}
+                value={price}
+                onChange={(e) => setPrice(e.target.value)}
+                inputMode="decimal"
+                placeholder="182.00"
+              />
+            </Field>
+          </div>
+          <Field label="Trade date">
+            <input type="date" className={inputClass} value={tradeDate} onChange={(e) => setTradeDate(e.target.value)} />
+          </Field>
+          <Field label="Notes (optional)">
+            <input className={inputClass} value={notes} onChange={(e) => setNotes(e.target.value)} />
+          </Field>
+        </div>
+        <div className="flex justify-end gap-2 border-t border-gray-200 px-5 py-3">
+          <button type="button" onClick={onClose} className="rounded-md border border-gray-300 px-3 py-1.5 text-sm">
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={submit}
+            disabled={submitting}
+            className="rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-indigo-700 disabled:opacity-50"
+          >
+            {submitting ? 'Recording…' : 'Record trade'}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+const inputClass = 'w-full rounded border border-gray-300 px-2 py-1 text-sm'
+
+function Field({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <label className="block text-sm">
+      <span className="mb-1 block text-xs font-medium text-gray-600">{label}</span>
+      {children}
+    </label>
+  )
+}
+
+function todayISO(): string {
+  const d = new Date()
+  const y = d.getFullYear()
+  const m = String(d.getMonth() + 1).padStart(2, '0')
+  const dd = String(d.getDate()).padStart(2, '0')
+  return `${y}-${m}-${dd}`
+}
+
+function extractErr(err: unknown): string {
+  if (err && typeof err === 'object' && 'response' in err) {
+    const r = (err as { response?: { data?: { error?: string } } }).response
+    if (r?.data?.error) return r.data.error
+  }
+  if (err instanceof Error) return err.message
+  return 'request failed'
+}

--- a/frontend/src/pages/AccountsPage.tsx
+++ b/frontend/src/pages/AccountsPage.tsx
@@ -1,9 +1,10 @@
 import { useEffect, useState, type ReactNode } from 'react'
-import { Pencil, Plus, Trash2 } from 'lucide-react'
+import { LineChart, Pencil, Plus, Trash2 } from 'lucide-react'
 import { AccountVisibilityChip } from '../components/AccountVisibilityChip'
 import { AmountDisplay } from '../components/AmountDisplay'
 import { PIIPanel } from '../components/PIIPanel'
 import { SyncStatusPill } from '../components/SyncStatusPill'
+import { TradeFormModal } from '../components/TradeFormModal'
 import { useAccountsStore } from '../store/accountsStore'
 import { useScopeStore } from '../store/scopeStore'
 import {
@@ -23,6 +24,9 @@ export function AccountsPage() {
   const householdId = useScopeStore((s) => s.householdId)
   const [adding, setAdding] = useState(false)
   const [editing, setEditing] = useState<Account | null>(null)
+  // Trade-entry surface — only available for brokerage-style accounts
+  // (matches backend brokerageAccountTypes in service/trade_service.go).
+  const [tradingOn, setTradingOn] = useState<Account | null>(null)
 
   useEffect(() => {
     void fetch()
@@ -95,6 +99,17 @@ export function AccountsPage() {
                   </td>
                 )}
                 <td className="px-4 py-2 text-right">
+                  {isBrokerage(a) && (
+                    <button
+                      type="button"
+                      onClick={() => setTradingOn(a)}
+                      className="mr-2 text-gray-500 hover:text-indigo-700"
+                      aria-label="Record trade"
+                      title="Record trade"
+                    >
+                      <LineChart size={16} />
+                    </button>
+                  )}
                   <button
                     type="button"
                     onClick={() => setEditing(a)}
@@ -144,8 +159,26 @@ export function AccountsPage() {
           }}
         />
       )}
+
+      {tradingOn && (
+        <TradeFormModal
+          account={tradingOn}
+          onClose={() => setTradingOn(null)}
+          onRecorded={() => {
+            // Account balance is derived from positions × prices, so the
+            // accounts list refresh picks up the post-trade value.
+            void fetch()
+          }}
+        />
+      )}
     </div>
   )
+}
+
+// isBrokerage mirrors backend service.brokerageAccountTypes — only these
+// account shapes accept trades.
+function isBrokerage(a: Account): boolean {
+  return a.account_type === 'investment' || a.account_type === 'crypto'
 }
 
 type FormProps = {

--- a/frontend/src/pages/TransactionsPage.tsx
+++ b/frontend/src/pages/TransactionsPage.tsx
@@ -1,15 +1,17 @@
 import { useEffect, useMemo, useState, type ReactNode } from 'react'
-import { Plus, Sparkles, Trash2 } from 'lucide-react'
+import { ChevronDown, ChevronRight, Plus, Sparkles, Trash2 } from 'lucide-react'
 import { Link } from 'react-router-dom'
 import { AmountDisplay } from '../components/AmountDisplay'
 import { DateDisplay } from '../components/DateDisplay'
 import { RuleFormModal, type RuleFormDefaults } from '../components/RuleFormModal'
 import { useAccountsStore } from '../store/accountsStore'
+import { useAssetsStore } from '../store/assetsStore'
 import { useCategoriesStore } from '../store/categoriesStore'
 import { useRulesStore } from '../store/rulesStore'
 import { useTransactionsStore } from '../store/transactionsStore'
 import { useDebounce } from '../hooks/useDebounce'
 import type { Account } from '../types/account'
+import type { Asset } from '../types/asset'
 import type { Category } from '../types/category'
 import type { CreateRuleInput } from '../types/categorizationRule'
 import type { CreateTransactionInput, Transaction, TransactionSource } from '../types/transaction'
@@ -22,6 +24,7 @@ export function TransactionsPage() {
     fetch, setFilter, setPage, create, setCategory, remove,
   } = useTransactionsStore()
   const { accounts, fetch: fetchAccounts } = useAccountsStore()
+  const { assets, fetch: fetchAssets } = useAssetsStore()
   const { categories, fetch: fetchCategories } = useCategoriesStore()
   const {
     rules,
@@ -48,10 +51,11 @@ export function TransactionsPage() {
 
   useEffect(() => {
     void fetchAccounts()
+    void fetchAssets()
     void fetchCategories()
     void fetchRules()
     void fetch()
-  }, [fetch, fetchAccounts, fetchCategories, fetchRules])
+  }, [fetch, fetchAccounts, fetchAssets, fetchCategories, fetchRules])
 
   // Same priority heuristic as RulesPage — new rules outrank existing ones
   // by default so the "create from this txn" shortcut wins immediately on
@@ -89,7 +93,28 @@ export function TransactionsPage() {
 
   const totalPages = Math.max(1, Math.ceil(total / pageSize))
   const accountByID = useMemo(() => mapByID(accounts), [accounts])
+  const assetByID = useMemo(() => mapByID(assets), [assets])
   const categoryByID = useMemo(() => mapByID(categories), [categories])
+  const transactionByID = useMemo(() => mapByID(transactions), [transactions])
+  // partnerSkip: ids that render inside a paired-trade row (so we don't
+  // also render them as a stand-alone row). Pairing is detected when two
+  // visible legs reference each other via transfer_pair_id AND share an
+  // account_id — cross-account transfers stay as two separate rows.
+  // The lower id is treated as the primary leg.
+  const partnerSkip = useMemo(() => {
+    const skip = new Set<number>()
+    for (const t of transactions) {
+      const partnerID = t.transfer_pair_id ?? null
+      if (partnerID == null) continue
+      const partner = transactionByID.get(partnerID)
+      if (!partner) continue
+      if (partner.account_id !== t.account_id) continue
+      // Skip the higher-id leg; render the lower-id leg as primary.
+      const higher = t.id > partner.id ? t.id : partner.id
+      skip.add(higher)
+    }
+    return skip
+  }, [transactions, transactionByID])
 
   return (
     <div>
@@ -156,22 +181,51 @@ export function TransactionsPage() {
             {!loading && transactions.length === 0 && (
               <tr><td colSpan={7} className="px-4 py-6 text-center text-gray-400">No transactions match these filters.</td></tr>
             )}
-            {transactions.map((t) => (
-              <TransactionRow
-                key={t.id}
-                tx={t}
-                account={t.account_id ? accountByID.get(t.account_id) : undefined}
-                categories={categories}
-                currentCategory={t.category_id ? categoryByID.get(t.category_id) : undefined}
-                onCategoryChange={(catID) => { void setCategory(t.id, catID) }}
-                onCreateRule={() => openRuleFromTxn(t)}
-                onDelete={async () => {
-                  if (window.confirm('Delete this transaction?')) {
-                    await remove(t.id)
-                  }
-                }}
-              />
-            ))}
+            {transactions.map((t) => {
+              if (partnerSkip.has(t.id)) return null
+              const partnerID = t.transfer_pair_id ?? null
+              const partner = partnerID != null ? transactionByID.get(partnerID) : undefined
+              const account = t.account_id ? accountByID.get(t.account_id) : undefined
+              if (partner && partner.account_id === t.account_id) {
+                // Both legs visible AND same account → collapse into a
+                // single trade row, expandable to show both legs.
+                return (
+                  <PairedTradeRow
+                    key={t.id}
+                    legA={t}
+                    legB={partner}
+                    account={account}
+                    assetByID={assetByID}
+                    categories={categories}
+                    categoryByID={categoryByID}
+                    onCategoryChange={(legID, catID) => { void setCategory(legID, catID) }}
+                    onCreateRule={openRuleFromTxn}
+                    onDelete={async (legID) => {
+                      if (window.confirm('Delete this trade leg?')) {
+                        await remove(legID)
+                      }
+                    }}
+                  />
+                )
+              }
+              return (
+                <TransactionRow
+                  key={t.id}
+                  tx={t}
+                  account={account}
+                  asset={assetByID.get(t.asset_id)}
+                  categories={categories}
+                  currentCategory={t.category_id ? categoryByID.get(t.category_id) : undefined}
+                  onCategoryChange={(catID) => { void setCategory(t.id, catID) }}
+                  onCreateRule={() => openRuleFromTxn(t)}
+                  onDelete={async () => {
+                    if (window.confirm('Delete this transaction?')) {
+                      await remove(t.id)
+                    }
+                  }}
+                />
+              )
+            })}
           </tbody>
         </table>
       </div>
@@ -271,21 +325,29 @@ export function TransactionsPage() {
 type RowProps = {
   tx: Transaction
   account?: Account
+  asset?: Asset
   categories: Category[]
   currentCategory?: Category
   onCategoryChange: (catID: number | null) => void
   onCreateRule: () => void
   onDelete: () => Promise<void>
+  // Optional indent for rows rendered as legs of an expanded paired
+  // trade. Keeps the visual hierarchy clear.
+  indented?: boolean
 }
 
-function TransactionRow({ tx, account, categories, currentCategory, onCategoryChange, onCreateRule, onDelete }: RowProps) {
+function TransactionRow({ tx, account, asset, categories, currentCategory, onCategoryChange, onCreateRule, onDelete, indented }: RowProps) {
+  // Per ADR-0013, the unit on a transaction is asset_id. Display currency
+  // = asset.symbol when available; fall back to the parent account's
+  // currency for older rows that haven't been backfilled.
+  const currency = asset?.symbol ?? account?.currency ?? 'USD'
   return (
     <tr className="hover:bg-gray-50">
-      <td className="px-3 py-2 text-gray-700"><DateDisplay value={tx.transaction_date} /></td>
+      <td className={`px-3 py-2 text-gray-700 ${indented ? 'pl-8' : ''}`}><DateDisplay value={tx.transaction_date} /></td>
       <td className="px-3 py-2 text-gray-900">{tx.description ?? '—'}</td>
       <td className="px-3 py-2 text-gray-700">{tx.merchant_name ?? '—'}</td>
       <td className="px-3 py-2 text-right">
-        <AmountDisplay amount={tx.amount} currency={tx.currency} signed />
+        <AmountDisplay amount={tx.amount} currency={currency} signed />
       </td>
       <td className="px-3 py-2 text-gray-700">{account?.name ?? `#${tx.account_id}`}</td>
       <td className="px-3 py-2">
@@ -324,6 +386,124 @@ function TransactionRow({ tx, account, categories, currentCategory, onCategoryCh
   )
 }
 
+type PairedTradeRowProps = {
+  legA: Transaction
+  legB: Transaction
+  account?: Account
+  assetByID: Map<number, Asset>
+  categories: Category[]
+  categoryByID: Map<number, Category>
+  onCategoryChange: (legID: number, catID: number | null) => void
+  onCreateRule: (tx: Transaction) => void
+  onDelete: (legID: number) => Promise<void>
+}
+
+// PairedTradeRow renders two paired transaction rows (a trade) as a
+// single collapsed line: "Bought N AAPL @ $P · -$cash". Expanding shows
+// both legs as full standalone rows. The collapsed view is read-only
+// (no per-leg category edits) — for those, expand.
+function PairedTradeRow({
+  legA,
+  legB,
+  account,
+  assetByID,
+  categories,
+  categoryByID,
+  onCategoryChange,
+  onCreateRule,
+  onDelete,
+}: PairedTradeRowProps) {
+  const [expanded, setExpanded] = useState(false)
+
+  // Classify legs: the cash leg's asset matches the account's primary
+  // quote asset. If the account is missing (rare — partner from another
+  // page), fall back to "leg with the smaller asset_id wins as cash" —
+  // good enough since we still display both on expand.
+  const cashAssetID = account?.primary_quote_asset_id
+  let cashLeg: Transaction
+  let securityLeg: Transaction
+  if (cashAssetID != null && legA.asset_id === cashAssetID) {
+    cashLeg = legA
+    securityLeg = legB
+  } else if (cashAssetID != null && legB.asset_id === cashAssetID) {
+    cashLeg = legB
+    securityLeg = legA
+  } else {
+    // Fallback: the leg whose absolute amount value is "round" cash —
+    // we can't reliably guess, so just pick legA as security.
+    securityLeg = legA
+    cashLeg = legB
+  }
+
+  const securityAsset = assetByID.get(securityLeg.asset_id)
+  const cashAsset = assetByID.get(cashLeg.asset_id)
+  const securityCurrency = securityAsset?.symbol ?? '—'
+  const cashCurrency = cashAsset?.symbol ?? account?.currency ?? 'USD'
+
+  return (
+    <>
+      <tr className="hover:bg-gray-50">
+        <td className="px-3 py-2 text-gray-700">
+          <DateDisplay value={securityLeg.transaction_date} />
+        </td>
+        <td className="px-3 py-2 text-gray-900">
+          <button
+            type="button"
+            onClick={() => setExpanded((v) => !v)}
+            className="mr-1 inline-flex items-center text-gray-400 hover:text-gray-700"
+            aria-label={expanded ? 'Collapse trade' : 'Expand trade'}
+            title={expanded ? 'Collapse legs' : 'Show both legs'}
+          >
+            {expanded ? <ChevronDown size={14} /> : <ChevronRight size={14} />}
+          </button>
+          {securityLeg.description ?? '—'}
+          <span className="ml-2 inline-flex items-center rounded bg-indigo-50 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-indigo-700">
+            trade
+          </span>
+        </td>
+        <td className="px-3 py-2 text-gray-400">—</td>
+        <td className="px-3 py-2 text-right">
+          <div className="tabular-nums">
+            <AmountDisplay amount={securityLeg.amount} currency={securityCurrency} signed />
+          </div>
+          <div className="tabular-nums text-xs text-gray-500">
+            <AmountDisplay amount={cashLeg.amount} currency={cashCurrency} signed />
+          </div>
+        </td>
+        <td className="px-3 py-2 text-gray-700">{account?.name ?? `#${securityLeg.account_id}`}</td>
+        <td className="px-3 py-2 text-gray-400 italic text-xs">expand to edit</td>
+        <td className="px-3 py-2"></td>
+      </tr>
+      {expanded && (
+        <>
+          <TransactionRow
+            tx={securityLeg}
+            account={account}
+            asset={securityAsset}
+            categories={categories}
+            currentCategory={securityLeg.category_id ? categoryByID.get(securityLeg.category_id) : undefined}
+            onCategoryChange={(catID) => onCategoryChange(securityLeg.id, catID)}
+            onCreateRule={() => onCreateRule(securityLeg)}
+            onDelete={() => onDelete(securityLeg.id)}
+            indented
+          />
+          <TransactionRow
+            tx={cashLeg}
+            account={account}
+            asset={cashAsset}
+            categories={categories}
+            currentCategory={cashLeg.category_id ? categoryByID.get(cashLeg.category_id) : undefined}
+            onCategoryChange={(catID) => onCategoryChange(cashLeg.id, catID)}
+            onCreateRule={() => onCreateRule(cashLeg)}
+            onDelete={() => onDelete(cashLeg.id)}
+            indented
+          />
+        </>
+      )}
+    </>
+  )
+}
+
 type AddProps = {
   accounts: Account[]
   categories: Category[]
@@ -335,7 +515,6 @@ function AddTransactionModal({ accounts, categories, onClose, onSubmit }: AddPro
   const [accountID, setAccountID] = useState<string>(accounts[0] ? String(accounts[0].id) : '')
   const [categoryID, setCategoryID] = useState<string>('')
   const [amount, setAmount] = useState('0.00')
-  const [currency, setCurrency] = useState(accounts[0]?.currency ?? 'USD')
   const [description, setDescription] = useState('')
   const [merchant, setMerchant] = useState('')
   const [date, setDate] = useState<string>(new Date().toISOString().slice(0, 10))
@@ -363,7 +542,6 @@ function AddTransactionModal({ accounts, categories, onClose, onSubmit }: AddPro
         account_id: Number(accountID),
         category_id: categoryID === '' ? null : Number(categoryID),
         amount,
-        currency: currency.toUpperCase(),
         description: description.trim() || null,
         merchant_name: merchant.trim() || null,
         transaction_date: date,
@@ -383,11 +561,7 @@ function AddTransactionModal({ accounts, categories, onClose, onSubmit }: AddPro
         <div className="space-y-3 px-5 py-4">
           {error && <div className="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">{error}</div>}
           <Field label="Account">
-            <select className={inputClass} value={accountID} onChange={(e) => {
-              setAccountID(e.target.value)
-              const acc = accounts.find((a) => String(a.id) === e.target.value)
-              if (acc) setCurrency(acc.currency)
-            }}>
+            <select className={inputClass} value={accountID} onChange={(e) => setAccountID(e.target.value)}>
               <option value="">(none)</option>
               {accounts.map((a) => <option key={a.id} value={a.id}>{a.name}</option>)}
             </select>
@@ -398,14 +572,9 @@ function AddTransactionModal({ accounts, categories, onClose, onSubmit }: AddPro
               {categories.map((c) => <option key={c.id} value={c.id}>{c.name}</option>)}
             </select>
           </Field>
-          <div className="grid grid-cols-2 gap-3">
-            <Field label="Amount (negative = spending)">
-              <input className={inputClass} value={amount} onChange={(e) => setAmount(e.target.value)} inputMode="decimal" />
-            </Field>
-            <Field label="Currency">
-              <input className={inputClass} value={currency} maxLength={3} onChange={(e) => setCurrency(e.target.value.toUpperCase())} />
-            </Field>
-          </div>
+          <Field label="Amount (negative = spending)">
+            <input className={inputClass} value={amount} onChange={(e) => setAmount(e.target.value)} inputMode="decimal" />
+          </Field>
           <Field label="Description">
             <input className={inputClass} value={description} onChange={(e) => setDescription(e.target.value)} />
           </Field>

--- a/frontend/src/store/assetsStore.ts
+++ b/frontend/src/store/assetsStore.ts
@@ -1,0 +1,40 @@
+import { create } from 'zustand'
+import { ensureAsset as apiEnsure, listAssets } from '../api/assets'
+import type { Asset, EnsureAssetInput } from '../types/asset'
+
+type State = {
+  assets: Asset[]
+  loaded: boolean
+  loading: boolean
+  error: string | null
+  fetch: () => Promise<void>
+  // ensure adds the returned asset to the cache when it wasn't there yet.
+  ensure: (input: EnsureAssetInput) => Promise<Asset>
+}
+
+// Assets are global reference data — cache once per session and refresh
+// on ensure-create.
+export const useAssetsStore = create<State>((set, get) => ({
+  assets: [],
+  loaded: false,
+  loading: false,
+  error: null,
+  fetch: async () => {
+    if (get().loaded || get().loading) return
+    set({ loading: true, error: null })
+    try {
+      const assets = await listAssets()
+      set({ assets, loaded: true, loading: false })
+    } catch (err) {
+      set({ loading: false, error: err instanceof Error ? err.message : 'failed' })
+    }
+  },
+  ensure: async (input) => {
+    const a = await apiEnsure(input)
+    const existing = get().assets.find((x) => x.id === a.id)
+    if (!existing) {
+      set({ assets: [...get().assets, a] })
+    }
+    return a
+  },
+}))

--- a/frontend/src/types/account.ts
+++ b/frontend/src/types/account.ts
@@ -11,6 +11,10 @@ export type Account = {
   institution_slug: string
   account_type: AccountType
   currency: string
+  // primary_quote_asset_id is the cash sleeve's asset for this account
+  // (per ADR-0013). Derived server-side from the chosen currency on
+  // create — clients shouldn't try to mutate it.
+  primary_quote_asset_id: number
   balance: string
   last_four?: string | null
   plaid_account_id?: string | null

--- a/frontend/src/types/asset.ts
+++ b/frontend/src/types/asset.ts
@@ -1,0 +1,34 @@
+// Asset mirrors backend model.Asset. Reference data shared across the
+// instance (USD, AAPL, BTC) — not user-scoped. The trade form uses these
+// to resolve an asset_id for POST /accounts/:id/trades.
+
+export const ASSET_KINDS = [
+  'fiat',
+  'equity',
+  'fund',
+  'crypto',
+  'bond',
+  'commodity',
+  'other',
+] as const
+
+export type AssetKind = (typeof ASSET_KINDS)[number]
+
+export type Asset = {
+  id: number
+  symbol: string
+  kind: AssetKind
+  display_name?: string | null
+  quote_currency_asset_id?: number | null
+  precision: number
+  created_at: string
+  updated_at: string
+}
+
+// EnsureAssetInput mirrors backend handler.ensureAssetRequest. Backend
+// uppercases symbol and falls back display_name → symbol when blank.
+export type EnsureAssetInput = {
+  symbol: string
+  kind: AssetKind
+  display_name?: string
+}

--- a/frontend/src/types/trade.ts
+++ b/frontend/src/types/trade.ts
@@ -1,0 +1,34 @@
+// Trade types mirror backend service.RecordTradeInput / TradeRecord
+// (see internal/service/trade_service.go). Money + quantity fields are
+// decimal strings on the wire — never parse into Number.
+
+import type { Transaction } from './transaction'
+
+export type TradeKind = 'buy' | 'sell'
+
+export type RecordTradeInput = {
+  kind: TradeKind
+  asset_id: number
+  quantity: string  // positive; backend flips sign per kind
+  price: string     // per-unit, in account's quote currency
+  trade_date: string // YYYY-MM-DD
+  notes?: string | null
+}
+
+export type Position = {
+  id: number
+  user_id: number
+  account_id: number
+  asset_id: number
+  quantity: string
+  cost_basis?: string | null
+  created_at: string
+  updated_at: string
+}
+
+export type TradeRecord = {
+  security_leg: Transaction
+  cash_leg: Transaction
+  security_position: Position
+  cash_position: Position
+}

--- a/frontend/src/types/transaction.ts
+++ b/frontend/src/types/transaction.ts
@@ -1,12 +1,15 @@
 // Transaction mirrors backend model.Transaction. Money fields are decimal
-// strings; format via AmountDisplay (never parse to Number).
+// strings; format via AmountDisplay (never parse to Number). Per ADR-0013,
+// the transaction's unit is `asset_id` — for cash legs it equals the
+// parent account's primary_quote_asset; for trade security legs it's the
+// security (AAPL, BTC, …).
 export type Transaction = {
   id: number
   user_id: number
   account_id: number
+  asset_id: number
   category_id?: number | null
   amount: string
-  currency: string
   description?: string | null
   description_clean?: string | null
   merchant_name?: string | null
@@ -27,11 +30,12 @@ export const TRANSACTION_SOURCES = ['manual', 'plaid', 'csv', 'pdf'] as const
 export type TransactionSource = (typeof TRANSACTION_SOURCES)[number]
 
 // CreateTransactionInput mirrors backend handler.createTransactionRequest.
+// Per ADR-0013, no `currency` field — the asset is derived server-side
+// from the parent account.
 export type CreateTransactionInput = {
   account_id: number
   category_id?: number | null
   amount: string
-  currency?: string
   description?: string | null
   merchant_name?: string | null
   transaction_date: string  // YYYY-MM-DD accepted
@@ -47,7 +51,6 @@ export type UpdateTransactionInput = {
   category_id?: number | null
   clear_category?: boolean
   amount?: string
-  currency?: string
   description?: string | null
   merchant_name?: string | null
   transaction_date?: string


### PR DESCRIPTION
## Summary
Closes the remaining frontend acceptance criteria on #238: a manual "Record trade" entry surface and collapsed paired-row rendering in the Transactions list.

- **Manual record-trade flow** — `TradeFormModal` opens from a per-account action on `/accounts`, gated to brokerage-style accounts (`investment` | `crypto`, mirroring `service.brokerageAccountTypes`). Asset resolution uses a new `POST /assets/ensure` so users can trade previously-unseen tickers; existing symbols snap the kind dropdown automatically.
- **`GET /assets` + `POST /assets/ensure`** — global reference endpoints behind the secured group. The list powers the trade form's datalist picker.
- **Paired-row collapse** — transactions whose `transfer_pair_id` partner is also visible *and shares an account_id* render as one collapsed `Bought N AAPL @ $P · -$cash` row with an expand toggle that shows both legs as standalone rows. Cross-account transfers stay as two rows (different `account_id`).
- **`asset_id` on the wire** — `Transaction` TS type now includes `asset_id` so the row currency comes from `asset.symbol` (cash legs show `USD`, security legs show `AAPL`/`BTC`/etc.) instead of the stale `currency` field. Add Transaction modal drops the `currency` input — per ADR-0013 the asset is derived server-side.

## Test plan
- [ ] On a brokerage account, click the trade icon → record a buy → both legs appear in `/transactions` collapsed into one row, expand shows two.
- [ ] Trade a brand-new ticker (e.g. `NVDA` if absent) → `assets/ensure` creates it, trade succeeds.
- [ ] Sell more than held → backend `INSUFFICIENT_HOLDING` surfaces inline.
- [ ] Plaid-synced trade pairs (M10b part 2) collapse with the same UI.
- [ ] Existing single-row transactions (manual entries, Plaid cash rows) still render unchanged.
- [ ] `make verify` green — backend tests + frontend lint + frontend build.

Closes #238

🤖 Generated with [Claude Code](https://claude.com/claude-code)