### PR TITLE
fix #266: tolerate portfolio 404 in Insights hook

### DIFF
--- a/frontend/src/hooks/useScopedInsights.ts
+++ b/frontend/src/hooks/useScopedInsights.ts
@@ -128,16 +128,27 @@ export function useScopedInsights(): Result {
 }
 
 async function loadPersonal(): Promise<InsightsData> {
-  const [summary, trend, portfolio, budgets, goals, accountsResp, categories] =
-    await Promise.all([
-      getDashboardSummary('current_month'),
-      getNetWorth(12),
-      getPortfolioSummary(),
-      listBudgets(),
-      listGoals(),
-      listAccounts({}),
-      listCategories(),
-    ])
+  // Portfolio summary is fetched alongside the required calls but tolerated
+  // via allSettled. The personal portfolio endpoint was removed per
+  // ADR-0013 — its position-based replacement lands in #238. Until then a
+  // missing Allocation band must not break the rest of Insights.
+  const [
+    summary,
+    trend,
+    budgets,
+    goals,
+    accountsResp,
+    categories,
+    portfolioResult,
+  ] = await Promise.all([
+    getDashboardSummary('current_month'),
+    getNetWorth(12),
+    listBudgets(),
+    listGoals(),
+    listAccounts({}),
+    listCategories(),
+    getPortfolioSummary().catch(() => null),
+  ])
 
   // Per-budget spend — fan out, drop silently on row failures so one
   // missing spend doesn't blank the band.
@@ -172,11 +183,13 @@ async function loadPersonal(): Promise<InsightsData> {
     spending: summary.spending,
     by_category: summary.by_category,
     net_worth_trend: trend.map((p) => ({ date: p.date.slice(0, 10), value: p.total })),
-    allocation: portfolio.by_asset_class.map((a) => ({
-      kind: a.asset_class,
-      value: a.market_value,
-      weight_pct: a.weight_pct,
-    })),
+    allocation: portfolioResult
+      ? portfolioResult.by_asset_class.map((a) => ({
+          kind: a.asset_class,
+          value: a.market_value,
+          weight_pct: a.weight_pct,
+        }))
+      : [],
     budgets: budgetRows,
     goals: goals.map((g) => ({
       id: g.id,


### PR DESCRIPTION
## Summary
- Fixes the dev-blocker reported live: `/insights` rendered a red "404 Not Found" banner because `getPortfolioSummary()` (called inside a top-level `Promise.all`) hits the removed `/investments/portfolio` endpoint and rejects the whole batch.
- Moves portfolio into the same `Promise.all` with `.catch(() => null)` and defaults `allocation: []` when missing. `AllocationBand` already shows "No investments yet…" for an empty allocation, so the Allocation band degrades cleanly until #238 ships the position-based aggregator.
- Household scope (`loadHousehold` via `getHouseholdAllocation`) was already going through the aggregator — unaffected.

## Test plan
- [x] `pnpm lint` clean
- [x] `pnpm build` clean
- [ ] Sign in on dev tailnet, load `/insights`, confirm 5 bands render (Allocation band shows the empty state)

Closes #266