### PR TITLE
#293 (slice 2b): reconcile Plaid cash positions into the ledger

### DIFF
--- a/backend/cmd/plaid-resync/main.go
+++ b/backend/cmd/plaid-resync/main.go
@@ -87,6 +87,16 @@ func main() {
 		piiSvc, mapper, gormDB,
 	).WithRuleRepo(repository.NewCategorizationRuleRepository(gormDB))
 
+	// Refresh accounts first so each cash position carries Plaid's current
+	// balance before SyncTransactions reconciles the fold against it
+	// (ADR-0017). Skipping this would reconcile against a stale balance and
+	// emit a spurious adjustment that cancels the freshly-synced flows.
+	ar, err := svc.SyncAccounts(context.Background(), userID, plaidItemID)
+	if err != nil {
+		log.Fatalf("sync-accounts: %v", err)
+	}
+	fmt.Printf("accounts: created=%d updated=%d\n", ar.Created, ar.Updated)
+
 	r, err := svc.SyncTransactions(context.Background(), userID, plaidItemID)
 	if err != nil {
 		log.Fatalf("sync: %v", err)

--- a/backend/internal/repository/account_repo.go
+++ b/backend/internal/repository/account_repo.go
@@ -32,6 +32,11 @@ type AccountRepository interface {
 	// account_id, scoped to userID. Returns ErrNotFound when no row exists.
 	// Used by the Plaid discovery flow to make sync re-runs idempotent.
 	FindByPlaidAccountID(ctx context.Context, userID int64, plaidAccountID string) (*model.Account, error)
+	// ListByPlaidItemID returns every non-deleted account belonging to a
+	// Plaid item, scoped to userID. Used by the sync path to reconcile each
+	// account's cash position after a transactions drain — including
+	// accounts that had no transactions in the current window.
+	ListByPlaidItemID(ctx context.Context, userID int64, plaidItemID string) ([]model.Account, error)
 }
 
 // ErrNotFound is returned by repository methods when no matching row exists.
@@ -122,6 +127,17 @@ func (r *accountRepo) FindByPlaidAccountID(ctx context.Context, userID int64, pl
 		return nil, err
 	}
 	return &a, nil
+}
+
+func (r *accountRepo) ListByPlaidItemID(ctx context.Context, userID int64, plaidItemID string) ([]model.Account, error) {
+	var out []model.Account
+	if err := r.db.WithContext(ctx).
+		Where("user_id = ? AND plaid_item_id = ?", userID, plaidItemID).
+		Order("id").
+		Find(&out).Error; err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (r *accountRepo) SoftDelete(ctx context.Context, userID, id int64) error {

--- a/backend/internal/service/plaid/service.go
+++ b/backend/internal/service/plaid/service.go
@@ -582,6 +582,8 @@ func (s *Service) SyncTransactions(ctx context.Context, userID int64, plaidItemI
 		itemRepo := repository.NewPlaidItemRepository(tx)
 		acctRepo := repository.NewAccountRepository(tx)
 		syncErrRepo := repository.NewPlaidSyncErrorRepository(tx)
+		obsRepo := repository.NewBalanceObservationRepository(tx)
+		posRepo := repository.NewPositionRepository(tx)
 		accountIDCache := map[string]accountRef{}
 		spIdx := 0
 
@@ -801,6 +803,17 @@ func (s *Service) SyncTransactions(ctx context.Context, userID int64, plaidItemI
 			}
 		}
 
+		// Reconcile each account's cash position against the transaction
+		// fold (ADR-0017). SyncAccounts maintains positions.quantity =
+		// Plaid's reported balance; now that this drain's flows are folded
+		// in, ReconcilePosition writes an opening_balance anchor (first run)
+		// or an adjustment (later drift) for the delta so
+		// Σ transactions.amount == positions.quantity holds per cash asset.
+		// Runs after all row writes so opening_balance = balance − Σ flows.
+		if err := s.reconcileItemCashPositions(ctx, txRepo, obsRepo, posRepo, acctRepo, userID, plaidItemID); err != nil {
+			return err
+		}
+
 		// Cursor advance — final write inside the same transaction. Always
 		// happens, even when result.Failed > 0: the whole point of the DLQ
 		// is to let good rows commit and let the cursor move past the
@@ -827,6 +840,59 @@ func (s *Service) SyncTransactions(ctx context.Context, userID int64, plaidItemI
 		_ = s.itemRepo.UpdateSyncStatus(statusCtx, userID, item.ID, "ok_with_errors", &msg)
 	}
 	return result, nil
+}
+
+// reconcileItemCashPositions makes Σ transactions.amount == positions.quantity
+// hold for every account's cash sleeve after a transactions drain (ADR-0017).
+//
+// For each of the item's accounts it reads the cash position (the position in
+// the account's primary quote asset, which SyncAccounts keeps pinned to
+// Plaid's reported balance) and calls ReconcilePosition with that quantity as
+// the reported truth. The first reconciling row per (account, cash asset) is
+// an opening_balance anchor; later divergence produces an adjustment. Because
+// positions.quantity already equals the reported balance, no position write is
+// needed here — making the fold equal it keeps both in sync.
+//
+// Accounts with no cash position row (e.g. a holdings-only sleeve) are skipped;
+// their non-cash positions are reconciled by SyncHoldings.
+//
+// All repos are bound to the surrounding sync transaction so the observation,
+// fold read, and reconciling write commit atomically with the drain.
+func (s *Service) reconcileItemCashPositions(
+	ctx context.Context,
+	txRepo repository.TransactionRepository,
+	obsRepo repository.BalanceObservationRepository,
+	posRepo repository.PositionRepository,
+	acctRepo repository.AccountRepository,
+	userID int64,
+	plaidItemID string,
+) error {
+	accounts, err := acctRepo.ListByPlaidItemID(ctx, userID, plaidItemID)
+	if err != nil {
+		return fmt.Errorf("plaid: list item accounts for reconcile: %w", err)
+	}
+	now := time.Now().UTC()
+	for _, acct := range accounts {
+		positions, err := posRepo.ListByAccountID(ctx, userID, acct.ID)
+		if err != nil {
+			return fmt.Errorf("plaid: read positions for reconcile (acct=%d): %w", acct.ID, err)
+		}
+		var cash *model.Position
+		for i := range positions {
+			if positions[i].AssetID == acct.PrimaryQuoteAssetID {
+				cash = &positions[i]
+				break
+			}
+		}
+		if cash == nil {
+			continue
+		}
+		if _, err := service.ReconcilePosition(ctx, txRepo, obsRepo,
+			userID, acct.ID, acct.PrimaryQuoteAssetID, cash.Quantity, now, "plaid"); err != nil {
+			return fmt.Errorf("plaid: reconcile cash (acct=%d): %w", acct.ID, err)
+		}
+	}
+	return nil
 }
 
 // accountRef bundles the two values transaction mapping needs from a Plaid

--- a/backend/internal/service/plaid/sync_transactions_reconcile_test.go
+++ b/backend/internal/service/plaid/sync_transactions_reconcile_test.go
@@ -1,0 +1,165 @@
+package plaid_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/shopspring/decimal"
+
+	"github.com/gregwym/offbook/backend/internal/crypto"
+	"github.com/gregwym/offbook/backend/internal/model"
+	"github.com/gregwym/offbook/backend/internal/repository"
+	"github.com/gregwym/offbook/backend/internal/service"
+	plaidsvc "github.com/gregwym/offbook/backend/internal/service/plaid"
+	"github.com/gregwym/offbook/backend/internal/testutil"
+)
+
+// TestService_SyncTransactions_ReconcilesCashPosition proves the ADR-0017
+// invariant for the Plaid cash path: after a drain, the transaction fold
+// equals the cash position SyncAccounts pinned to Plaid's balance. The first
+// reconcile writes an opening_balance anchor (balance − Σ flows); a later
+// drift produces an adjustment. Every reported balance is recorded as an
+// observation.
+func TestService_SyncTransactions_ReconcilesCashPosition(t *testing.T) {
+	g := openPlaidTestDB(t)
+	userID := seedPlaidTestUser(t, g)
+	usdID := testutil.LookupUSDAssetID(t, g)
+	ctx := context.Background()
+
+	const plaidAcctID = "pacct-recon-cash-1"
+	const plaidItemID = "item-recon-cash-1"
+	acct := &model.Account{
+		UserID:              userID,
+		Name:                "Recon Checking",
+		InstitutionSlug:     "ins_test",
+		AccountType:         "checking",
+		PrimaryQuoteAssetID: usdID,
+		PlaidAccountID:      &[]string{plaidAcctID}[0],
+		PlaidItemID:         &[]string{plaidItemID}[0],
+		IsActive:            true,
+	}
+	if err := g.Create(acct).Error; err != nil {
+		t.Fatalf("seed account: %v", err)
+	}
+	t.Cleanup(func() {
+		g.Unscoped().Where("user_id = ?", userID).Delete(&model.AccountBalanceObservation{})
+	})
+
+	// SyncAccounts would have pinned the cash position to Plaid's balance.
+	posRepo := repository.NewPositionRepository(g)
+	if err := posRepo.Upsert(ctx, &model.Position{
+		UserID:    userID,
+		AccountID: acct.ID,
+		AssetID:   usdID,
+		Quantity:  decimal.NewFromInt(5000),
+	}); err != nil {
+		t.Fatalf("seed cash position: %v", err)
+	}
+
+	srv, _ := fakeTxnsSyncServer(t, plaidAcctID)
+	client, _ := plaidsvc.NewSDKClient(plaidsvc.Config{ClientID: "cid", Secret: "csec", Env: srv.URL})
+	box, _ := crypto.NewSecretBox(newTestKey())
+	itemRepo := repository.NewPlaidItemRepository(g)
+	acctRepo := repository.NewAccountRepository(g)
+	txRepo := repository.NewTransactionRepository(g)
+	piiSvc := service.NewPIIService(repository.NewPIIRepository(g), nil)
+
+	enc, _ := box.Encrypt([]byte("access-sandbox-fake"))
+	item := &model.PlaidItem{
+		UserID:         userID,
+		PlaidItemID:    plaidItemID,
+		AccessTokenEnc: enc,
+		Status:         "active",
+	}
+	if err := itemRepo.Create(ctx, item); err != nil {
+		t.Fatalf("seed item: %v", err)
+	}
+
+	svc := plaidsvc.NewService(client, box, itemRepo, acctRepo, txRepo,
+		repository.NewPlaidSyncErrorRepository(g), repository.NewAssetRepository(g),
+		posRepo, piiSvc, nil, g)
+
+	// First drain: flows net to -5.43 + 2000 - 12.50 = 1982.07.
+	// opening_balance = 5000 − 1982.07 = 3017.93; fold must equal the
+	// position quantity (5000).
+	if _, err := svc.SyncTransactions(ctx, userID, plaidItemID); err != nil {
+		t.Fatalf("SyncTransactions: %v", err)
+	}
+
+	fold, err := txRepo.FoldQuantity(ctx, userID, acct.ID, usdID)
+	if err != nil {
+		t.Fatalf("fold: %v", err)
+	}
+	if !fold.Equal(decimal.NewFromInt(5000)) {
+		t.Errorf("fold = %s, want 5000 (== cash position)", fold)
+	}
+
+	var opening model.Transaction
+	if err := g.Where("user_id = ? AND account_id = ? AND kind = ?",
+		userID, acct.ID, model.KindOpeningBalance).First(&opening).Error; err != nil {
+		t.Fatalf("expected an opening_balance row: %v", err)
+	}
+	if !opening.Amount.Equal(decimal.RequireFromString("3017.93")) {
+		t.Errorf("opening_balance amount = %s, want 3017.93 (balance − Σflows)", opening.Amount)
+	}
+	if opening.Source != "system" {
+		t.Errorf("opening_balance source = %q, want system", opening.Source)
+	}
+
+	// One observation recorded for the reported balance.
+	obsRepo := repository.NewBalanceObservationRepository(g)
+	obs, err := obsRepo.ListByAccountAsset(ctx, userID, acct.ID, usdID)
+	if err != nil {
+		t.Fatalf("list observations: %v", err)
+	}
+	if len(obs) != 1 {
+		t.Fatalf("observations after first sync = %d, want 1", len(obs))
+	}
+
+	// Drift: SyncAccounts re-pins the cash position to a new balance (5500).
+	// The next drain (no new flows) must emit an adjustment of +500, not a
+	// silent overwrite, keeping fold == position.
+	if err := posRepo.Upsert(ctx, &model.Position{
+		UserID:    userID,
+		AccountID: acct.ID,
+		AssetID:   usdID,
+		Quantity:  decimal.NewFromInt(5500),
+	}); err != nil {
+		t.Fatalf("re-pin cash position: %v", err)
+	}
+	if _, err := svc.SyncTransactions(ctx, userID, plaidItemID); err != nil {
+		t.Fatalf("SyncTransactions #2: %v", err)
+	}
+
+	fold, err = txRepo.FoldQuantity(ctx, userID, acct.ID, usdID)
+	if err != nil {
+		t.Fatalf("fold #2: %v", err)
+	}
+	if !fold.Equal(decimal.NewFromInt(5500)) {
+		t.Errorf("fold after drift = %s, want 5500", fold)
+	}
+
+	var adjustments []model.Transaction
+	if err := g.Where("user_id = ? AND account_id = ? AND kind = ?",
+		userID, acct.ID, model.KindAdjustment).Find(&adjustments).Error; err != nil {
+		t.Fatalf("load adjustments: %v", err)
+	}
+	if len(adjustments) != 1 || !adjustments[0].Amount.Equal(decimal.NewFromInt(500)) {
+		t.Fatalf("adjustments = %+v, want a single +500 row", adjustments)
+	}
+
+	// Idempotent: a third drain with the position unchanged adds no new
+	// reconciling rows.
+	if _, err := svc.SyncTransactions(ctx, userID, plaidItemID); err != nil {
+		t.Fatalf("SyncTransactions #3: %v", err)
+	}
+	var reconCount int64
+	if err := g.Model(&model.Transaction{}).
+		Where("user_id = ? AND source = 'system'", userID).
+		Count(&reconCount).Error; err != nil {
+		t.Fatalf("count reconciling rows: %v", err)
+	}
+	if reconCount != 2 {
+		t.Errorf("system reconciling rows = %d, want 2 (opening + 1 adjustment)", reconCount)
+	}
+}


