### PR TITLE
chore #257: Tailscale per-instance deployment pattern

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,6 +72,11 @@ When running via Claude's Bash tool, prefix `make` with `command` (`command make
 - Settings → "Linked Institutions" lists each `plaid_items` row and exposes a per-item Disconnect (soft-delete; accounts and historical transactions remain).
 - All Plaid surfaces are personal-scope only — sharing into a household is per-account via `account_shares`, not per-item.
 
+## Tailscale Deployment
+- Multi-instance deployment on one host runs **one Compose project per instance, each with its own Tailscale sidecar** — see [ADR-0016](docs/ADR/0016-tailscale-per-instance-deployment.md).
+- Sidecar override is `docker-compose.tailscale.yml`. Instance-agnostic; composes with any base stack. Required env: `TS_AUTHKEY`, `TS_HOSTNAME`. Walkthrough in `infra/tailscale/README.md`.
+- Do not multiplex multiple instances behind a single Tailscale node (path-based or port-based). One node per instance = one MagicDNS hostname per instance, which is the only configuration the React app and cookie scoping don't have to know about.
+
 ## Backlog Discipline
 - Do NOT fix things outside the current issue
 - Instead: `gh issue create --title "..." --body "..." --label backlog`

--- a/docker-compose.tailscale.yml
+++ b/docker-compose.tailscale.yml
@@ -1,0 +1,36 @@
+# Tailscale sidecar override — exposes the composed `frontend` over HTTPS at
+# https://${TS_HOSTNAME}.<tailnet>.ts.net. Instance-agnostic: compose with any
+# base stack; instance identity comes from the compose project name.
+#
+# Required env (no defaults — intentional, fail-fast):
+#   TS_AUTHKEY   Tailscale auth key (tskey-...). Prefer per-instance, tagged.
+#   TS_HOSTNAME  MagicDNS name for this node (e.g. offbook-dev, offbook-prod).
+#
+# Example:
+#   TS_AUTHKEY=tskey-... TS_HOSTNAME=offbook-dev \
+#     docker compose -p offbook-dev \
+#       -f docker-compose.yml -f docker-compose.tailscale.yml up -d
+#
+# See ADR-0016 for rationale.
+services:
+  tailscale:
+    image: tailscale/tailscale:latest
+    hostname: ${TS_HOSTNAME:?TS_HOSTNAME required (the MagicDNS name for this instance)}
+    environment:
+      TS_AUTHKEY: ${TS_AUTHKEY:?TS_AUTHKEY required (per-instance Tailscale auth key)}
+      TS_HOSTNAME: ${TS_HOSTNAME}
+      TS_STATE_DIR: /var/lib/tailscale
+      TS_USERSPACE: "true"
+      TS_EXTRA_ARGS: --advertise-tags=tag:offbook
+      # Serve config is rendered into a file the sidecar reads; the frontend
+      # service in the merged compose graph must be reachable as `frontend:80`.
+      TS_SERVE_CONFIG: /config/serve.json
+    volumes:
+      - tailscale_state:/var/lib/tailscale
+      - ./infra/tailscale/serve.json:/config/serve.json:ro
+    depends_on:
+      - frontend
+    restart: unless-stopped
+
+volumes:
+  tailscale_state:

