### PR TITLE
#293 (slice 1): opening balance as an opening_balance ledger transaction

### DIFF
--- a/backend/internal/repository/budget_repo.go
+++ b/backend/internal/repository/budget_repo.go
@@ -114,6 +114,7 @@ func (r *budgetRepo) SpendByCategoryInRange(ctx context.Context, userID int64, c
 		  AND user_id = ?
 		  AND category_id IN ?
 		  AND is_transfer = FALSE
+		  AND kind NOT IN ('opening_balance', 'adjustment')
 		  AND transaction_date >= ?
 		  AND transaction_date <  ?
 		GROUP BY category_id
@@ -145,6 +146,7 @@ func (r *budgetRepo) CurrentPeriodSpend(ctx context.Context, userID, categoryID 
 		  AND user_id = ?
 		  AND category_id = ?
 		  AND is_transfer = FALSE
+		  AND kind NOT IN ('opening_balance', 'adjustment')
 		  AND transaction_date >= ?
 		  AND transaction_date <  ?
 	`, userID, categoryID, from, to).Scan(&s).Error

--- a/backend/internal/repository/dashboard_repo.go
+++ b/backend/internal/repository/dashboard_repo.go
@@ -154,6 +154,7 @@ func (r *dashboardRepo) Summarize(ctx context.Context, userID int64, from, to ti
 		FROM transactions
 		WHERE deleted_at IS NULL
 		  AND user_id = ?
+		  AND kind NOT IN ('opening_balance', 'adjustment')
 		  AND transaction_date >= ?
 		  AND transaction_date <  ?
 	`, userID, from, to).Scan(&ie).Error; err != nil {
@@ -232,6 +233,7 @@ func (r *dashboardRepo) SpendByCategory(ctx context.Context, userID int64, from,
 		WHERE t.deleted_at IS NULL
 		  AND t.user_id = ?
 		  AND t.is_transfer = FALSE
+		  AND t.kind NOT IN ('opening_balance', 'adjustment')
 		  AND t.amount < 0
 		  AND t.transaction_date >= ?
 		  AND t.transaction_date <  ?
@@ -292,6 +294,7 @@ func (r *dashboardRepo) CashFlowByMonth(ctx context.Context, userID int64, now t
 		WHERE deleted_at IS NULL
 		  AND user_id = ?
 		  AND is_transfer = FALSE
+		  AND kind NOT IN ('opening_balance', 'adjustment')
 		  AND transaction_date >= ?
 		  AND transaction_date <  ?
 		GROUP BY date_trunc('month', transaction_date)

--- a/backend/internal/repository/household_aggregator_repo.go
+++ b/backend/internal/repository/household_aggregator_repo.go
@@ -209,6 +209,7 @@ func (r *householdAggregatorRepo) PeriodIncomeSpending(ctx context.Context, acco
 		FROM transactions
 		WHERE deleted_at IS NULL
 		  AND account_id IN ?
+		  AND kind NOT IN ('opening_balance', 'adjustment')
 		  AND transaction_date >= ?
 		  AND transaction_date <  ?
 	`, accountIDs, from, to).Scan(&ie).Error
@@ -254,6 +255,7 @@ func (r *householdAggregatorRepo) CategoryAggregates(ctx context.Context, accoun
 		LEFT JOIN categories c ON c.id = t.category_id
 		WHERE t.deleted_at IS NULL
 		  AND t.account_id IN ?
+		  AND t.kind NOT IN ('opening_balance', 'adjustment')
 		  AND t.transaction_date >= ?
 		  AND t.transaction_date <  ?
 		GROUP BY t.category_id, c.name
@@ -289,6 +291,7 @@ func (r *householdAggregatorRepo) SpendingByCategory(ctx context.Context, accoun
 		WHERE deleted_at IS NULL
 		  AND account_id IN ?
 		  AND category_id = ?
+		  AND kind NOT IN ('opening_balance', 'adjustment')
 		  AND transaction_date >= ?
 		  AND transaction_date <  ?
 	`, accountIDs, categoryID, from, to).Scan(&s).Error

--- a/backend/internal/service/account_service.go
+++ b/backend/internal/service/account_service.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/shopspring/decimal"
 	"gorm.io/gorm"
@@ -131,6 +132,25 @@ func (s *AccountService) Create(ctx context.Context, userID int64, in CreateAcco
 			return fmt.Errorf("create account: %w", err)
 		}
 		if !in.OpeningBalance.IsZero() {
+			// Record the opening balance as a real ledger fact (ADR-0017):
+			// an opening_balance transaction is the anchor the position folds
+			// from. kind=opening_balance keeps it out of spending/cash-flow/
+			// budget analytics while still counting toward net worth.
+			txRepo := repository.NewTransactionRepository(tx)
+			desc := "Opening balance"
+			openingTx := &model.Transaction{
+				UserID:          userID,
+				AccountID:       a.ID,
+				AssetID:         asset.ID,
+				Kind:            model.KindOpeningBalance,
+				Amount:          in.OpeningBalance,
+				Description:     &desc,
+				TransactionDate: time.Now().UTC(),
+				Source:          "manual",
+			}
+			if err := txRepo.Create(ctx, openingTx); err != nil {
+				return fmt.Errorf("seed opening balance transaction: %w", err)
+			}
 			posRepo := repository.NewPositionRepository(tx)
 			pos := &model.Position{
 				UserID:    userID,

--- a/backend/internal/service/account_service_test.go
+++ b/backend/internal/service/account_service_test.go
@@ -284,3 +284,41 @@ func TestAccountService_CurrencyDerivedFromAsset(t *testing.T) {
 		t.Error("primary_quote_asset_id not set")
 	}
 }
+
+// TestAccountService_Create_OpeningBalanceIsLedgerFact: an opening balance is
+// recorded as an opening_balance transaction (ADR-0017) that counts toward
+// net worth but is excluded from income/spending flow analytics. (#293)
+func TestAccountService_Create_OpeningBalanceIsLedgerFact(t *testing.T) {
+	svc, userID, g := newAccountSvc(t)
+	ctx := context.Background()
+
+	in := validInput(tcSuffix(7))
+	in.OpeningBalance = decimal.NewFromInt(1000)
+	acct, err := svc.Create(ctx, userID, in)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	// The anchor is a real ledger row tagged opening_balance.
+	var tx model.Transaction
+	if err := g.Where("account_id = ? AND kind = ?", acct.ID, model.KindOpeningBalance).
+		First(&tx).Error; err != nil {
+		t.Fatalf("opening_balance transaction not found: %v", err)
+	}
+	if !tx.Amount.Equal(decimal.NewFromInt(1000)) {
+		t.Errorf("opening_balance amount = %s, want 1000", tx.Amount)
+	}
+
+	// Counts toward net worth (positions × price) but NOT income/spending.
+	dash := repository.NewDashboardRepository(g)
+	agg, err := dash.Summarize(ctx, userID, time.Now().AddDate(0, -1, 0), time.Now().AddDate(0, 0, 1))
+	if err != nil {
+		t.Fatalf("summarize: %v", err)
+	}
+	if !agg.NetWorth.Equal(decimal.NewFromInt(1000)) {
+		t.Errorf("net worth = %s, want 1000 (opening balance counts)", agg.NetWorth)
+	}
+	if !agg.Income.IsZero() || !agg.Spending.IsZero() {
+		t.Errorf("income=%s spending=%s, want 0/0 (opening_balance excluded from flow)", agg.Income, agg.Spending)
+	}
+}


### PR DESCRIPTION
Refs #293 (incremental slice 1 of 3 — does not close it)

## What
First slice of the event-sourcing work (ADR-0017), kept deliberately small and safe.

- `AccountService.Create` writes an **`opening_balance` transaction** (the anchor fact) alongside the seeded position when an account is created with an opening balance — instead of only writing the position.
- The value-aggregating **flow queries now exclude `kind IN ('opening_balance','adjustment')`** so the anchor never reads as income/spending:
  - dashboard: `Summarize` income/spending, `SpendByCategory`, `CashFlowByMonth`
  - budget: `SpendByCategoryInRange`, `CurrentPeriodSpend`
  - household: `PeriodIncomeSpending`, `CategoryAggregates`, `SpendingByCategory`

## Scope boundaries (intentional)
- **Not** touched: transaction COUNT queries and `NetWorthByMonth` — opening_balance correctly counts toward net worth.
- **Not** touched: `trade_leg` flow behavior. Switching the flow filter from `is_transfer` to `kind = 'flow'` (which also fixes the latent trade-leg-in-spending leak) is **slice 3**, with its own test updates.
- Plaid reconciliation (`account_balance_observations` + `adjustment` generation) is **slice 2**.

## Safety
No existing test creates a non-zero opening balance via the service, so the exclusions change **zero** existing assertions. `go clean -testcache && make verify` green. New test asserts the opening balance counts toward net worth but not income/spending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)