### PR TITLE
#293 (slice 2a): reconcile primitive — fold==reported via opening_balance/adjustment

### DIFF
--- a/backend/internal/model/balance_observation.go
+++ b/backend/internal/model/balance_observation.go
@@ -1,0 +1,26 @@
+package model
+
+import (
+	"time"
+
+	"github.com/shopspring/decimal"
+)
+
+// AccountBalanceObservation is an append-only record of what a sync source
+// (Plaid, CSV, …) reported as the holding of AssetID in AccountID at AsOf
+// (ADR-0017). It is the reconciliation input + audit trail, NOT the quantity
+// source of truth — the transaction ledger is. ReconcilePosition compares the
+// observed quantity to the transaction fold and writes the reconciling
+// opening_balance/adjustment transaction.
+type AccountBalanceObservation struct {
+	ID               int64           `gorm:"primaryKey" json:"id"`
+	UserID           int64           `gorm:"not null" json:"user_id"`
+	AccountID        int64           `gorm:"not null" json:"account_id"`
+	AssetID          int64           `gorm:"not null" json:"asset_id"`
+	ObservedQuantity decimal.Decimal `gorm:"type:numeric(30,18);not null" json:"observed_quantity"`
+	AsOf             time.Time       `gorm:"not null" json:"as_of"`
+	Source           string          `gorm:"not null" json:"source"`
+	CreatedAt        time.Time       `json:"created_at"`
+}
+
+func (AccountBalanceObservation) TableName() string { return "account_balance_observations" }

--- a/backend/internal/repository/balance_observation_repo.go
+++ b/backend/internal/repository/balance_observation_repo.go
@@ -1,0 +1,42 @@
+package repository
+
+import (
+	"context"
+
+	"gorm.io/gorm"
+
+	"github.com/gregwym/offbook/backend/internal/model"
+)
+
+// BalanceObservationRepository is the append-only writer/reader for the
+// account_balance_observations audit log (ADR-0017). Observations are never
+// mutated or deleted; they record what a sync source reported over time.
+type BalanceObservationRepository interface {
+	Insert(ctx context.Context, o *model.AccountBalanceObservation) error
+	// ListByAccountAsset returns observations for (account, asset), newest
+	// first. Used for audit/debugging the reconciliation trail.
+	ListByAccountAsset(ctx context.Context, userID, accountID, assetID int64) ([]model.AccountBalanceObservation, error)
+}
+
+type balanceObservationRepo struct {
+	db *gorm.DB
+}
+
+func NewBalanceObservationRepository(db *gorm.DB) BalanceObservationRepository {
+	return &balanceObservationRepo{db: db}
+}
+
+func (r *balanceObservationRepo) Insert(ctx context.Context, o *model.AccountBalanceObservation) error {
+	return r.db.WithContext(ctx).Create(o).Error
+}
+
+func (r *balanceObservationRepo) ListByAccountAsset(ctx context.Context, userID, accountID, assetID int64) ([]model.AccountBalanceObservation, error) {
+	var out []model.AccountBalanceObservation
+	if err := r.db.WithContext(ctx).
+		Where("user_id = ? AND account_id = ? AND asset_id = ?", userID, accountID, assetID).
+		Order("as_of DESC, id DESC").
+		Find(&out).Error; err != nil {
+		return nil, err
+	}
+	return out, nil
+}

--- a/backend/internal/repository/transaction_repo.go
+++ b/backend/internal/repository/transaction_repo.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"time"
 
+	"github.com/shopspring/decimal"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
 