--- a/docs/ADR/0016-tailscale-per-instance-deployment.md
+++ b/docs/ADR/0016-tailscale-per-instance-deployment.md
@@ -1,0 +1,55 @@
+# ADR 0016: Local Multi-Instance Deployment via Per-Instance Tailscale Sidecars
+
+## Status
+Accepted
+
+## Context
+Offbook is intentionally self-hostable and runs as a Docker Compose stack rather than as a packaged binary or desktop app (see [ADR-0002](0002-postgres-over-sqlite.md) — Postgres dependency rules out a single-file distribution without a SQLite rewrite). Operators commonly want to run more than one instance on the same host: a stable instance against their real data, and a development/preview instance for testing changes before they touch the real DB.
+
+We need a deployment pattern that:
+1. Runs multiple instances side-by-side on one host without port/volume collisions.
+2. Exposes each instance over HTTPS at a stable hostname, ideally without owning a public domain or punching holes in NAT.
+3. Keeps the per-instance footprint thin — no per-instance reverse proxy, no per-instance certificate management, no per-instance DNS surgery.
+4. Doesn't require packaging the app (deferred — Postgres + the React frontend make a single binary a real project, not a side quest).
+
+Tailscale Serve is a natural fit for (2): every node on a tailnet gets a `<hostname>.<tailnet>.ts.net` MagicDNS name and a managed Let's Encrypt cert, with no inbound NAT exposure. The wrinkle: a single Tailscale node owns exactly one ts.net hostname, and `tailscale serve` doesn't do Host-header virtual-host routing. So "multiple instances on one host" must be solved at the Tailscale layer, not by stuffing multiple apps behind a shared node.
+
+## Decision
+Each Offbook instance runs as a separate Docker Compose **project** with its own Tailscale **sidecar container**. One node per instance, one MagicDNS hostname per instance.
+
+Concretely:
+1. **`docker-compose.tailscale.yml`** is a reusable, instance-agnostic override that adds a `tailscale` service. Required env: `TS_AUTHKEY` (auth key), `TS_HOSTNAME` (the desired MagicDNS name).
+2. **Instance identity is the compose project name** (`docker compose -p offbook-dev ...` vs `-p offbook-prod ...`). Project name namespaces containers, networks, and named volumes — so two instances on one host don't fight over `postgres_data`.
+3. **The sidecar joins the tailnet, runs `tailscale serve` against the in-compose frontend service**, and terminates HTTPS at `:443` on the tailnet-facing interface. The frontend container does not bind a host port for tailnet-exposed instances; only the sidecar is reachable from the tailnet.
+4. **Per-instance auth keys** — each sidecar gets its own ephemeral or reusable auth key, ideally tagged (`--advertise-tags=tag:offbook`) so ACLs and key rotation can target Offbook nodes without touching the rest of the tailnet.
+
+## Rationale
+- **One node per instance is the only Tailscale-native way to get one ts.net hostname per instance.** `tailscale serve` is path/port-aware, not Host-header-aware. Multiplexing two apps behind one node forces either path prefixes (`/dev`, `/prod`) — which the React app would have to know about via `vite.config.ts` `base`, cookie path scoping, and absolute API URLs — or alternate ports (`:443`, `:8443`), which works but is uglier and breaks browser-managed assumptions like cookie defaults.
+- **Sidecar containers don't need root or `CAP_NET_ADMIN` on the host** — userspace networking (`TS_USERSPACE=true`) is sufficient for Serve, which keeps the operator story "docker compose up" rather than "install Tailscale on the host first." It also means the host's own tailnet identity (if any) is untouched.
+- **Compose project name as the isolation boundary** is already how `docker-compose.qa.yml` works (`-p offbook-qa`). Reusing the pattern keeps mental overhead low: a new instance is `-p <name>` + a base/override pair, not a new abstraction.
+- **Instance-agnostic override** means the same `docker-compose.tailscale.yml` works with the current dev stack, a future `docker-compose.prod.yml`, and even the QA stack. The override knows nothing about which environment it's exposing; it just proxies whichever `frontend` service exists in the merged composition.
+- **Per-instance auth keys with tags** keep blast radius bounded. A leaked dev key doesn't grant tailnet access beyond the dev node and can be revoked without touching prod. Tagged nodes also let ACLs say "tag:offbook nodes are reachable by tag:family" without enumerating hostnames.
+
+## Consequences
+- **`docker-compose.tailscale.yml`** lands in the repo root, composable with any base stack:
+  ```sh
+  TS_AUTHKEY=tskey-... TS_HOSTNAME=offbook-dev \
+    docker compose -p offbook-dev -f docker-compose.yml -f docker-compose.tailscale.yml up -d
+  ```
+- **Operators need a Tailscale account and tailnet.** This is the cost of the simplicity — no DDNS, no reverse proxy, no certbot, but the operator is now Tailscale-dependent. Acceptable: Tailscale's free tier covers personal/family use, and the alternative (Caddy + DDNS + LetsEncrypt) is materially more setup.
+- **Per-instance Tailscale state is volume-backed** so a sidecar restart doesn't re-key the node and rotate the cert. State volume is namespaced by compose project name, so dev and prod state can't collide.
+- **The base `docker-compose.yml` does not change.** It still binds host ports for local development (`5173`, `8000`, `5432`). When exposed via Tailscale, those host ports are redundant but harmless; operators concerned about local exposure can override with `ports: !override []` in their site-specific compose file. We don't bake that in because it would break the documented local-dev experience.
+- **A real `docker-compose.prod.yml`** (different DB name, different volume, prod env defaults, no init scripts that create dev/test DBs) is not part of this ADR — it's a separate follow-up. This ADR makes the prod stack *possible*; it doesn't write it. Filed as backlog.
+- **AGENTS.md gains a short "Tailscale deployment" section** pointing at this ADR and the override.
+
+## Alternatives Considered
+- **Single Tailscale node, path-based multiplexing (`/dev`, `/prod`).** Rejected. Forces React app to know its base path, breaks cookie defaults, makes absolute API URLs in the frontend a footgun. The cleanup work in the app would dwarf the infrastructure savings.
+- **Single Tailscale node, port-based multiplexing (`:443`, `:8443`).** Workable but uglier — users have to remember non-standard ports, and browser features (HSTS preloading, secure-cookie defaults) get awkward across mixed ports.
+- **Tailscale on the host, no sidecars.** Couples app deployment to host config; operator has to install Tailscale on the host *and* manage `tailscale serve` outside Compose. Loses the "one `docker compose up` and you're done" property.
+- **Caddy reverse proxy + DDNS + LetsEncrypt.** Strictly more general but materially more setup per operator. Tailscale gives us MagicDNS, cert provisioning, and zero-trust ingress in one dependency.
+- **Package as a single binary / `.app`.** Discussed and deferred — Postgres dependency makes this a real project (SQLite migration or bundled Postgres process). Not blocked by this ADR; orthogonal.
+
+## Follow-up
+- **Backlog: `docker-compose.prod.yml`** — separate DB name (`offbook_prod`), separate named volume, no init scripts that create dev/test DBs, prod env defaults (e.g. fail-fast on missing `SESSION_SECRET`, `PLAID_TOKEN_KEY`).
+- **Backlog: ACL template** under `infra/tailscale/` showing the tag scheme (`tag:offbook`, `tag:offbook-prod`, `tag:offbook-dev`) and a sample ACL granting the operator's tag access to both.
+- **Backlog: Funnel exposure** (`tailscale funnel`) for instances the operator wants reachable from the public internet. Not in scope for this ADR — Funnel changes the threat model significantly and deserves its own decision.

