### PR TITLE
Tech Debt #286: prices UNIQUE(asset,quote,as_of,source) + idempotent ingest

### DIFF
--- a/backend/internal/repository/price_repo.go
+++ b/backend/internal/repository/price_repo.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/gregwym/offbook/backend/internal/model"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
 // PriceRepository is the data-access contract for the prices time series.
@@ -23,10 +24,12 @@ type PriceRepository interface {
 	// as_of ASC, within [from, to). Used by the net-worth trend chart.
 	ListHistory(ctx context.Context, assetID, quoteAssetID int64, from, to time.Time) ([]model.Price, error)
 
-	// Insert appends one price observation. Callers de-dupe on
-	// (asset_id, quote_asset_id, as_of, source) at the application layer
-	// when needed — the index doesn't enforce uniqueness because the same
-	// (asset, quote, as_of) may come from multiple sources.
+	// Insert appends one price observation, idempotently. The unique index
+	// uq_prices_asset_quote_asof_source keys on
+	// (asset_id, quote_asset_id, as_of, source), so re-ingesting the same
+	// observation upserts the price in place rather than duplicating the row.
+	// The same (asset, quote, as_of) may still come from multiple sources —
+	// those don't conflict.
 	Insert(ctx context.Context, p *model.Price) error
 }
 
@@ -64,5 +67,16 @@ func (r *priceRepo) ListHistory(ctx context.Context, assetID, quoteAssetID int64
 }
 
 func (r *priceRepo) Insert(ctx context.Context, p *model.Price) error {
-	return r.db.WithContext(ctx).Create(p).Error
+	// Idempotent on the unique key (asset_id, quote_asset_id, as_of, source):
+	// a re-ingest from the same source updates the price in place. Multiple
+	// sources for the same instant remain distinct rows.
+	return r.db.WithContext(ctx).
+		Clauses(clause.OnConflict{
+			Columns: []clause.Column{
+				{Name: "asset_id"}, {Name: "quote_asset_id"},
+				{Name: "as_of"}, {Name: "source"},
+			},
+			DoUpdates: clause.AssignmentColumns([]string{"price"}),
+		}).
+		Create(p).Error
 }

--- a/backend/migrations/000016_prices_unique.down.sql
+++ b/backend/migrations/000016_prices_unique.down.sql
@@ -1,0 +1,8 @@
+BEGIN;
+
+-- Reverse #286: drop the unique constraint, restore the non-unique lookup index.
+DROP INDEX IF EXISTS uq_prices_asset_quote_asof_source;
+
+CREATE INDEX ix_prices_lookup ON prices (asset_id, quote_asset_id, as_of DESC);
+
+COMMIT;

--- a/backend/migrations/000016_prices_unique.up.sql
+++ b/backend/migrations/000016_prices_unique.up.sql
@@ -1,0 +1,26 @@
+BEGIN;
+
+-- #286: dedup the prices time series and make price ingest idempotent.
+--
+-- prices was append-only with only a non-unique lookup index, so re-running
+-- a sync could insert duplicate (asset, quote, as_of, source) rows and the
+-- table grew unbounded. Add a unique constraint at the source-aware grain:
+-- the same (asset, quote, as_of) may legitimately come from multiple sources
+-- (e.g. a daily historical_snapshot and a future FX feed), so `source` is
+-- part of the key. Within one source, a re-ingest upserts in place
+-- (price_repo.Insert uses ON CONFLICT ... DO UPDATE).
+--
+-- The unique index's leading columns (asset_id, quote_asset_id, as_of)
+-- subsume the old ix_prices_lookup, so drop it — LatestPriceAt's
+-- "ORDER BY as_of DESC LIMIT 1" is served by a backward scan of the new
+-- index. Net-zero storage.
+--
+-- Pre-prod: dev DBs are wiped and rebuilt, so no dedup of existing rows is
+-- needed before the unique index is created.
+
+DROP INDEX IF EXISTS ix_prices_lookup;
+
+CREATE UNIQUE INDEX uq_prices_asset_quote_asof_source
+    ON prices (asset_id, quote_asset_id, as_of, source);
+
+COMMIT;


### PR DESCRIPTION
Closes #286

## What
- New migration `000016_prices_unique`: drops `ix_prices_lookup`, adds `UNIQUE(asset_id, quote_asset_id, as_of, source)` on `prices`.
- `price_repo.Insert` now upserts via `ON CONFLICT (asset_id, quote_asset_id, as_of, source) DO UPDATE SET price` — re-ingest from the same source is idempotent; multiple sources for the same instant stay distinct.

## Why
`prices` was append-only with no uniqueness, so syncs could duplicate points and the table grew unbounded. Source-aware grain preserves multi-source provenance (e.g. a daily `historical_snapshot` and a future FX feed) while killing within-source dupes.

## Notes
- The unique index subsumes the old lookup index (same leading columns), so it's net-zero storage; `LatestPriceAt`'s `ORDER BY as_of DESC LIMIT 1` uses a backward scan.
- Pre-prod: dev DBs wiped & rebuilt, so no existing-row dedup step.

## Verification
`make verify` green (backend race tests incl. `internal/db` migration-backfill which exercises the new index; frontend lint+build; contract-check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)