### PR TITLE
#293 (slice 3): flow analytics filter -> kind='flow' (fixes trade-leg-in-spending leak)

### DIFF
--- a/backend/internal/repository/budget_repo.go
+++ b/backend/internal/repository/budget_repo.go
@@ -114,7 +114,7 @@ func (r *budgetRepo) SpendByCategoryInRange(ctx context.Context, userID int64, c
 		  AND user_id = ?
 		  AND category_id IN ?
 		  AND is_transfer = FALSE
-		  AND kind NOT IN ('opening_balance', 'adjustment')
+		  AND kind = 'flow'
 		  AND transaction_date >= ?
 		  AND transaction_date <  ?
 		GROUP BY category_id
@@ -146,7 +146,7 @@ func (r *budgetRepo) CurrentPeriodSpend(ctx context.Context, userID, categoryID 
 		  AND user_id = ?
 		  AND category_id = ?
 		  AND is_transfer = FALSE
-		  AND kind NOT IN ('opening_balance', 'adjustment')
+		  AND kind = 'flow'
 		  AND transaction_date >= ?
 		  AND transaction_date <  ?
 	`, userID, categoryID, from, to).Scan(&s).Error

--- a/backend/internal/repository/dashboard_repo.go
+++ b/backend/internal/repository/dashboard_repo.go
@@ -154,7 +154,7 @@ func (r *dashboardRepo) Summarize(ctx context.Context, userID int64, from, to ti
 		FROM transactions
 		WHERE deleted_at IS NULL
 		  AND user_id = ?
-		  AND kind NOT IN ('opening_balance', 'adjustment')
+		  AND kind = 'flow'
 		  AND transaction_date >= ?
 		  AND transaction_date <  ?
 	`, userID, from, to).Scan(&ie).Error; err != nil {
@@ -233,7 +233,7 @@ func (r *dashboardRepo) SpendByCategory(ctx context.Context, userID int64, from,
 		WHERE t.deleted_at IS NULL
 		  AND t.user_id = ?
 		  AND t.is_transfer = FALSE
-		  AND t.kind NOT IN ('opening_balance', 'adjustment')
+		  AND t.kind = 'flow'
 		  AND t.amount < 0
 		  AND t.transaction_date >= ?
 		  AND t.transaction_date <  ?
@@ -294,7 +294,7 @@ func (r *dashboardRepo) CashFlowByMonth(ctx context.Context, userID int64, now t
 		WHERE deleted_at IS NULL
 		  AND user_id = ?
 		  AND is_transfer = FALSE
-		  AND kind NOT IN ('opening_balance', 'adjustment')
+		  AND kind = 'flow'
 		  AND transaction_date >= ?
 		  AND transaction_date <  ?
 		GROUP BY date_trunc('month', transaction_date)

--- a/backend/internal/repository/household_aggregator_repo.go
+++ b/backend/internal/repository/household_aggregator_repo.go
@@ -209,7 +209,7 @@ func (r *householdAggregatorRepo) PeriodIncomeSpending(ctx context.Context, acco
 		FROM transactions
 		WHERE deleted_at IS NULL
 		  AND account_id IN ?
-		  AND kind NOT IN ('opening_balance', 'adjustment')
+		  AND kind = 'flow'
 		  AND transaction_date >= ?
 		  AND transaction_date <  ?
 	`, accountIDs, from, to).Scan(&ie).Error
@@ -255,7 +255,7 @@ func (r *householdAggregatorRepo) CategoryAggregates(ctx context.Context, accoun
 		LEFT JOIN categories c ON c.id = t.category_id
 		WHERE t.deleted_at IS NULL
 		  AND t.account_id IN ?
-		  AND t.kind NOT IN ('opening_balance', 'adjustment')
+		  AND t.kind = 'flow'
 		  AND t.transaction_date >= ?
 		  AND t.transaction_date <  ?
 		GROUP BY t.category_id, c.name
@@ -291,7 +291,7 @@ func (r *householdAggregatorRepo) SpendingByCategory(ctx context.Context, accoun
 		WHERE deleted_at IS NULL
 		  AND account_id IN ?
 		  AND category_id = ?
-		  AND kind NOT IN ('opening_balance', 'adjustment')
+		  AND kind = 'flow'
 		  AND transaction_date >= ?
 		  AND transaction_date <  ?
 	`, accountIDs, categoryID, from, to).Scan(&s).Error

--- a/backend/internal/service/trade_service_test.go
+++ b/backend/internal/service/trade_service_test.go
@@ -187,3 +187,30 @@ func TestTradeService_Record_TenantIsolation(t *testing.T) {
 	}
 	_ = userA
 }
+
+// TestTradeService_TradeLegsExcludedFromSpending: a buy's cash leg is
+// kind=trade_leg, so it must not count as spending in flow analytics (#293
+// slice 3 — the flow filter is kind='flow'). Previously trade legs leaked
+// into spending because they set transfer_pair_id but not is_transfer.
+func TestTradeService_TradeLegsExcludedFromSpending(t *testing.T) {
+	svc, userID, accountID, aapl, g := seedTradeFixture(t)
+	ctx := context.Background()
+
+	if _, err := svc.Record(ctx, userID, accountID, service.RecordTradeInput{
+		Kind: "buy", AssetID: aapl,
+		Quantity: decimal.NewFromInt(10), Price: decimal.NewFromInt(150),
+		TradeDate: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("record: %v", err)
+	}
+
+	dash := repository.NewDashboardRepository(g)
+	agg, err := dash.Summarize(ctx, userID, time.Now().AddDate(0, -1, 0), time.Now().AddDate(0, 0, 1))
+	if err != nil {
+		t.Fatalf("summarize: %v", err)
+	}
+	// The -1500 cash leg is a trade_leg, not a flow → excluded from spending.
+	if !agg.Spending.IsZero() {
+		t.Errorf("spending = %s, want 0 (trade legs excluded from flow analytics)", agg.Spending)
+	}
+}


### PR DESCRIPTION
Refs #293 (slice 3 of 3 — does not close it; slice 2 Plaid reconciliation remains)

## What
Switches the 8 value-aggregating flow queries from `kind NOT IN ('opening_balance','adjustment')` to **`kind = 'flow'`**:
- dashboard: `Summarize` income/spending, `SpendByCategory`, `CashFlowByMonth`
- budget: `SpendByCategoryInRange`, `CurrentPeriodSpend`
- household: `PeriodIncomeSpending`, `CategoryAggregates`, `SpendingByCategory`

## Why — fixes a latent bug
A trade's cash leg sets `transfer_pair_id` but **not** `is_transfer`, so with the old `is_transfer = FALSE` filter a buy's `-$1500` cash leg was being counted as **spending** in dashboards/budgets. `kind = 'flow'` excludes `trade_leg` (and opening_balance/adjustment), so trades no longer leak into flow analytics.

## Scope notes
- `is_transfer` filtering left as-is (regular transfers still excluded where they were).
- `NetWorthByMonth` and transaction COUNT queries untouched.
- No existing test records a trade and checks these aggregates, so **zero** assertions change. New test asserts a buy's cash leg is not counted as spending.

## Remaining for #293
Slice 2 (Plaid reconciliation: `account_balance_observations` + `adjustment` generation + positions-as-fold) is the last piece — it changes how live financial data syncs and is the part most worth a review checkpoint.

## Verification
`go clean -testcache && make verify` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)