--- a/infra/tailscale/README.md
+++ b/infra/tailscale/README.md
@@ -1,0 +1,42 @@
+# Tailscale Sidecar
+
+Pattern for exposing an Offbook instance over HTTPS at a `*.ts.net` MagicDNS hostname. See [ADR-0016](../../docs/ADR/0016-tailscale-per-instance-deployment.md) for the decision.
+
+## One-time setup
+
+1. Have a Tailscale account and tailnet.
+2. In the admin console, create a tag for Offbook nodes: `tag:offbook` (assign your user as the owner so you can mint keys for it).
+3. Mint a per-instance auth key, **tagged** `tag:offbook`. Reusable + ephemeral is fine for a personal tailnet; choose per your threat model.
+
+## Bring up an instance
+
+```sh
+TS_AUTHKEY=tskey-auth-... TS_HOSTNAME=offbook-dev \
+  docker compose -p offbook-dev \
+    -f docker-compose.yml \
+    -f docker-compose.tailscale.yml \
+    up -d
+```
+
+The node appears in the tailnet as `offbook-dev.<tailnet>.ts.net` once Tailscale has fetched a cert (first boot takes ~30s).
+
+## Bring up a second instance on the same host
+
+Same command, different project name + hostname + auth key. Compose project name namespaces containers, networks, and named volumes (including `postgres_data` and `tailscale_state`), so there's no collision:
+
+```sh
+TS_AUTHKEY=tskey-auth-... TS_HOSTNAME=offbook-prod \
+  docker compose -p offbook-prod \
+    -f docker-compose.yml \
+    -f docker-compose.tailscale.yml \
+    up -d
+```
+
+(A dedicated `docker-compose.prod.yml` with a different DB name and prod env defaults is a planned follow-up; until it lands, this exposes the dev-flavored stack under the prod hostname.)
+
+## Notes
+
+- The sidecar runs `tailscale serve` in userspace mode — no `CAP_NET_ADMIN`, no `/dev/net/tun` mount, no host Tailscale install.
+- `serve.json` uses `${TS_CERT_DOMAIN}` — Tailscale substitutes the node's full MagicDNS name at read time. The same file works for every instance.
+- Funnel (public-internet exposure) is explicitly disabled in `serve.json`. Enabling it is a separate decision; see the follow-up note in ADR-0016.
+- The base `docker-compose.yml` still binds host ports for local dev. They're redundant when accessing via Tailscale but harmless. Override with `ports: !override []` in a site-specific compose file if local exposure is a concern.

