### PR TITLE
M9 #229: signup + setup-admin strip-down + Insights empty-state CTA

### DIFF
--- a/frontend/src/pages/InsightsPage.tsx
+++ b/frontend/src/pages/InsightsPage.tsx
@@ -82,6 +82,13 @@ export function InsightsPage() {
 }
 
 function InsightsBody({ data }: { data: InsightsData }) {
+  // Personal fresh-signup state: no accounts at all → single primary CTA
+  // per v6 §02 A2, instead of five empty bands. Household scope keeps its
+  // existing "share an account" empty state on the AccountsBand.
+  if (data.scope === 'personal' && data.accounts.length === 0) {
+    return <FreshSignupEmpty />
+  }
+
   return (
     <>
       <NetWorthBand data={data} />
@@ -93,6 +100,25 @@ function InsightsBody({ data }: { data: InsightsData }) {
         {data.period.from.slice(0, 10)} → {data.period.to.slice(0, 10)}
       </p>
     </>
+  )
+}
+
+function FreshSignupEmpty() {
+  return (
+    <div className="rounded-lg border border-dashed border-gray-300 bg-white p-10 text-center">
+      <Wallet size={32} className="mx-auto text-gray-300 mb-3" />
+      <h2 className="text-lg font-medium text-gray-900">Add your first account</h2>
+      <p className="mt-1 text-sm text-gray-500">
+        Connect a bank or add one manually. Your net worth, allocation, and
+        spending will populate as soon as transactions arrive.
+      </p>
+      <Link
+        to="/accounts/add"
+        className="mt-6 inline-flex items-center gap-2 rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700"
+      >
+        Add your first account →
+      </Link>
+    </div>
   )
 }
 

--- a/frontend/src/pages/SetupAdminPage.tsx
+++ b/frontend/src/pages/SetupAdminPage.tsx
@@ -1,6 +1,5 @@
 import { useState } from 'react'
 import { Navigate } from 'react-router-dom'
-import { Sparkles } from 'lucide-react'
 import { useAuthStore } from '../store/authStore'
 import type { SignupMode } from '../types/auth'
 
@@ -30,14 +29,7 @@ export function SetupAdminPage() {
 
   return (
     <AuthShell>
-      <h1 className="text-xl font-semibold text-gray-900 flex items-center gap-2">
-        <Sparkles size={18} className="text-indigo-600" />
-        Welcome to Offbook
-      </h1>
-      <p className="mt-2 text-sm text-gray-600">
-        This instance hasn't been set up yet. Create the admin account and pick how new users
-        can sign up. You can change the signup mode later.
-      </p>
+      <h1 className="text-xl font-semibold text-gray-900">Set up your admin account</h1>
 
       <form onSubmit={submit} className="mt-6 space-y-4">
         <Field label="Admin email">
@@ -88,7 +80,7 @@ export function SetupAdminPage() {
           disabled={submitting || !email || !password}
           className="w-full rounded-md bg-indigo-600 px-3 py-2 text-sm font-medium text-white hover:bg-indigo-700 disabled:opacity-40"
         >
-          {submitting ? 'Creating admin…' : 'Create admin account'}
+          {submitting ? 'Creating admin…' : 'Create admin account →'}
         </button>
       </form>
     </AuthShell>

--- a/frontend/src/pages/SignupPage.tsx
+++ b/frontend/src/pages/SignupPage.tsx
@@ -106,8 +106,8 @@ export function SignupPage() {
               ? 'Accepting invite…'
               : 'Creating account…'
             : inviteRequired
-              ? 'Accept invite & sign up'
-              : 'Sign up'}
+              ? 'Accept invite & create account →'
+              : 'Create account →'}
         </button>
       </form>
 


### PR DESCRIPTION
## Summary
- Signup button → "Create account →"; setup-admin loses welcome blurb (bare "Set up your admin account" + same form).
- Insights fresh-signup empty state (personal, zero accounts) shows a single primary CTA linking to `/accounts/add` (route lands in #227).
- v6 vault/recovery/AI language was already absent. Name field deliberately omitted — backend has no `users.name` column and adding one is scope creep.

Closes #229

Stacked on #245 (Insights page). Will retarget at main after #245 merges.

## Test plan
- [ ] Fresh signup as a brand-new user lands on `/insights` with the "Add your first account →" CTA.
- [ ] Setup admin renders the trimmed copy; submit still works end-to-end.
- [ ] Signup form button reads "Create account →"; invite mode reads "Accept invite & create account →".

🤖 Generated with [Claude Code](https://claude.com/claude-code)