### PR TITLE
fix #268: drop /investments route + sidebar entry (dissolved per ADR-0013)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -24,7 +24,6 @@ const TransactionsPage = lazy(() => import('./pages/TransactionsPage').then((m) 
 const RulesPage = lazy(() => import('./pages/RulesPage').then((m) => ({ default: m.RulesPage })))
 const BudgetsPage = lazy(() => import('./pages/BudgetsPage').then((m) => ({ default: m.BudgetsPage })))
 const SavingsGoalsPage = lazy(() => import('./pages/SavingsGoalsPage').then((m) => ({ default: m.SavingsGoalsPage })))
-const InvestmentsPage = lazy(() => import('./pages/InvestmentsPage').then((m) => ({ default: m.InvestmentsPage })))
 const SettingsPage = lazy(() => import('./pages/SettingsPage').then((m) => ({ default: m.SettingsPage })))
 const HouseholdMembersPage = lazy(() => import('./pages/HouseholdMembersPage').then((m) => ({ default: m.HouseholdMembersPage })))
 const HouseholdSettingsPage = lazy(() => import('./pages/HouseholdSettingsPage').then((m) => ({ default: m.HouseholdSettingsPage })))
@@ -72,7 +71,10 @@ export default function App() {
           <Route path="/rules" element={<LazyRoute><RulesPage /></LazyRoute>} />
           <Route path="/budgets" element={<LazyRoute><BudgetsPage /></LazyRoute>} />
           <Route path="/savings-goals" element={<LazyRoute><SavingsGoalsPage /></LazyRoute>} />
-          <Route path="/investments" element={<LazyRoute><InvestmentsPage /></LazyRoute>} />
+          {/* /investments was dissolved per ADR-0013 — allocation moved to
+              Insights, holdings to Accounts, trades to Transactions. Keep
+              the redirect so bookmarks survive (#268). */}
+          <Route path="/investments" element={<Navigate to="/insights" replace />} />
           {/* /ai is deferred in v6 — AI provider config lives in Settings.
               Redirect bookmarks to Settings rather than 404. */}
           <Route path="/ai" element={<Navigate to="/settings" replace />} />

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -7,7 +7,6 @@ import {
   Receipt,
   Settings,
   Target,
-  TrendingUp,
   Users,
   Wallet,
   X,
@@ -23,17 +22,18 @@ type NavItem = { to: string; label: string; icon: typeof LayoutDashboard }
 
 // Personal-scope routes — mutually exclusive with HOUSEHOLD_NAV per
 // .claude/rules/frontend.md (sidebar renders only the active scope's list).
-// v6 §07 names exactly seven surfaces here. "Connect Bank" + "Import"
+// v6 §07 names exactly six surfaces here. "Connect Bank" + "Import"
 // folded into /accounts/add; "Rules" lives within the Transactions flow
 // (create-from-row) rather than a top-level entry; "AI Advisor" deferred
-// — provider config lives in Settings.
+// — provider config lives in Settings. "Investments" dissolved per
+// ADR-0013 — allocation lives on Insights, holdings on Accounts, trades
+// in Transactions (#268).
 const PERSONAL_NAV: NavItem[] = [
   { to: '/insights',      label: 'Insights',      icon: LayoutDashboard },
   { to: '/accounts',      label: 'Accounts',      icon: Wallet },
   { to: '/transactions',  label: 'Transactions',  icon: Receipt },
   { to: '/budgets',       label: 'Budgets',       icon: Target },
   { to: '/savings-goals', label: 'Goals',         icon: PiggyBank },
-  { to: '/investments',   label: 'Investments',   icon: TrendingUp },
   { to: '/settings',      label: 'Settings',      icon: Settings },
 ]
 


### PR DESCRIPTION
## Summary
- Personal sidebar "Investments" → `/investments` → `InvestmentsPage` called `/investments` and `/investments/portfolio`, both removed per ADR-0013. Whole page was unusable.
- Per v6 IA the concept dissolves: allocation → Insights, holdings → Accounts, trades → Transactions.
- This PR redirects `/investments → /insights` so bookmarks land somewhere useful, and drops the sidebar entry. Page file + API client left in place (Insights still imports `getPortfolioSummary`, tolerated via #267). Proper deletion can ride with the position-based aggregator in M10b #238.

## QA context
Found during a live sweep of every personal + household page. Two real breakages: this one and #266 (Insights), both ADR-0013 fallout. Insights was fixed in #267; this is the second.

## Test plan
- [x] `pnpm lint` clean
- [x] `pnpm build` clean
- [ ] Reload dev tailnet: sidebar shows 6 entries (no Investments); visiting `/investments` lands on `/insights`.

Closes #268