--- a/infra/tailscale/serve.json
+++ b/infra/tailscale/serve.json
@@ -1,0 +1,19 @@
+{
+  "TCP": {
+    "443": {
+      "HTTPS": true
+    }
+  },
+  "Web": {
+    "${TS_CERT_DOMAIN}:443": {
+      "Handlers": {
+        "/": {
+          "Proxy": "http://frontend:80"
+        }
+      }
+    }
+  },
+  "AllowFunnel": {
+    "${TS_CERT_DOMAIN}:443": false
+  }
+}


### PR DESCRIPTION
Closes #257

## Summary
- ADR-0016 documents the decision: one Docker Compose project per Offbook instance, each with its own Tailscale sidecar = one `*.ts.net` MagicDNS hostname per instance.
- `docker-compose.tailscale.yml` is an instance-agnostic override that adds the sidecar. Requires `TS_AUTHKEY` + `TS_HOSTNAME`; composes with the existing base stack today and any future `docker-compose.prod.yml`.
- `infra/tailscale/` contains the `tailscale serve` config (proxies `/` → `frontend:80`, funnel explicitly off) plus a README walkthrough.
- AGENTS.md gains a "Tailscale Deployment" section pointing at the ADR + override.

## Why this shape
- Tailscale Serve doesn't do Host-header vhost routing — a single node owns one hostname. Multiplexing two instances behind one node forces React base-path / cookie-scope gymnastics; one node per instance avoids that entirely.
- Compose project name as the isolation boundary mirrors the existing QA pattern (`docker-compose.qa.yml` + `-p offbook-qa`). No new abstraction.

## Out of scope (filed separately as future work in ADR)
- A real `docker-compose.prod.yml` (different DB name, prod env defaults, no init scripts that create dev/test DBs).
- ACL templates under `infra/tailscale/`.
- Funnel exposure — different threat model, deserves its own decision.

## Test plan
- [ ] `docker compose -f docker-compose.yml -f docker-compose.tailscale.yml config` parses cleanly with `TS_AUTHKEY` + `TS_HOSTNAME` set (no actual auth key needed for parse check).
- [ ] Bring up an instance against a real tailnet, confirm `https://<TS_HOSTNAME>.<tailnet>.ts.net` serves the frontend.
- [ ] Bring up a second instance with a different project name + hostname + auth key, confirm both are reachable in parallel with no volume/port collisions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)