### PR TITLE
chore #259: docker-compose.prod.yml for prod-flavored local stack

### DIFF
--- a/.env.prod.example
+++ b/.env.prod.example
@@ -1,0 +1,29 @@
+# Template for .env.prod — the env file consumed by the prod compose stack
+# (docker-compose.prod.yml). Copy to `.env.prod` and fill in.
+#
+#   cp .env.prod.example .env.prod
+#   openssl rand -hex 32   # use for SESSION_SECRET
+#
+# .env.prod is gitignored. The same file is loaded both as `--env-file` for
+# compose variable substitution (TS_*) and as the backend container's
+# env_file (SESSION_SECRET, FRONTEND_URL).
+
+# ─── Tailscale sidecar (docker-compose.tailscale.yml) ─────────────────────────
+# Mint a per-instance, tagged (tag:offbook) auth key at:
+#   https://login.tailscale.com/admin/settings/keys
+TS_AUTHKEY=
+# MagicDNS hostname for this instance. Final URL: https://<TS_HOSTNAME>.<tailnet>.ts.net
+TS_HOSTNAME=offbook-prod
+
+# ─── Backend ──────────────────────────────────────────────────────────────────
+# 32-byte hex key. `openssl rand -hex 32`. Required in prod.
+SESSION_SECRET=
+# CORS allow-origin. Set to the full tailnet URL. Same-origin via nginx proxy
+# in production, so this is belt-and-suspenders; still keep it accurate.
+FRONTEND_URL=https://offbook-prod.<your-tailnet>.ts.net
+
+# ─── Plaid (disabled in prod for now — leave unset) ───────────────────────────
+# PLAID_CLIENT_ID=
+# PLAID_SECRET=
+# PLAID_ENV=sandbox
+# PLAID_TOKEN_KEY=

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,8 @@ frontend/dist/
 # Environment
 .env
 .env.qa
+.env.dev
+.env.prod
 .env.local
 .env.*.local
 

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,46 @@
+# Prod-flavored compose override. Composes with the base docker-compose.yml.
+# Designed to coexist on a single host with the dev stack (no host port
+# collisions, no shared Postgres volume). Tailscale-fronted only — the
+# expected ingress is docker-compose.tailscale.yml; no host ports are bound.
+#
+# Usage (with Tailscale sidecar):
+#   docker compose -p offbook-prod \
+#     --env-file .env.prod \
+#     -f docker-compose.yml \
+#     -f docker-compose.prod.yml \
+#     -f docker-compose.tailscale.yml \
+#     up -d
+#
+# Required env (in .env.prod): SESSION_SECRET, TS_AUTHKEY, TS_HOSTNAME.
+# See .env.prod.example for the full set. See ADR-0016 for the deployment pattern.
+services:
+  postgres:
+    environment:
+      POSTGRES_DB: offbook_prod
+    ports: !override []
+    volumes: !override
+      - prod_postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U offbook -d offbook_prod"]
+
+  backend:
+    ports: !override []
+    environment:
+      APP_ENV: prod
+      DATABASE_URL: postgres://offbook:offbook@postgres:5432/offbook_prod?sslmode=disable
+      PORT: "8000"
+      MIGRATIONS_PATH: /app/migrations
+      # FRONTEND_URL and SESSION_SECRET come from .env.prod via --env-file
+      # substitution. Explicit ${VAR} bindings (rather than env_file:) so they
+      # override the base file's hardcoded FRONTEND_URL — Compose merges
+      # environment over env_file, so a base-level hardcoded key wins against
+      # an overlay env_file unless we re-state it here.
+      FRONTEND_URL: ${FRONTEND_URL:?FRONTEND_URL required (set in .env.prod, then pass --env-file .env.prod)}
+      SESSION_SECRET: ${SESSION_SECRET:?SESSION_SECRET required (set in .env.prod, then pass --env-file .env.prod)}
+    env_file: !override []
+
+  frontend:
+    ports: !override []
+
+volumes:
+  prod_postgres_data:

--- a/infra/tailscale/README.md
+++ b/infra/tailscale/README.md
@@ -20,19 +20,23 @@ TS_AUTHKEY=tskey-auth-... TS_HOSTNAME=offbook-dev \
 
 The node appears in the tailnet as `offbook-dev.<tailnet>.ts.net` once Tailscale has fetched a cert (first boot takes ~30s).
 
-## Bring up a second instance on the same host
+## Bring up a second (prod-flavored) instance on the same host
 
-Same command, different project name + hostname + auth key. Compose project name namespaces containers, networks, and named volumes (including `postgres_data` and `tailscale_state`), so there's no collision:
+Same command, but compose in `docker-compose.prod.yml` and pass a prod env file. Compose project name namespaces containers, networks, and named volumes (including `prod_postgres_data` and `tailscale_state`), so there's no collision with the dev stack:
 
 ```sh
-TS_AUTHKEY=tskey-auth-... TS_HOSTNAME=offbook-prod \
-  docker compose -p offbook-prod \
-    -f docker-compose.yml \
-    -f docker-compose.tailscale.yml \
-    up -d
+cp .env.prod.example .env.prod
+# Fill in SESSION_SECRET (openssl rand -hex 32), TS_AUTHKEY, FRONTEND_URL
+
+docker compose -p offbook-prod \
+  --env-file .env.prod \
+  -f docker-compose.yml \
+  -f docker-compose.prod.yml \
+  -f docker-compose.tailscale.yml \
+  up -d
 ```
 
-(A dedicated `docker-compose.prod.yml` with a different DB name and prod env defaults is a planned follow-up; until it lands, this exposes the dev-flavored stack under the prod hostname.)
+The prod override swaps `POSTGRES_DB` to `offbook_prod`, uses a named volume (no collision with the dev stack's `./data/postgres` bind mount), unbinds all host ports (only the Tailscale sidecar is reachable), and refuses to start without `SESSION_SECRET`.
 
 ## Notes
 


### PR DESCRIPTION
Closes #259

## Summary
- `docker-compose.prod.yml` — prod-flavored override that composes on top of the base + Tailscale sidecar.
- `.env.prod.example` template; `.env.dev` / `.env.prod` added to `.gitignore`.
- Tailscale walkthrough updated to use the prod override for the second-instance bring-up.

## Design decisions
- **Named volume, not bind mount** for the prod Postgres data dir. Compose namespaces named volumes by project (`offbook-prod_prod_postgres_data`), so two stacks on one host don't collide; bind mounts would.
- **Init script unmounted in prod** so the prod Postgres instance doesn't end up with empty `offbook_qa` / `offbook_test` sibling DBs.
- **All host ports unbound** (`ports: !override []` on postgres/backend/frontend). Tailscale sidecar is the only ingress; this lets the prod stack coexist with the dev stack on a single host.
- **FRONTEND_URL / SESSION_SECRET re-stated in `environment:`** (not just env_file) because Compose precedence rules: `environment:` wins over `env_file:`, so a base-level hardcoded key in `docker-compose.yml` would otherwise survive an overlay env_file. Using `${VAR:?...}` substitution makes it fail-fast if `--env-file .env.prod` isn't passed.

## Verification
- `docker compose -p offbook-prod --env-file .env.prod -f docker-compose.yml -f docker-compose.prod.yml -f docker-compose.tailscale.yml config` parses cleanly; resolved env shows `APP_ENV=prod`, `POSTGRES_DB=offbook_prod`, `FRONTEND_URL`/`SESSION_SECRET` sourced from `.env.prod`, no host port bindings.
- Dev stack (`-p offbook-dev -f docker-compose.yml -f docker-compose.tailscale.yml`) still parses cleanly with host ports bound and `POSTGRES_DB=offbook_dev`. No volume or port overlap between the two stacks.

## Test plan
- [ ] Bring up dev stack with a real `TS_AUTHKEY`; confirm `https://offbook-dev.<tailnet>.ts.net` serves the SPA.
- [ ] Bring up prod stack alongside it; confirm `https://offbook-prod.<tailnet>.ts.net` serves the SPA and `/api/v1/health` returns 200.
- [ ] Confirm `offbook_prod` exists in the prod Postgres container and `offbook_qa` / `offbook_test` do not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)