@@ -91,6 +92,14 @@ type TransactionRepository interface {
 	// by the cost-basis recompute, which walks the entire trade history
 	// per (account, asset) and folds quantities + cash legs together.
 	ListByAccountAndAsset(ctx context.Context, userID, accountID, assetID int64) ([]model.Transaction, error)
+	// FoldQuantity returns Σ amount over non-deleted transactions for the
+	// (account, asset) pair — the quantity the position should equal
+	// (ADR-0017). Returns 0 when there are no rows.
+	FoldQuantity(ctx context.Context, userID, accountID, assetID int64) (decimal.Decimal, error)
+	// HasReconcilingTxn reports whether an opening_balance or adjustment row
+	// already exists for the (account, asset) pair. The first reconciling
+	// write is an opening_balance anchor; later ones are adjustments.
+	HasReconcilingTxn(ctx context.Context, userID, accountID, assetID int64) (bool, error)
 	// ListForCategorizationScope returns a chunk of non-deleted transactions
 	// for the user, ordered by id ASC for cursor-style pagination. Callers
 	// drive a loop by passing the last returned row's id as afterID on the
@@ -402,6 +411,36 @@ func (r *transactionRepo) ListByAccountAndAsset(ctx context.Context, userID, acc
 		return nil, err
 	}
 	return out, nil
+}
+
+func (r *transactionRepo) FoldQuantity(ctx context.Context, userID, accountID, assetID int64) (decimal.Decimal, error) {
+	var s string
+	if err := r.db.WithContext(ctx).Raw(`
+		SELECT COALESCE(SUM(amount), 0)::text
+		FROM transactions
+		WHERE deleted_at IS NULL
+		  AND user_id = ? AND account_id = ? AND asset_id = ?
+	`, userID, accountID, assetID).Scan(&s).Error; err != nil {
+		return decimal.Zero, err
+	}
+	d, err := decimal.NewFromString(s)
+	if err != nil {
+		return decimal.Zero, err
+	}
+	return d, nil
+}
+
+func (r *transactionRepo) HasReconcilingTxn(ctx context.Context, userID, accountID, assetID int64) (bool, error) {
+	var n int64
+	if err := r.db.WithContext(ctx).
+		Model(&model.Transaction{}).
+		Where("user_id = ? AND account_id = ? AND asset_id = ? AND kind IN ?",
+			userID, accountID, assetID, []string{model.KindOpeningBalance, model.KindAdjustment}).
+		Limit(1).
+		Count(&n).Error; err != nil {
+		return false, err
+	}
+	return n > 0, nil
 }
 
 func (r *transactionRepo) SoftDelete(ctx context.Context, userID, id int64) error {

--- a/backend/internal/service/reconcile.go
+++ b/backend/internal/service/reconcile.go
@@ -1,0 +1,80 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/shopspring/decimal"
+
+	"github.com/gregwym/offbook/backend/internal/model"
+	"github.com/gregwym/offbook/backend/internal/repository"
+)
+
+// ReconcilePosition makes the transaction-ledger fold equal `reported` for one
+// (account, asset) by writing a single reconciling transaction for any delta,
+// and records the observation (ADR-0017). The first reconciling row for an
+// (account, asset) is an opening_balance anchor; later ones are adjustments.
+//
+// Returns the written transaction, or nil when the fold already equals
+// `reported` (no reconciling row needed). It is idempotent: a second call with
+// the same reported value writes nothing.
+//
+// Callers pass repos bound to the surrounding DB transaction so the
+// observation, fold read, and reconciling write commit atomically. `source`
+// identifies who reported the value (e.g. "plaid") and is stored on the
+// observation; the reconciling transaction itself is always source="system".
+func ReconcilePosition(
+	ctx context.Context,
+	txRepo repository.TransactionRepository,
+	obsRepo repository.BalanceObservationRepository,
+	userID, accountID, assetID int64,
+	reported decimal.Decimal,
+	asOf time.Time,
+	source string,
+) (*model.Transaction, error) {
+	if err := obsRepo.Insert(ctx, &model.AccountBalanceObservation{
+		UserID:           userID,
+		AccountID:        accountID,
+		AssetID:          assetID,
+		ObservedQuantity: reported,
+		AsOf:             asOf,
+		Source:           source,
+	}); err != nil {
+		return nil, fmt.Errorf("reconcile: record observation: %w", err)
+	}
+
+	fold, err := txRepo.FoldQuantity(ctx, userID, accountID, assetID)
+	if err != nil {
+		return nil, fmt.Errorf("reconcile: fold: %w", err)
+	}
+	delta := reported.Sub(fold)
+	if delta.IsZero() {
+		return nil, nil
+	}
+
+	hasAnchor, err := txRepo.HasReconcilingTxn(ctx, userID, accountID, assetID)
+	if err != nil {
+		return nil, fmt.Errorf("reconcile: anchor check: %w", err)
+	}
+	kind := model.KindAdjustment
+	desc := "Reconciliation adjustment"
+	if !hasAnchor {
+		kind = model.KindOpeningBalance
+		desc = "Opening balance"
+	}
+	recTx := &model.Transaction{
+		UserID:          userID,
+		AccountID:       accountID,
+		AssetID:         assetID,
+		Kind:            kind,
+		Amount:          delta,
+		Description:     &desc,
+		TransactionDate: asOf,
+		Source:          "system",
+	}
+	if err := txRepo.Create(ctx, recTx); err != nil {
+		return nil, fmt.Errorf("reconcile: write %s: %w", kind, err)
+	}
+	return recTx, nil
+}

