### PR TITLE
M9 #228: Transactions Needs-Review filter + recent-import banner

### DIFF
--- a/backend/internal/handler/transaction_handler.go
+++ b/backend/internal/handler/transaction_handler.go
@@ -77,6 +77,20 @@ func (h *TransactionHandler) List(c *gin.Context) {
 		}
 		f.To = &t
 	}
+	if v := c.Query("categorization_method"); v != "" {
+		// Only the values the model already constrains are allowed —
+		// kept narrow to avoid a surprise filter against arbitrary strings.
+		switch v {
+		case "plaid_default", "rule", "manual":
+			f.CategorizationMethod = v
+		default:
+			c.JSON(http.StatusBadRequest, gin.H{
+				"error": "categorization_method must be one of plaid_default, rule, manual",
+				"code":  "INVALID_REQUEST",
+			})
+			return
+		}
+	}
 	f.Search = c.Query("search")
 	if v := c.Query("limit"); v != "" {
 		n, err := strconv.Atoi(v)

--- a/backend/internal/repository/transaction_repo.go
+++ b/backend/internal/repository/transaction_repo.go
@@ -17,12 +17,17 @@ import (
 type TransactionFilter struct {
 	AccountID         *int64
 	CategoryID        *int64
-	UncategorizedOnly bool       // matches rows where category_id IS NULL
-	From              *time.Time // inclusive lower bound on transaction_date
-	To                *time.Time // inclusive upper bound on transaction_date
-	Search            string     // ILIKE %term% across description + merchant_name
-	Limit             int
-	Offset            int
+	UncategorizedOnly bool // matches rows where category_id IS NULL
+	// CategorizationMethod, when non-empty, restricts to rows where
+	// categorization_method matches exactly. Used by the v6 "Needs review"
+	// filter chip to surface rows auto-assigned via plaid_default that the
+	// user hasn't confirmed or rule-overridden.
+	CategorizationMethod string
+	From                 *time.Time // inclusive lower bound on transaction_date
+	To                   *time.Time // inclusive upper bound on transaction_date
+	Search               string     // ILIKE %term% across description + merchant_name
+	Limit                int
+	Offset               int
 }
 
 // TransactionRepository is the data-access contract for transactions.
@@ -147,6 +152,9 @@ func (r *transactionRepo) List(ctx context.Context, userID int64, f TransactionF
 		q = q.Where("category_id IS NULL")
 	case f.CategoryID != nil:
 		q = q.Where("category_id = ?", *f.CategoryID)
+	}
+	if m := f.CategorizationMethod; m != "" {
+		q = q.Where("categorization_method = ?", m)
 	}
 	if f.From != nil {
 		q = q.Where("transaction_date >= ?", *f.From)

--- a/frontend/src/api/transactions.ts
+++ b/frontend/src/api/transactions.ts
@@ -9,6 +9,10 @@ export type TransactionListFilter = {
   account_id?: number
   // Pass null for uncategorized-only (mapped to ?category_id=null on the wire).
   category_id?: number | null
+  // Restricts to rows with this categorization_method. Backed by the v6
+  // "Needs review" chip — passing 'plaid_default' shows rows the engine
+  // auto-assigned but the user hasn't confirmed.
+  categorization_method?: 'plaid_default' | 'rule' | 'manual'
   from?: string  // YYYY-MM-DD
   to?: string
   search?: string
@@ -24,6 +28,7 @@ export async function listTransactions(
   if (f.category_id !== undefined) {
     params.category_id = f.category_id === null ? 'null' : f.category_id
   }
+  if (f.categorization_method) params.categorization_method = f.categorization_method
   if (f.from) params.from = f.from
   if (f.to) params.to = f.to
   if (f.search) params.search = f.search

--- a/frontend/src/pages/TransactionsPage.tsx
+++ b/frontend/src/pages/TransactionsPage.tsx
@@ -1,9 +1,10 @@
 import { useEffect, useMemo, useState, type ReactNode } from 'react'
-import { ChevronDown, ChevronRight, Plus, Sparkles, Trash2 } from 'lucide-react'
+import { ChevronDown, ChevronRight, Eye, Plus, Sparkles, Trash2, X } from 'lucide-react'
 import { Link } from 'react-router-dom'
 import { AmountDisplay } from '../components/AmountDisplay'
 import { DateDisplay } from '../components/DateDisplay'
 import { RuleFormModal, type RuleFormDefaults } from '../components/RuleFormModal'
+import { listTransactions } from '../api/transactions'
 import { useAccountsStore } from '../store/accountsStore'
 import { useAssetsStore } from '../store/assetsStore'
 import { useCategoriesStore } from '../store/categoriesStore'
@@ -48,6 +49,18 @@ export function TransactionsPage() {
   const [searchInput, setSearchInput] = useState<string>(filter.search ?? '')
   const search = useDebounce(searchInput, 300)
   const [adding, setAdding] = useState(false)
+  // "Needs review" filter chip + banner. needsReview drives the store
+  // filter (categorization_method=plaid_default). reviewCount is a
+  // separate query so the banner can announce a number independent of
+  // whatever filter the user is currently looking at.
+  const [needsReview, setNeedsReview] = useState<boolean>(
+    filter.categorization_method === 'plaid_default',
+  )
+  const [reviewCount, setReviewCount] = useState<number | null>(null)
+  // bannerDismissed mirrors localStorage by key. We let it lag behind a
+  // sync-driven key change for one frame, but the showBanner logic also
+  // checks against the live key, so the user never sees a stale banner.
+  const [dismissedKey, setDismissedKey] = useState<string | null>(null)
 
   useEffect(() => {
     void fetchAccounts()
@@ -84,12 +97,74 @@ export function TransactionsPage() {
     setFilter({
       account_id: accountID === '' ? undefined : Number(accountID),
       category_id: categoryID === '' ? undefined : categoryID === 'null' ? null : Number(categoryID),
+      categorization_method: needsReview ? 'plaid_default' : undefined,
       from: from === '' ? undefined : from,
       to: to === '' ? undefined : to,
       search: search === '' ? undefined : search,
     })
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [accountID, categoryID, from, to, search])
+  }, [accountID, categoryID, from, to, search, needsReview])
+
+  // Recent-import signal: the most recent last_synced_at across all
+  // Plaid-linked accounts. The banner key is built off this so a new
+  // sync (= newer timestamp) re-shows the banner even if the user
+  // dismissed an earlier one.
+  const recentSyncAt = useMemo(() => {
+    let max: string | null = null
+    for (const a of accounts) {
+      if (!a.last_synced_at) continue
+      if (max == null || a.last_synced_at > max) max = a.last_synced_at
+    }
+    return max
+  }, [accounts])
+
+  const bannerKey = recentSyncAt ? `txn-review-banner:${recentSyncAt}` : null
+
+  // Pull the count of rows that would land in the "Needs review" filter,
+  // independently from the main list (which honors all current filters).
+  // limit=1 keeps the fetch cheap — we only need `total`.
+  useEffect(() => {
+    let cancelled = false
+    void listTransactions({ categorization_method: 'plaid_default', limit: 1 })
+      .then((r) => { if (!cancelled) setReviewCount(r.total) })
+      .catch(() => { /* swallow — banner just won't surface */ })
+    return () => { cancelled = true }
+  }, [recentSyncAt])
+
+  // Dismissal is persisted in localStorage keyed by bannerKey, so a newer
+  // sync (newer key) re-shows the banner without needing reset state. We
+  // read once per key change via useMemo (pure derivation); the local
+  // `dismissedKey` state covers the in-session click without round-tripping
+  // through storage.
+  const storedDismissedKey = useMemo(() => {
+    if (!bannerKey) return null
+    try {
+      return window.localStorage.getItem(bannerKey) === '1' ? bannerKey : null
+    } catch {
+      return null
+    }
+  }, [bannerKey])
+  const bannerDismissed = dismissedKey === bannerKey || storedDismissedKey === bannerKey
+
+  const dismissBanner = () => {
+    if (!bannerKey) return
+    setDismissedKey(bannerKey)
+    try { window.localStorage.setItem(bannerKey, '1') } catch { /* private mode etc. */ }
+  }
+
+  // Capture "now" at mount via lazy state init. React's purity rule
+  // forbids Date.now() in render or useMemo, and pure state inits sidestep
+  // that; coarse 24h window means we don't need a ticker.
+  const [nowAtMount] = useState(() => Date.now())
+  const RECENT_WINDOW_MS = 24 * 60 * 60 * 1000
+  const recentlySynced =
+    recentSyncAt != null && nowAtMount - new Date(recentSyncAt).getTime() < RECENT_WINDOW_MS
+
+  const showBanner =
+    !needsReview &&
+    !bannerDismissed &&
+    reviewCount != null && reviewCount > 0 &&
+    recentlySynced
 
   const totalPages = Math.max(1, Math.ceil(total / pageSize))
   const accountByID = useMemo(() => mapByID(accounts), [accounts])
@@ -136,7 +211,53 @@ export function TransactionsPage() {
         <div className="mt-4 rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">{error}</div>
       )}
 
-      <div className="mt-4 grid grid-cols-1 gap-3 md:grid-cols-5">
+      {showBanner && (
+        <div className="mt-4 flex items-start justify-between gap-3 rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-900">
+          <div className="flex items-start gap-2">
+            <Eye size={16} className="mt-0.5 shrink-0" />
+            <span>
+              {reviewCount} row{reviewCount === 1 ? '' : 's'} need a category review after the recent sync —{' '}
+              <button
+                type="button"
+                onClick={() => setNeedsReview(true)}
+                className="underline hover:text-amber-700"
+              >
+                show needs review
+              </button>
+              .
+            </span>
+          </div>
+          <button
+            type="button"
+            onClick={dismissBanner}
+            aria-label="Dismiss banner"
+            className="text-amber-700 hover:text-amber-900"
+          >
+            <X size={14} />
+          </button>
+        </div>
+      )}
+
+      <div className="mt-4 flex flex-wrap items-center gap-2">
+        <button
+          type="button"
+          onClick={() => setNeedsReview((v) => !v)}
+          className={[
+            'inline-flex items-center gap-1.5 rounded-full border px-3 py-1 text-xs font-medium',
+            needsReview
+              ? 'border-amber-400 bg-amber-50 text-amber-800'
+              : 'border-gray-300 bg-white text-gray-700 hover:bg-gray-50',
+          ].join(' ')}
+        >
+          <Eye size={12} />
+          Needs review
+          {reviewCount != null && reviewCount > 0 && (
+            <span className={needsReview ? 'text-amber-700' : 'text-gray-500'}>· {reviewCount}</span>
+          )}
+        </button>
+      </div>
+
+      <div className="mt-3 grid grid-cols-1 gap-3 md:grid-cols-5">
         <Field label="Account">
           <select className={inputClass} value={accountID} onChange={(e) => setAccountID(e.target.value)}>
             <option value="">All</option>

--- a/frontend/src/store/transactionsStore.ts
+++ b/frontend/src/store/transactionsStore.ts
@@ -85,10 +85,24 @@ export const useTransactionsStore = create<State>((set, get) => ({
 
   setCategory: async (id, categoryID) => {
     const before = get().transactions
-    // Optimistic update.
-    set({
-      transactions: before.map((t) => (t.id === id ? { ...t, category_id: categoryID } : t)),
-    })
+    const filterMethod = get().filter.categorization_method
+    // Picking a category server-side flips categorization_method to
+    // 'manual' (clearing it nulls the method out). Mirror that locally
+    // so a row immediately leaves the "Needs review" view per the v6 §04
+    // acceptance criterion — no full reload.
+    const newMethod: string | null = categoryID === null ? null : 'manual'
+    const next = before
+      .map((t) =>
+        t.id === id
+          ? { ...t, category_id: categoryID, categorization_method: newMethod ?? undefined }
+          : t,
+      )
+      // If the active filter restricts to a different method (e.g.
+      // 'plaid_default'), the updated row no longer belongs in this list.
+      // Filtering happens after the map so the user sees the change before
+      // the row vanishes.
+      .filter((t) => (filterMethod ? t.categorization_method === filterMethod : true))
+    set({ transactions: next })
     try {
       if (categoryID === null) {
         await apiUpdate(id, { clear_category: true })


### PR DESCRIPTION
## Summary
- New "Needs review" filter chip on the Transactions page (\`categorization_method=plaid_default\`).
- Dismissible banner appears after a recent (≤24h) account sync, summarising row count and activating the chip on click.
- Backend: \`TransactionFilter.CategorizationMethod\` + \`?categorization_method=plaid_default|rule|manual\` query param on \`/transactions\`.
- Categorizing a row in the chip view removes it from the local list immediately (no reload) — the store's optimistic update mirrors the server-side flip to \`manual\` and re-filters local state.

Closes #228

Stacked on #247. Will retarget at main once the chain merges.

## Test plan
- [ ] Sync a Plaid sandbox account → banner appears with non-zero count.
- [ ] Click "show needs review" → chip activates, table restricts.
- [ ] Pick a category on a row → row vanishes from view without a reload.
- [ ] Dismiss banner → stays dismissed until a fresher sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)