### PR TITLE
L6 #276: AGENTS.md rule for route removal (epic #270)

### DIFF
--- a/.claude/rules/go-backend.md
+++ b/.claude/rules/go-backend.md
@@ -15,3 +15,4 @@ paths:
 - Auth: handlers derive `user_id` from the session, never from request body/query. Repositories that read user-owned tables take `user_id` as a parameter and filter on it.
 - Cross-user reads: only `internal/service/household/aggregator.go` may read across user_ids, and only within a single household via opt-in shares. New household-facing handlers under `/h/...` call the aggregator, never repositories.
 - The aggregator package must NEVER import `pii_repo` — same hard rule as `service/ai/`.
+- **Removing a handler / Register call requires migrating its frontend callers in the same PR.** See "Frontend↔Backend Contract Discipline" in AGENTS.md. `make contract-check` enforces this; the CI job fails fast if a route disappears from the backend but `frontend/src/api/*.ts` still references it.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,6 +82,11 @@ When running via Claude's Bash tool, prefix `make` with `command` (`command make
 - Instead: `gh issue create --title "..." --body "..." --label backlog`
 - Then return to current work
 
+## Frontend↔Backend Contract Discipline
+- **Removing a backend route requires removing or migrating every frontend caller in the same PR.** Bugs #266 and #268 both shipped because a route was deleted in isolation (M10a/#240 dropped the `/investments` wiring per ADR-0013) and the frontend kept calling it. Before deleting a handler or its Register call, grep `frontend/src/api/*.ts` for the URL string. If the replacement lands in a follow-on PR (e.g. ADR-0013 → M10b #238), either redirect the caller to the new route, render an explicit empty state, or temporarily wrap the call in `.catch(...)` so the page degrades — never leave a frontend caller pointed at a 404.
+- `make contract-check` (and the `Contract check` CI job) enforces this mechanically: every `apiClient.<method>('<path>')` in `frontend/src/api/*.ts` must map to a registered backend route. The check is sub-second and runs first inside `make verify`. If it fails, fix the contract — never silence the check.
+- The full layered test-gap plan that produced this rule lives in epic #270.
+
 ## Scopes & Households (M2.5+)
 - Every domain row (account, transaction, budget, savings goal, investment, AI thread) carries `user_id NOT NULL`. Always derive `user_id` from the session, never trust it in the request body.
 - Two scopes per user: **personal** (own book) and **household** (shared). Mutually exclusive route lists. Default at login: `household` if member of one, else `personal`. Persists per user in `users.last_scope`.


### PR DESCRIPTION
Sixth and last "policy" layer of the test-gap closure plan. Trivial doc change; tooling layers L1 + L3 already enforce mechanically.

## Summary
- New \`AGENTS.md\` section "Frontend↔Backend Contract Discipline" — the rule that would have prevented #266 and #268, written down once.
- One-line cross-reference in \`.claude/rules/go-backend.md\` so the rule surfaces when working in the backend tree.

## Why both?
Tooling (\`make contract-check\` + the CI job) catches violations mechanically — but the *intent* belongs in the prose so reviewers and Claude sessions see the rule before they get a CI failure and have to reverse-engineer why.

Closes #276