--- a/backend/internal/service/reconcile_test.go
+++ b/backend/internal/service/reconcile_test.go
@@ -1,0 +1,101 @@
+package service_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/shopspring/decimal"
+	"gorm.io/gorm"
+
+	"github.com/gregwym/offbook/backend/internal/model"
+	"github.com/gregwym/offbook/backend/internal/repository"
+	"github.com/gregwym/offbook/backend/internal/service"
+	"github.com/gregwym/offbook/backend/internal/testutil"
+)
+
+func seedReconcileAccount(t *testing.T, g *gorm.DB, userID int64) (accountID, usdID int64) {
+	t.Helper()
+	usdID = testutil.LookupUSDAssetID(t, g)
+	acct := &model.Account{
+		UserID:              userID,
+		Name:                "recon-" + time.Now().Format("150405.000000000"),
+		InstitutionSlug:     "fixture",
+		AccountType:         "checking",
+		PrimaryQuoteAssetID: usdID,
+		IsActive:            true,
+	}
+	if err := g.Create(acct).Error; err != nil {
+		t.Fatalf("seed account: %v", err)
+	}
+	t.Cleanup(func() { g.Unscoped().Delete(&model.Account{}, acct.ID) })
+	return acct.ID, usdID
+}
+
+// TestReconcilePosition_FirstIsOpeningBalance_ThenAdjustment proves the
+// ADR-0017 invariant: ReconcilePosition makes Σ transactions == reported, the
+// first reconciling row is opening_balance, later divergences are adjustments,
+// and equal values are idempotent.
+func TestReconcilePosition_FirstIsOpeningBalance_ThenAdjustment(t *testing.T) {
+	g := openTestDB(t)
+	userID := seedTestUser(t, g)
+	accountID, usdID := seedReconcileAccount(t, g, userID)
+	ctx := context.Background()
+	txRepo := repository.NewTransactionRepository(g)
+	obsRepo := repository.NewBalanceObservationRepository(g)
+
+	// First reconcile: no transactions yet; Plaid reports 1000 → opening_balance.
+	rec, err := service.ReconcilePosition(ctx, txRepo, obsRepo, userID, accountID, usdID,
+		decimal.NewFromInt(1000), time.Now().UTC(), "plaid")
+	if err != nil {
+		t.Fatalf("first reconcile: %v", err)
+	}
+	if rec == nil || rec.Kind != model.KindOpeningBalance || !rec.Amount.Equal(decimal.NewFromInt(1000)) {
+		t.Fatalf("first reconcile = %+v, want opening_balance of 1000", rec)
+	}
+	if rec.Source != "system" {
+		t.Errorf("reconciling source = %q, want system", rec.Source)
+	}
+	assertFold(t, txRepo, userID, accountID, usdID, "1000")
+
+	// Idempotent: same value again → no row.
+	rec, err = service.ReconcilePosition(ctx, txRepo, obsRepo, userID, accountID, usdID,
+		decimal.NewFromInt(1000), time.Now().UTC(), "plaid")
+	if err != nil {
+		t.Fatalf("idempotent reconcile: %v", err)
+	}
+	if rec != nil {
+		t.Errorf("expected no reconciling row when fold==reported, got %+v", rec)
+	}
+
+	// Divergence: Plaid now reports 1200 → adjustment of +200.
+	rec, err = service.ReconcilePosition(ctx, txRepo, obsRepo, userID, accountID, usdID,
+		decimal.NewFromInt(1200), time.Now().UTC(), "plaid")
+	if err != nil {
+		t.Fatalf("divergence reconcile: %v", err)
+	}
+	if rec == nil || rec.Kind != model.KindAdjustment || !rec.Amount.Equal(decimal.NewFromInt(200)) {
+		t.Fatalf("divergence reconcile = %+v, want adjustment of 200", rec)
+	}
+	assertFold(t, txRepo, userID, accountID, usdID, "1200")
+
+	// Every report is recorded as an observation (3 calls).
+	obs, err := obsRepo.ListByAccountAsset(ctx, userID, accountID, usdID)
+	if err != nil {
+		t.Fatalf("list observations: %v", err)
+	}
+	if len(obs) != 3 {
+		t.Errorf("observations = %d, want 3", len(obs))
+	}
+}
+
+func assertFold(t *testing.T, txRepo repository.TransactionRepository, userID, accountID, assetID int64, want string) {
+	t.Helper()
+	fold, err := txRepo.FoldQuantity(context.Background(), userID, accountID, assetID)
+	if err != nil {
+		t.Fatalf("fold: %v", err)
+	}
+	if !fold.Equal(decimal.RequireFromString(want)) {
+		t.Errorf("fold = %s, want %s", fold, want)
+	}
+}

