### PR TITLE
Tech Debt #284: drop accounts.currency; derive from primary_quote_asset

### DIFF
--- a/backend/internal/model/account.go
+++ b/backend/internal/model/account.go
@@ -11,12 +11,16 @@ import (
 // currency — never read from a stored balance column. AccountType is a
 // display hint (which UI to render), not a data-shape switch.
 type Account struct {
-	ID                  int64          `gorm:"primaryKey" json:"id"`
-	UserID              int64          `gorm:"not null" json:"user_id"`
-	Name                string         `gorm:"not null" json:"name"`
-	InstitutionSlug     string         `gorm:"not null" json:"institution_slug"`
-	AccountType         string         `gorm:"not null" json:"account_type"`
-	Currency            string         `gorm:"not null;default:USD" json:"currency"`
+	ID              int64  `gorm:"primaryKey" json:"id"`
+	UserID          int64  `gorm:"not null" json:"user_id"`
+	Name            string `gorm:"not null" json:"name"`
+	InstitutionSlug string `gorm:"not null" json:"institution_slug"`
+	AccountType     string `gorm:"not null" json:"account_type"`
+	// Currency is derived, not stored (#284). The single source of truth is
+	// PrimaryQuoteAssetID; for a fiat asset assets.symbol IS the currency
+	// code. gorm:"-" keeps it out of reads/writes; the service hydrates it
+	// from the asset on read, and Create/Update set it from the request.
+	Currency            string         `gorm:"-" json:"currency"`
 	PrimaryQuoteAssetID int64          `gorm:"column:primary_quote_asset_id;not null" json:"primary_quote_asset_id"`
 	LastFour            *string        `json:"last_four,omitempty"`
 	PlaidAccountID      *string        `gorm:"column:plaid_account_id" json:"plaid_account_id,omitempty"`

--- a/backend/internal/repository/household_aggregator_repo.go
+++ b/backend/internal/repository/household_aggregator_repo.go
@@ -438,14 +438,15 @@ func (r *householdAggregatorRepo) AccountBalances(ctx context.Context, accountID
 		SELECT a.id           AS account_id,
 		       a.name         AS name,
 		       a.account_type AS account_type,
-		       a.currency     AS currency,
+		       qa.symbol      AS currency,
 		       a.user_id      AS owner_user_id,
 		       COALESCE(SUM(`+fmt.Sprintf(positionValueExpr, "")+`), 0)::text AS balance
 		FROM accounts a
-		JOIN users     u ON u.id = a.user_id
+		JOIN users     u  ON u.id = a.user_id
+		JOIN assets    qa ON qa.id = a.primary_quote_asset_id
 		LEFT JOIN positions p ON p.deleted_at IS NULL AND p.account_id = a.id
 		WHERE a.deleted_at IS NULL AND a.id IN ?
-		GROUP BY a.id, a.name, a.account_type, a.currency, a.user_id
+		GROUP BY a.id, a.name, a.account_type, qa.symbol, a.user_id
 		ORDER BY a.id
 	`, accountIDs).Scan(&rows).Error
 	if err != nil {

--- a/backend/internal/service/account_service.go
+++ b/backend/internal/service/account_service.go
@@ -157,11 +157,46 @@ func (s *AccountService) Get(ctx context.Context, userID, id int64) (*model.Acco
 		}
 		return nil, err
 	}
+	if err := s.hydrateCurrency(ctx, a); err != nil {
+		return nil, err
+	}
 	return a, nil
 }
 
 func (s *AccountService) List(ctx context.Context, userID int64, f repository.AccountFilter) ([]model.Account, int64, error) {
-	return s.repo.List(ctx, userID, f)
+	accounts, total, err := s.repo.List(ctx, userID, f)
+	if err != nil {
+		return nil, 0, err
+	}
+	ptrs := make([]*model.Account, len(accounts))
+	for i := range accounts {
+		ptrs[i] = &accounts[i]
+	}
+	if err := s.hydrateCurrency(ctx, ptrs...); err != nil {
+		return nil, 0, err
+	}
+	return accounts, total, nil
+}
+
+// hydrateCurrency fills each account's derived Currency from its primary
+// quote asset's symbol (#284 — currency is no longer a stored column). One
+// asset-table read serves any number of accounts, so List stays O(1) queries.
+func (s *AccountService) hydrateCurrency(ctx context.Context, accts ...*model.Account) error {
+	if len(accts) == 0 {
+		return nil
+	}
+	assets, err := s.assetRepo.List(ctx)
+	if err != nil {
+		return fmt.Errorf("load assets for currency: %w", err)
+	}
+	symbolByID := make(map[int64]string, len(assets))
+	for _, a := range assets {
+		symbolByID[a.ID] = a.Symbol
+	}
+	for _, a := range accts {
+		a.Currency = symbolByID[a.PrimaryQuoteAssetID]
+	}
+	return nil
 }
 
 func (s *AccountService) Update(ctx context.Context, userID, id int64, in UpdateAccountInput) (*model.Account, error) {
@@ -170,6 +205,11 @@ func (s *AccountService) Update(ctx context.Context, userID, id int64, in Update
 		if errors.Is(err, repository.ErrNotFound) {
 			return nil, ErrAccountNotFound
 		}
+		return nil, err
+	}
+	// Populate the derived Currency from the asset so the "currency changed?"
+	// check below and the response reflect the existing value (#284).
+	if err := s.hydrateCurrency(ctx, a); err != nil {
 		return nil, err
 	}
 

--- a/backend/internal/service/account_service_test.go
+++ b/backend/internal/service/account_service_test.go
@@ -253,3 +253,34 @@ func tcSuffix(i int) string {
 	const letters = "abcdefghijklmnopqrstuvwxyz"
 	return string(letters[i%len(letters)]) + time.Now().Format("150405.000000")
 }
+
+// TestAccountService_CurrencyDerivedFromAsset proves currency is no longer a
+// stored column (#284): after Create, Get/List resolve it from the account's
+// primary quote asset symbol, not a persisted accounts.currency value.
+func TestAccountService_CurrencyDerivedFromAsset(t *testing.T) {
+	svc, userID, _ := newAccountSvc(t)
+	ctx := context.Background()
+
+	in := validInput(tcSuffix(0))
+	in.Currency = "EUR"
+	created, err := svc.Create(ctx, userID, in)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if created.Currency != "EUR" {
+		t.Errorf("create response currency = %q, want EUR", created.Currency)
+	}
+
+	// Read back via the service — currency must be hydrated from the asset,
+	// since the accounts.currency column no longer exists.
+	got, err := svc.Get(ctx, userID, created.ID)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.Currency != "EUR" {
+		t.Errorf("get currency = %q, want EUR (derived from primary_quote_asset)", got.Currency)
+	}
+	if got.PrimaryQuoteAssetID == 0 {
+		t.Error("primary_quote_asset_id not set")
+	}
+}

--- a/backend/migrations/000019_drop_accounts_currency.down.sql
+++ b/backend/migrations/000019_drop_accounts_currency.down.sql
@@ -1,0 +1,10 @@
+BEGIN;
+
+-- Restore accounts.currency, backfilled from the primary quote asset's symbol.
+ALTER TABLE accounts ADD COLUMN currency TEXT NOT NULL DEFAULT 'USD';
+UPDATE accounts a
+   SET currency = ass.symbol
+  FROM assets ass
+ WHERE ass.id = a.primary_quote_asset_id;
+
+COMMIT;

--- a/backend/migrations/000019_drop_accounts_currency.up.sql
+++ b/backend/migrations/000019_drop_accounts_currency.up.sql
@@ -1,0 +1,12 @@
+BEGIN;
+
+-- #284: accounts.currency duplicated primary_quote_asset_id. For a fiat asset
+-- assets.symbol IS the currency code, so accounts.currency was always equal to
+-- (SELECT symbol FROM assets WHERE id = accounts.primary_quote_asset_id). The
+-- asset FK is the single source of truth; the string column is derived.
+--
+-- Currency is now resolved from the asset on read (service hydration + the
+-- household aggregator joins assets). API/UI still see a `currency` field.
+ALTER TABLE accounts DROP COLUMN IF EXISTS currency;
+
+COMMIT;


### PR DESCRIPTION
Closes #284

## What
- Migration `000019`: drops `accounts.currency`.
- `model.Account.Currency` is now `gorm:"-"` — derived, not stored, still serialized as `currency` so the API and frontend are unchanged.
- `AccountService` hydrates `Currency` from the primary-quote-asset symbol on `Get`/`List`/`Update` (one `assets` read per call — no N+1 on List); `Create`/`Update` set it from the request.
- Household aggregator `AccountBalances` joins `assets` for the symbol instead of reading `a.currency`.

## Why
`accounts.currency` duplicated `primary_quote_asset_id`. For a fiat asset `assets.symbol` **is** the currency code, so the column was always redundant. It used to be the *source* (the FK was derived from it via a `BeforeCreate` hook) — this inverts that so the asset FK is the single source of truth.

## Notes
- Frontend untouched — `currency` is still on account responses, now derived server-side.
- Pre-existing/out of scope: `AccountsPage.tsx`/`InsightsPage.tsx` still reference `a.balance` (dropped in M10) — separate dead-field cleanup, not touched here.

## Verification
`go clean -testcache && make verify` green (so the plaid/integration packages re-ran for real, not from cache). New `TestAccountService_CurrencyDerivedFromAsset` asserts `Get` returns the derived currency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)