### PR TITLE
chore #264: restart policies on app services in tailscale override

### DIFF
--- a/docker-compose.tailscale.yml
+++ b/docker-compose.tailscale.yml
@@ -37,5 +37,17 @@ services:
       - frontend
     restart: unless-stopped
 
+  # Restart-policy overlays on the app services. The base docker-compose.yml
+  # leaves these unset (`no`) so the hot-reload dev workflow can bring
+  # containers up/down deliberately. When you're composing with this file
+  # you're running a long-lived deployment — surviving a Colima/Docker
+  # restart should not require manual intervention.
+  postgres:
+    restart: unless-stopped
+  backend:
+    restart: unless-stopped
+  frontend:
+    restart: unless-stopped
+
 volumes:
   tailscale_state:


### PR DESCRIPTION
Closes #264

## Summary
Add `restart: unless-stopped` overlays for `postgres`, `backend`, and `frontend` in `docker-compose.tailscale.yml` so a Tailscale-fronted deployment fully recovers from a Docker daemon restart, not just the sidecar.

## Why this file and not the base
The presence of `docker-compose.tailscale.yml` in a composition is already the signal "this is a long-lived deployment." Adding restart policies to the base `docker-compose.yml` would affect hot-reload dev and QA workflows, which intentionally come up and down via explicit `up`/`down`.

## Test plan
- [x] `docker compose -p offbook-dev --env-file .env.dev -f docker-compose.yml -f docker-compose.tailscale.yml config` shows `restart: unless-stopped` on all four services.
- [ ] Recreate the dev stack, kill Colima, restart Colima → all four containers come back without manual intervention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)