### PR TITLE
Tech Debt #285: scope categories by user_id (preventative)

### DIFF
--- a/backend/internal/handler/category_handler.go
+++ b/backend/internal/handler/category_handler.go
@@ -6,6 +6,7 @@ import (
 	"github.com/gin-gonic/gin"
 
 	"github.com/gregwym/offbook/backend/internal/service"
+	"github.com/gregwym/offbook/backend/internal/service/auth"
 )
 
 type CategoryHandler struct {
@@ -21,7 +22,8 @@ func (h *CategoryHandler) Register(g *gin.RouterGroup) {
 }
 
 func (h *CategoryHandler) List(c *gin.Context) {
-	cats, err := h.svc.List(c.Request.Context())
+	uid := auth.MustUserID(c.Request.Context())
+	cats, err := h.svc.List(c.Request.Context(), uid)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error(), "code": "INTERNAL"})
 		return

--- a/backend/internal/model/category.go
+++ b/backend/internal/model/category.go
@@ -10,6 +10,8 @@ type Category struct {
 	ID int64 `gorm:"primaryKey" json:"id"`
 	// UserID owns a user-created category; NULL means a system category
 	// (the seeded taxonomy). Reads are scoped to "user_id IS NULL OR = me".
+	// Intentionally no DB FK to users yet — see migration 000017 (added with
+	// category CRUD to avoid TRUNCATE-CASCADE wiping seeded categories).
 	UserID    *int64         `json:"user_id,omitempty"`
 	ParentID  *int64         `json:"parent_id,omitempty"`
 	Name      string         `gorm:"not null" json:"name"`

--- a/backend/internal/model/category.go
+++ b/backend/internal/model/category.go
@@ -7,7 +7,10 @@ import (
 )
 
 type Category struct {
-	ID        int64          `gorm:"primaryKey" json:"id"`
+	ID int64 `gorm:"primaryKey" json:"id"`
+	// UserID owns a user-created category; NULL means a system category
+	// (the seeded taxonomy). Reads are scoped to "user_id IS NULL OR = me".
+	UserID    *int64         `json:"user_id,omitempty"`
 	ParentID  *int64         `json:"parent_id,omitempty"`
 	Name      string         `gorm:"not null" json:"name"`
 	Slug      string         `gorm:"not null" json:"slug"`

--- a/backend/internal/repository/category_repo.go
+++ b/backend/internal/repository/category_repo.go
@@ -13,8 +13,14 @@ import (
 // for M2 we only need existence checks during transaction validation and a
 // future read for the frontend dropdown (#32).
 type CategoryRepository interface {
+	// GetByID fetches one category by id. Not user-scoped: today every
+	// category is a system row (user_id NULL). When category CRUD lands
+	// (#285), this must gain a user_id filter so a caller can't reference
+	// another user's private category.
 	GetByID(ctx context.Context, id int64) (*model.Category, error)
-	List(ctx context.Context) ([]model.Category, error)
+	// List returns the system taxonomy (user_id NULL) plus the caller's
+	// own categories.
+	List(ctx context.Context, userID int64) ([]model.Category, error)
 }
 
 type categoryRepo struct {
@@ -36,9 +42,11 @@ func (r *categoryRepo) GetByID(ctx context.Context, id int64) (*model.Category, 
 	return &c, nil
 }
 
-func (r *categoryRepo) List(ctx context.Context) ([]model.Category, error) {
+func (r *categoryRepo) List(ctx context.Context, userID int64) ([]model.Category, error) {
 	var out []model.Category
-	if err := r.db.WithContext(ctx).Order("name ASC").Find(&out).Error; err != nil {
+	if err := r.db.WithContext(ctx).
+		Where("user_id IS NULL OR user_id = ?", userID).
+		Order("name ASC").Find(&out).Error; err != nil {
 		return nil, err
 	}
 	return out, nil

--- a/backend/internal/repository/category_repo_test.go
+++ b/backend/internal/repository/category_repo_test.go
@@ -1,0 +1,81 @@
+package repository_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"gorm.io/gorm"
+
+	"github.com/gregwym/offbook/backend/internal/model"
+	"github.com/gregwym/offbook/backend/internal/repository"
+)
+
+// seedCategory inserts a user-owned category (user_id non-nil) and registers
+// cleanup. Returns the new category id.
+func seedCategory(t *testing.T, g *gorm.DB, userID int64, slug string) int64 {
+	t.Helper()
+	c := &model.Category{
+		UserID: &userID,
+		Name:   slug,
+		Slug:   slug,
+	}
+	if err := g.Create(c).Error; err != nil {
+		t.Fatalf("seed category: %v", err)
+	}
+	t.Cleanup(func() { g.Unscoped().Delete(&model.Category{}, c.ID) })
+	return c.ID
+}
+
+// TestCategoryRepo_List_ScopedByUser asserts List returns the system taxonomy
+// plus the caller's own categories, and never another user's. This is the
+// multi-tenant read guarantee for #285.
+func TestCategoryRepo_List_ScopedByUser(t *testing.T) {
+	g := openTestDB(t)
+	repo := repository.NewCategoryRepository(g)
+	ctx := context.Background()
+
+	userA := seedTestUser(t, g)
+	userB := seedTestUser(t, g)
+	stamp := time.Now().UnixNano()
+	catA := seedCategory(t, g, userA, fmt.Sprintf("cat-a-%d", stamp))
+	catB := seedCategory(t, g, userB, fmt.Sprintf("cat-b-%d", stamp))
+
+	listA, err := repo.List(ctx, userA)
+	if err != nil {
+		t.Fatalf("List(A): %v", err)
+	}
+
+	var sawA, sawB, sawSystem bool
+	for _, c := range listA {
+		switch {
+		case c.ID == catA:
+			sawA = true
+		case c.ID == catB:
+			sawB = true
+		case c.UserID == nil:
+			sawSystem = true
+		}
+	}
+	if !sawA {
+		t.Error("List(A) missing user A's own category")
+	}
+	if sawB {
+		t.Error("List(A) leaked user B's private category — multi-tenant violation")
+	}
+	if !sawSystem {
+		t.Error("List(A) missing seeded system categories (user_id NULL)")
+	}
+
+	// Symmetric check from B's side.
+	listB, err := repo.List(ctx, userB)
+	if err != nil {
+		t.Fatalf("List(B): %v", err)
+	}
+	for _, c := range listB {
+		if c.ID == catA {
+			t.Error("List(B) leaked user A's private category — multi-tenant violation")
+		}
+	}
+}

--- a/backend/internal/service/ai/context_builder.go
+++ b/backend/internal/service/ai/context_builder.go
@@ -196,7 +196,7 @@ func (b *ContextBuilder) Build(ctx context.Context, userID int64) (*Context, err
 		if err != nil {
 			return nil, fmt.Errorf("ai: list budgets: %w", err)
 		}
-		labels := b.categoryLabels(ctx)
+		labels := b.categoryLabels(ctx, userID)
 		for _, bud := range list {
 			if !bud.IsActive {
 				continue
@@ -262,11 +262,11 @@ func (b *ContextBuilder) Build(ctx context.Context, userID int64) (*Context, err
 // Empty map (rather than error) when the category service is missing or
 // errors — labels are nice-to-have; budget data is the load-bearing
 // signal.
-func (b *ContextBuilder) categoryLabels(ctx context.Context) map[int64]string {
+func (b *ContextBuilder) categoryLabels(ctx context.Context, userID int64) map[int64]string {
 	if b.categories == nil {
 		return map[int64]string{}
 	}
-	cats, err := b.categories.List(ctx)
+	cats, err := b.categories.List(ctx, userID)
 	if err != nil {
 		return map[int64]string{}
 	}

--- a/backend/internal/service/category_service.go
+++ b/backend/internal/service/category_service.go
@@ -7,9 +7,9 @@ import (
 	"github.com/gregwym/offbook/backend/internal/repository"
 )
 
-// CategoryService is intentionally thin — categories are shared lookup data
-// (seeded in migration 000002) with no per-user ownership. The repository
-// already returns canonically-ordered rows.
+// CategoryService is intentionally thin. Categories are the seeded system
+// taxonomy (migration 000002, user_id NULL) plus any user-owned categories
+// once CRUD ships (#285). List returns system rows plus the caller's own.
 type CategoryService struct {
 	repo repository.CategoryRepository
 }
@@ -18,6 +18,6 @@ func NewCategoryService(repo repository.CategoryRepository) *CategoryService {
 	return &CategoryService{repo: repo}
 }
 
-func (s *CategoryService) List(ctx context.Context) ([]model.Category, error) {
-	return s.repo.List(ctx)
+func (s *CategoryService) List(ctx context.Context, userID int64) ([]model.Category, error) {
+	return s.repo.List(ctx, userID)
 }

--- a/backend/migrations/000017_categories_user_id.down.sql
+++ b/backend/migrations/000017_categories_user_id.down.sql
@@ -1,0 +1,9 @@
+BEGIN;
+
+-- Reverse #285.
+DROP INDEX IF EXISTS ix_categories_user_id;
+DROP INDEX IF EXISTS uq_categories_slug;
+CREATE UNIQUE INDEX uq_categories_slug ON categories (slug) WHERE deleted_at IS NULL;
+ALTER TABLE categories DROP COLUMN IF EXISTS user_id;
+
+COMMIT;

--- a/backend/migrations/000017_categories_user_id.up.sql
+++ b/backend/migrations/000017_categories_user_id.up.sql
@@ -6,8 +6,15 @@ BEGIN;
 --
 -- NULL user_id = system category (the seeded taxonomy); non-null = owned by
 -- that user. is_system is retained and stays equivalent to (user_id IS NULL).
+--
+-- No FK to users(id) yet, deliberately: a categories→users FK makes the test
+-- suite's `TRUNCATE users ... CASCADE` also wipe the seeded system categories
+-- (and plaid_category_map, which FKs to categories), breaking unrelated
+-- packages. The FK is added with category CRUD (the real trigger), when the
+-- reset harness can be hardened to re-seed reference data. Until then user_id
+-- is a plain nullable column.
 ALTER TABLE categories
-    ADD COLUMN user_id BIGINT REFERENCES users(id);
+    ADD COLUMN user_id BIGINT;
 
 -- Slug uniqueness becomes per-owner. COALESCE(user_id, 0) buckets all system
 -- categories under owner "0" (real user ids start at 1), so system slugs stay

--- a/backend/migrations/000017_categories_user_id.up.sql
+++ b/backend/migrations/000017_categories_user_id.up.sql
@@ -1,0 +1,24 @@
+BEGIN;
+
+-- #285: give categories an owner so user-created categories can't collide in
+-- a global namespace once category CRUD ships. Latent today — categories are
+-- read-only and system-seeded (000002) — so this is preventative.
+--
+-- NULL user_id = system category (the seeded taxonomy); non-null = owned by
+-- that user. is_system is retained and stays equivalent to (user_id IS NULL).
+ALTER TABLE categories
+    ADD COLUMN user_id BIGINT REFERENCES users(id);
+
+-- Slug uniqueness becomes per-owner. COALESCE(user_id, 0) buckets all system
+-- categories under owner "0" (real user ids start at 1), so system slugs stay
+-- globally unique while each user gets an independent slug namespace.
+DROP INDEX IF EXISTS uq_categories_slug;
+CREATE UNIQUE INDEX uq_categories_slug
+    ON categories (COALESCE(user_id, 0), slug)
+    WHERE deleted_at IS NULL;
+
+CREATE INDEX ix_categories_user_id
+    ON categories (user_id)
+    WHERE deleted_at IS NULL AND user_id IS NOT NULL;
+
+COMMIT;


### PR DESCRIPTION
Closes #285

## What
- Migration `000017_categories_user_id`: adds nullable `categories.user_id` (NULL = system), replaces the global `uq_categories_slug` with a per-owner unique index `(COALESCE(user_id,0), slug) WHERE deleted_at IS NULL`, indexes `user_id`.
- `CategoryRepository.List` / `CategoryService.List` now take `userID` and return `WHERE user_id IS NULL OR user_id = ?` (system taxonomy + caller's own). Handler derives `userID` from the session; AI context-builder threads it through `categoryLabels`.
- Multi-tenant read test: `List(A)` returns A's own + system categories, never B's.

## Why
`categories` had no owner and a global slug namespace. Latent today (categories are read-only, system-seeded), but the moment category CRUD ships a user could claim a slug globally and leak it across tenants. This lays the ownership + scoping foundation first.

## Scope notes
- `is_system` retained; it stays equivalent to `user_id IS NULL`.
- `GetByID` left unscoped with a TODO — it only does existence checks against system rows today; it gains a `user_id` filter when CRUD lands.

## Verification
`make verify` green (contract-check, vet, lint, race tests incl. the new multi-tenant test, frontend build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)