### PR DESCRIPTION
Part of epic #270 / #293. Wires the `ReconcilePosition` primitive (slice 2a, #296) into the Plaid sync so the ADR-0017 invariant — `Σ transactions.amount == positions.quantity` per (account, cash asset) — holds after every sync.

## What changed
- **`SyncTransactions`** reconciles each account's cash sleeve at the end of the drain (inside the same DB transaction, with tx-bound repos). `SyncAccounts` keeps `positions.quantity` pinned to Plaid's reported balance; once this drain's flows are folded in, `ReconcilePosition` writes:
  - an **`opening_balance`** anchor on the first reconcile (`balance − Σ flows`), or
  - an **`adjustment`** on later drift (trust-feed) — never a silent overwrite.
- **`AccountRepository.ListByPlaidItemID`** — so accounts with no transactions in the sync window still get an opening anchor for their balance.
- **`cmd/plaid-resync`** now runs `SyncAccounts` before `SyncTransactions`. Without a fresh balance the reconcile would compare new flows against a stale balance and emit a spurious adjustment that cancels them.

## Why end-of-`SyncTransactions`
`opening_balance = balance − Σ flows` requires the flows to exist first. Plaid's reported balance is already net of history, so reconciling before transactions are folded would double-count. Running after the drain (with `positions.quantity` already == the reported balance) makes the fold equal it with one anchor row.

## Tests
`TestService_SyncTransactions_ReconcilesCashPosition`: opening_balance on first drain, adjustment on a drifted balance, idempotent re-sync (no extra rows), observation trail recorded. Full `make verify` green (vet, `-race -p 1`, contract-check, frontend build).

## Follow-up (still on #293)
- Holdings reconcile: route `SyncHoldings`' position overwrite through `ReconcilePosition` (the analogous trade-leg/adjustment path).
- Then #282 (unified valuation) unblocks.

Closes nothing yet — #293 stays open until the holdings slice lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)