--- a/backend/migrations/000021_balance_observations.down.sql
+++ b/backend/migrations/000021_balance_observations.down.sql
@@ -1,0 +1,9 @@
+BEGIN;
+
+ALTER TABLE transactions DROP CONSTRAINT transactions_source_check;
+ALTER TABLE transactions ADD CONSTRAINT transactions_source_check
+    CHECK (source IN ('plaid', 'csv', 'pdf', 'manual'));
+
+DROP TABLE IF EXISTS account_balance_observations;
+
+COMMIT;

--- a/backend/migrations/000021_balance_observations.up.sql
+++ b/backend/migrations/000021_balance_observations.up.sql
@@ -1,0 +1,32 @@
+BEGIN;
+
+-- #293 (slice 2): reconciliation input + system-generated transaction source.
+--
+-- account_balance_observations is the append-only audit/reconciliation input
+-- (ADR-0017): each row records what a sync source reported for an
+-- (account, asset) at a point in time. It is NOT the quantity source of
+-- truth — the transaction ledger is. ReconcilePosition compares the reported
+-- value to the transaction fold and writes an opening_balance/adjustment for
+-- any delta.
+CREATE TABLE account_balance_observations (
+    id                BIGSERIAL PRIMARY KEY,
+    user_id           BIGINT NOT NULL REFERENCES users(id),
+    account_id        BIGINT NOT NULL REFERENCES accounts(id),
+    asset_id          BIGINT NOT NULL REFERENCES assets(id),
+    observed_quantity NUMERIC(30, 18) NOT NULL,
+    as_of             TIMESTAMPTZ NOT NULL,
+    source            TEXT NOT NULL,
+    created_at        TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX ix_abo_account_asset_asof
+    ON account_balance_observations (account_id, asset_id, as_of DESC);
+
+-- Allow 'system' as a transaction source for reconciliation rows
+-- (opening_balance / adjustment) that the app writes itself — distinct from
+-- real Plaid/CSV/manual events. ADR-0017: never invent trades; reconciliation
+-- rows are explicit, typed, transparent facts.
+ALTER TABLE transactions DROP CONSTRAINT transactions_source_check;
+ALTER TABLE transactions ADD CONSTRAINT transactions_source_check
+    CHECK (source IN ('plaid', 'csv', 'pdf', 'manual', 'system'));
+
+COMMIT;


### PR DESCRIPTION
Refs #293 (slice 2a — the tested reconcile logic, UNWIRED; wiring is 2b)

## What
The core reconciliation logic of ADR-0017, delivered in isolation with unit tests so the tricky part is proven correct before it touches live Plaid sync. **Zero behavior change** — nothing calls `ReconcilePosition` yet.

- Migration `000021`: `account_balance_observations` (append-only reconciliation input + audit) and allow `source='system'` on `transactions`.
- `model.AccountBalanceObservation` + `BalanceObservationRepository`.
- `transactionRepo.FoldQuantity` (Σ amount per account/asset) + `HasReconcilingTxn`.
- `service.ReconcilePosition(...)`: records the observation, then writes **one** reconciling transaction for any `(reported − fold)` delta — `opening_balance` the first time for an (account, asset), `adjustment` thereafter — so `Σ transactions == reported`. Idempotent.

## Why unwired
The wiring (calling this at the end of Plaid cash/holdings sync) is where the live-financial-data risk is. Landing the logic first, fully tested, makes the wiring PR a small, low-risk change — and gives a clean review point for the reconciliation semantics.

## Test
`TestReconcilePosition_FirstIsOpeningBalance_ThenAdjustment`: first report → `opening_balance`; same value → no row (idempotent); divergence → `adjustment`; fold equals reported after each. `go clean -testcache && make verify` green.

## Next (slice 2b)
Wire `ReconcilePosition` into `SyncTransactions` (cash) and `SyncHoldings`, passing repos bound to the sync tx. Then #282 (unified valuation) unblocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)