### PR TITLE
chore #261: make TS_EXTRA_ARGS operator-configurable

### DIFF
--- a/.env.prod.example
+++ b/.env.prod.example
@@ -14,6 +14,10 @@
 TS_AUTHKEY=
 # MagicDNS hostname for this instance. Final URL: https://<TS_HOSTNAME>.<tailnet>.ts.net
 TS_HOSTNAME=offbook-prod
+# Optional. Extra flags for `tailscaled`. Leave unset if your auth key
+# auto-applies a tag (the recommended setup for ACL-restricted reusable keys).
+# Set e.g. `--advertise-tags=tag:offbook` only if you mint untagged keys.
+# TS_EXTRA_ARGS=
 
 # ─── Backend ──────────────────────────────────────────────────────────────────
 # 32-byte hex key. `openssl rand -hex 32`. Required in prod.

--- a/docker-compose.tailscale.yml
+++ b/docker-compose.tailscale.yml
@@ -21,7 +21,12 @@ services:
       TS_HOSTNAME: ${TS_HOSTNAME}
       TS_STATE_DIR: /var/lib/tailscale
       TS_USERSPACE: "true"
-      TS_EXTRA_ARGS: --advertise-tags=tag:offbook
+      # Optional. Pass extra `tailscaled` flags here, e.g. --advertise-tags=tag:X.
+      # Leave empty when your auth key already auto-applies a tag (common when
+      # using a reusable + ACL-restricted key) — explicit --advertise-tags
+      # *overrides* the key's tags and will fail registration if the key's
+      # identity doesn't have permission for the new tag.
+      TS_EXTRA_ARGS: ${TS_EXTRA_ARGS:-}
       # Serve config is rendered into a file the sidecar reads; the frontend
       # service in the merged compose graph must be reachable as `frontend:80`.
       TS_SERVE_CONFIG: /config/serve.json

--- a/infra/tailscale/README.md
+++ b/infra/tailscale/README.md
@@ -5,8 +5,10 @@ Pattern for exposing an Offbook instance over HTTPS at a `*.ts.net` MagicDNS hos
 ## One-time setup
 
 1. Have a Tailscale account and tailnet.
-2. In the admin console, create a tag for Offbook nodes: `tag:offbook` (assign your user as the owner so you can mint keys for it).
-3. Mint a per-instance auth key, **tagged** `tag:offbook`. Reusable + ephemeral is fine for a personal tailnet; choose per your threat model.
+2. Decide how the sidecar nodes will be tagged. Two common shapes:
+   - **Reusable key with auto-applied tag (recommended):** define an Offbook tag in your ACL policy (e.g. `tag:offbook`) and mint a reusable + ephemeral key that auto-applies it. The sidecar inherits the tag automatically; leave `TS_EXTRA_ARGS` unset.
+   - **Untagged key + sidecar-side advertise:** mint an untagged key and set `TS_EXTRA_ARGS=--advertise-tags=tag:offbook` in your env file. Requires the key's identity to have permission for the tag, or registration fails.
+3. ACL recommendation: restrict whatever tag you use so Offbook nodes can only be reached by you, not the broader tailnet.
 
 ## Bring up an instance
 


### PR DESCRIPTION
Closes #261

## Summary
Default `TS_EXTRA_ARGS` to empty in `docker-compose.tailscale.yml` so reusable + auto-tagging auth keys (the common ACL-restricted setup) work without override conflicts. Document both setup shapes in the README and `.env.prod.example`.

## Why
Hardcoded `--advertise-tags=tag:offbook` overrides whatever tag a reusable auth key auto-applies, which fails registration when the key's identity lacks permission for the new tag.

## Test plan
- [ ] `docker compose -f docker-compose.yml -f docker-compose.tailscale.yml config` with `TS_AUTHKEY` + `TS_HOSTNAME` set (no `TS_EXTRA_ARGS`) shows `TS_EXTRA_ARGS: ''`.
- [ ] Same with `TS_EXTRA_ARGS=--advertise-tags=tag:offbook` exported shows that value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)