### PR TITLE
Tech Debt #283: drop households.owner_id; role='owner' single source of truth

### DIFF
--- a/backend/internal/handler/household_handler.go
+++ b/backend/internal/handler/household_handler.go
@@ -584,6 +584,7 @@ func (h *HouseholdHandler) writeError(c *gin.Context, err error) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error(), "code": "INVALID_GOAL"})
 	case errors.Is(err, household.ErrEmptyName),
 		errors.Is(err, household.ErrInvalidRole),
+		errors.Is(err, household.ErrCannotPromoteToOwner),
 		errors.Is(err, household.ErrInvalidGrace),
 		errors.Is(err, household.ErrInvalidVisibility):
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error(), "code": "INVALID_REQUEST"})

--- a/backend/internal/model/household.go
+++ b/backend/internal/model/household.go
@@ -24,9 +24,11 @@ const (
 )
 
 type Household struct {
-	ID              int64          `gorm:"primaryKey" json:"id"`
-	Name            string         `gorm:"not null" json:"name"`
-	OwnerID         int64          `gorm:"not null" json:"owner_id"`
+	ID   int64  `gorm:"primaryKey" json:"id"`
+	Name string `gorm:"not null" json:"name"`
+	// Ownership is not stored here. The single source of truth is the
+	// household_members row with role='owner' (one active owner per
+	// household, enforced by uq_household_single_owner). See #283.
 	GracePeriodDays int            `gorm:"not null;default:30" json:"grace_period_days"`
 	CreatedAt       time.Time      `json:"created_at"`
 	UpdatedAt       time.Time      `json:"updated_at"`

--- a/backend/internal/service/household/aggregator_test.go
+++ b/backend/internal/service/household/aggregator_test.go
@@ -56,9 +56,11 @@ func newAggregator(t *testing.T) (*household.Aggregator, *gorm.DB) {
 // household and registers cleanup. Members are added separately.
 func seedHouseholdRow(t *testing.T, g *gorm.DB, ownerID int64, name string, grace int) *model.Household {
 	t.Helper()
+	// ownerID is retained in the signature for call-site clarity; ownership
+	// is established by the owner member row callers add separately (#283).
+	_ = ownerID
 	hh := &model.Household{
 		Name:            name + "-" + fmt.Sprintf("%d", time.Now().UnixNano()),
-		OwnerID:         ownerID,
 		GracePeriodDays: grace,
 	}
 	if err := g.Create(hh).Error; err != nil {

--- a/backend/internal/service/household/errors.go
+++ b/backend/internal/service/household/errors.go
@@ -9,10 +9,11 @@ var (
 	ErrInviteExpired         = errors.New("invite expired")
 	ErrInviteAlreadyAccepted = errors.New("invite already accepted")
 
-	ErrEmptyName         = errors.New("name must not be empty")
-	ErrInvalidRole       = errors.New("invalid role")
-	ErrInvalidGrace      = errors.New("grace_period_days must be >= 0")
-	ErrInvalidVisibility = errors.New("invalid visibility")
+	ErrEmptyName            = errors.New("name must not be empty")
+	ErrInvalidRole          = errors.New("invalid role")
+	ErrInvalidGrace         = errors.New("grace_period_days must be >= 0")
+	ErrInvalidVisibility    = errors.New("invalid visibility")
+	ErrCannotPromoteToOwner = errors.New("cannot promote to owner; use transfer-owner")
 
 	// Lifecycle / authorization
 	ErrForbidden        = errors.New("forbidden")

--- a/backend/internal/service/household/member_moderation_test.go
+++ b/backend/internal/service/household/member_moderation_test.go
@@ -100,6 +100,18 @@ func TestUpdateMemberRole_OwnerPromotesContributor(t *testing.T) {
 	}
 }
 
+// TestUpdateMemberRole_RejectsPromoteToOwner: the generic role editor must
+// not mint a second owner — ownership changes go through TransferOwner. The
+// single-owner invariant (uq_household_single_owner) is enforced at the
+// service layer here so the caller gets a clean 400, not a DB error (#283).
+func TestUpdateMemberRole_RejectsPromoteToOwner(t *testing.T) {
+	svc, ownerID, contribID, hhID := seedOwnerWithMember(t)
+	_, err := svc.UpdateMemberRole(context.Background(), ownerID, hhID, contribID, model.RoleOwner)
+	if !errors.Is(err, household.ErrCannotPromoteToOwner) {
+		t.Fatalf("err = %v, want ErrCannotPromoteToOwner", err)
+	}
+}
+
 func TestUpdateMemberRole_RejectsInvalidRole(t *testing.T) {
 	svc, ownerID, contribID, hhID := seedOwnerWithMember(t)
 	_, err := svc.UpdateMemberRole(context.Background(), ownerID, hhID, contribID, "superuser")

--- a/backend/internal/service/household/service.go
+++ b/backend/internal/service/household/service.go
@@ -145,7 +145,6 @@ func (s *Service) Create(ctx context.Context, userID int64, in CreateInput) (*mo
 
 	h := &model.Household{
 		Name:            name,
-		OwnerID:         userID,
 		GracePeriodDays: grace,
 	}
 	if err := s.households.Create(ctx, h); err != nil {
@@ -489,6 +488,12 @@ func (s *Service) UpdateMemberRole(ctx context.Context, userID, householdID, tar
 	if !isValidRole(role) {
 		return nil, ErrInvalidRole
 	}
+	// Ownership changes go through TransferOwner, which atomically demotes
+	// the current owner. The generic role editor must never mint a second
+	// owner (uq_household_single_owner would reject it at the DB anyway).
+	if role == model.RoleOwner {
+		return nil, ErrCannotPromoteToOwner
+	}
 	if targetUserID == userID {
 		return nil, ErrCannotModifySelf
 	}
@@ -557,9 +562,10 @@ func (s *Service) RemoveMember(ctx context.Context, userID, householdID, targetU
 
 // TransferOwner promotes targetUserID to owner and demotes the caller to
 // contributor. Caller must be the current owner. Target must be an active
-// member of this household. Both role updates AND the households.owner_id
-// flip happen in a single DB transaction so a mid-flight failure can't
-// produce a "two owners" or "owner_id mismatches role" intermediate state.
+// member of this household. Both role updates happen in a single DB
+// transaction so a mid-flight failure can't produce a "two owners" or
+// "zero owners" intermediate state. Ownership lives solely in the member
+// role now (#283) — there is no households.owner_id to keep in sync.
 //
 // Self-transfer is rejected (no-op anyway). After the transfer the caller
 // is no longer the owner — they may then call Leave if they want to exit
@@ -590,16 +596,11 @@ func (s *Service) TransferOwner(ctx context.Context, callerID, householdID, targ
 	}
 
 	return s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
-		// 1. Promote target to owner.
-		if res := tx.Model(&model.HouseholdMember{}).
-			Where("id = ? AND left_at IS NULL AND purged_at IS NULL", target.ID).
-			Update("role", model.RoleOwner); res.Error != nil {
-			return fmt.Errorf("promote target: %w", res.Error)
-		} else if res.RowsAffected == 0 {
-			return ErrMemberNotFound
-		}
-		// 2. Demote caller to contributor (chosen over view_only — the
-		// previous owner deserves write access by default).
+		// Demote the caller FIRST, then promote the target. The
+		// uq_household_single_owner partial index permits only one active
+		// owner per household, so the two updates must never leave two
+		// owner rows visible at once — demote-then-promote keeps the owner
+		// count at 1→0→1 rather than 1→2→1.
 		if res := tx.Model(&model.HouseholdMember{}).
 			Where("id = ? AND left_at IS NULL AND purged_at IS NULL", caller.ID).
 			Update("role", model.RoleContributor); res.Error != nil {
@@ -607,13 +608,12 @@ func (s *Service) TransferOwner(ctx context.Context, callerID, householdID, targ
 		} else if res.RowsAffected == 0 {
 			return ErrForbidden
 		}
-		// 3. Flip the owner_id on the household row to match.
-		if res := tx.Model(&model.Household{}).
-			Where("id = ?", householdID).
-			Update("owner_id", targetUserID); res.Error != nil {
-			return fmt.Errorf("update owner_id: %w", res.Error)
+		if res := tx.Model(&model.HouseholdMember{}).
+			Where("id = ? AND left_at IS NULL AND purged_at IS NULL", target.ID).
+			Update("role", model.RoleOwner); res.Error != nil {
+			return fmt.Errorf("promote target: %w", res.Error)
 		} else if res.RowsAffected == 0 {
-			return ErrHouseholdNotFound
+			return ErrMemberNotFound
 		}
 		return nil
 	})

--- a/backend/internal/service/household/service_test.go
+++ b/backend/internal/service/household/service_test.go
@@ -177,12 +177,10 @@ func TestCreate_CreatorBecomesOwner(t *testing.T) {
 	}
 	cleanupHousehold(t, g, hh.ID)
 
-	if hh.OwnerID != userID {
-		t.Errorf("OwnerID = %d, want %d", hh.OwnerID, userID)
-	}
 	if hh.GracePeriodDays != grace {
 		t.Errorf("GracePeriodDays = %d, want %d", hh.GracePeriodDays, grace)
 	}
+	// Ownership lives in the member role now (#283), asserted below.
 	detail, err := svc.Get(ctx, userID, hh.ID)
 	if err != nil {
 		t.Fatalf("Get: %v", err)

--- a/backend/internal/service/household/transfer_owner_test.go
+++ b/backend/internal/service/household/transfer_owner_test.go
@@ -10,7 +10,8 @@ import (
 )
 
 // TestTransferOwner_HappyPath: owner promotes a contributor; the promotion
-// flips both roles AND households.owner_id atomically.
+// atomically demotes the old owner and promotes the new one. Ownership lives
+// solely in the member role (#283).
 func TestTransferOwner_HappyPath(t *testing.T) {
 	svc, ownerID, contribID, hhID := seedOwnerWithMember(t)
 	ctx := context.Background()
@@ -26,9 +27,6 @@ func TestTransferOwner_HappyPath(t *testing.T) {
 	}
 	if asOldOwner.Role != model.RoleContributor {
 		t.Errorf("old owner role = %q, want contributor", asOldOwner.Role)
-	}
-	if asOldOwner.Household.OwnerID != contribID {
-		t.Errorf("Household.OwnerID = %d, want %d (new owner)", asOldOwner.Household.OwnerID, contribID)
 	}
 	// New owner sees themselves as owner.
 	asNewOwner, err := svc.Get(ctx, contribID, hhID)

--- a/backend/migrations/000018_household_single_owner.down.sql
+++ b/backend/migrations/000018_household_single_owner.down.sql
@@ -1,0 +1,17 @@
+BEGIN;
+
+-- Reverse #283: restore owner_id, backfilled from the active owner member.
+DROP INDEX IF EXISTS uq_household_single_owner;
+
+ALTER TABLE households ADD COLUMN owner_id BIGINT REFERENCES users(id);
+UPDATE households h
+   SET owner_id = (
+       SELECT hm.user_id FROM household_members hm
+        WHERE hm.household_id = h.id
+          AND hm.role = 'owner'
+          AND hm.purged_at IS NULL
+        LIMIT 1
+   );
+ALTER TABLE households ALTER COLUMN owner_id SET NOT NULL;
+
+COMMIT;

--- a/backend/migrations/000018_household_single_owner.up.sql
+++ b/backend/migrations/000018_household_single_owner.up.sql
@@ -1,0 +1,17 @@
+BEGIN;
+
+-- #283: households.owner_id duplicated household_members.role='owner'.
+--
+-- role is the RBAC backbone (owner | contributor | view_only) and the only
+-- ownership signal auth actually reads (the LAST_OWNER guard counts
+-- role='owner' rows). owner_id was write-only and forced keeping two sources
+-- in sync on every transfer. Drop it; make role='owner' the single source of
+-- truth, with a partial unique index guaranteeing exactly one active owner
+-- per household.
+ALTER TABLE households DROP COLUMN IF EXISTS owner_id;
+
+CREATE UNIQUE INDEX uq_household_single_owner
+    ON household_members (household_id)
+    WHERE role = 'owner' AND purged_at IS NULL;
+
+COMMIT;

--- a/frontend/src/types/household.ts
+++ b/frontend/src/types/household.ts
@@ -6,7 +6,8 @@ export type HouseholdRole = 'owner' | 'contributor' | 'view_only'
 export type Household = {
   id: number
   name: string
-  owner_id: number
+  // Ownership is not a household field — it's the member with role 'owner'
+  // (single source of truth, backend #283).
   grace_period_days: number
   created_at: string
   updated_at: string


### PR DESCRIPTION
Closes #283

## What
- Migration `000018_household_single_owner`: drops `households.owner_id`, adds `uq_household_single_owner` — a partial unique index `ON household_members (household_id) WHERE role='owner' AND purged_at IS NULL` (exactly one active owner per household).
- `TransferOwner` reordered to **demote-then-promote** so the owner count goes 1→0→1 (the index would reject the old 1→2→1 transient two-owner state); the `owner_id` flip step is gone.
- `UpdateMemberRole` now rejects `role='owner'` with `ErrCannotPromoteToOwner` (400) — ownership changes go through `TransferOwner`, so the generic role editor can't mint a second owner (which would otherwise surface as a raw DB unique-violation 500).
- Frontend `Household` type drops `owner_id` (it was declared but never rendered).

## Why
`owner_id` duplicated `role='owner'`. `role` is the actual RBAC backbone and the only ownership signal auth reads (the `LAST_OWNER` guard counts `role='owner'`); `owner_id` was write-only and had to be kept in sync on transfer (the old code even apologized for it in a comment). One source of truth now.

## Tests
- New `TestUpdateMemberRole_RejectsPromoteToOwner`.
- `TransferOwner` happy-path updated to assert role swap (not `owner_id`).
- `make verify` green (contract-check, vet, lint, race tests, frontend build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)