### PR TITLE
#293 (slice 2c): reconcile Plaid holdings into the ledger

### DIFF
--- a/backend/internal/service/plaid/holdings_reconcile_test.go
+++ b/backend/internal/service/plaid/holdings_reconcile_test.go
@@ -149,14 +149,19 @@ func seedHoldingsFixture(t *testing.T, g *gorm.DB, snapshotQty decimal.Decimal) 
 	return svc, userID, accountID, aaplID, item
 }
 
-// TestSyncHoldings_AdjustsPositionWithoutSyntheticTxns covers the
-// ADR-0013 §3 invariant: when Plaid's snapshot disagrees with our
-// derived position, we update the position to match Plaid but
-// DO NOT insert any synthetic trade rows to bridge the gap.
-func TestSyncHoldings_AdjustsPositionWithoutSyntheticTxns(t *testing.T) {
+// TestSyncHoldings_ReconcilesViaLedgerNotSyntheticTrades covers the ADR-0017
+// refinement of ADR-0013 §3: when Plaid's snapshot disagrees with our derived
+// fold, we make Σ transactions == the snapshot by writing an explicit, typed
+// reconciling row (opening_balance here — the fold starts at 0) and adopt the
+// snapshot as the position quantity. The invariant is "never invent a *trade*":
+// no flow / trade_leg row may be fabricated to bridge the gap.
+func TestSyncHoldings_ReconcilesViaLedgerNotSyntheticTrades(t *testing.T) {
 	g := openPlaidTestDB(t)
 	svc, userID, accountID, aaplID, item := seedHoldingsFixture(t, g, decimal.NewFromInt(8))
 	ctx := context.Background()
+	t.Cleanup(func() {
+		g.Unscoped().Where("user_id = ?", userID).Delete(&model.AccountBalanceObservation{})
+	})
 
 	// Before: 0 transactions for this user on this account.
 	var beforeCount int64
@@ -173,7 +178,7 @@ func TestSyncHoldings_AdjustsPositionWithoutSyntheticTxns(t *testing.T) {
 		t.Errorf("Holdings = %d, want 1", res.Holdings)
 	}
 	if res.PositionsAdjusted != 1 {
-		t.Errorf("PositionsAdjusted = %d, want 1 (10 → 8)", res.PositionsAdjusted)
+		t.Errorf("PositionsAdjusted = %d, want 1 (fold 0 → 8)", res.PositionsAdjusted)
 	}
 	if res.PricesObserved != 1 {
 		t.Errorf("PricesObserved = %d, want 1", res.PricesObserved)
@@ -189,11 +194,36 @@ func TestSyncHoldings_AdjustsPositionWithoutSyntheticTxns(t *testing.T) {
 		t.Errorf("quantity = %s, want 8 (Plaid snapshot wins)", pos.Quantity)
 	}
 
-	// Critical invariant: NO synthetic transactions inserted.
-	var afterCount int64
-	g.Model(&model.Transaction{}).Where("user_id = ?", userID).Count(&afterCount)
-	if afterCount != 0 {
-		t.Errorf("synthesized %d transactions during reconciliation — invariant violation", afterCount)
+	// The reconciling row is an opening_balance of 8, source=system — and the
+	// fold now equals the position. NO trade leg was invented.
+	txRepo := repository.NewTransactionRepository(g)
+	fold, err := txRepo.FoldQuantity(ctx, userID, accountID, aaplID)
+	if err != nil {
+		t.Fatalf("fold: %v", err)
+	}
+	if !fold.Equal(decimal.NewFromInt(8)) {
+		t.Errorf("fold = %s, want 8 (== position)", fold)
+	}
+	var recon []model.Transaction
+	if err := g.Where("user_id = ? AND account_id = ? AND asset_id = ?", userID, accountID, aaplID).
+		Find(&recon).Error; err != nil {
+		t.Fatalf("load recon txns: %v", err)
+	}
+	if len(recon) != 1 {
+		t.Fatalf("transactions for holding = %d, want 1 (single opening_balance anchor)", len(recon))
+	}
+	if recon[0].Kind != model.KindOpeningBalance || recon[0].Source != "system" {
+		t.Errorf("recon row = {kind:%s source:%s}, want {opening_balance system}", recon[0].Kind, recon[0].Source)
+	}
+	if !recon[0].Amount.Equal(decimal.NewFromInt(8)) {
+		t.Errorf("recon amount = %s, want 8", recon[0].Amount)
+	}
+	var tradeLegs int64
+	g.Model(&model.Transaction{}).
+		Where("user_id = ? AND kind IN ?", userID, []string{model.KindTradeLeg, model.KindFlow}).
+		Count(&tradeLegs)
+	if tradeLegs != 0 {
+		t.Errorf("invented %d trade/flow rows — ADR-0017 forbids synthesizing trades", tradeLegs)
 	}
 
 	// A price observation was written.
@@ -201,5 +231,65 @@ func TestSyncHoldings_AdjustsPositionWithoutSyntheticTxns(t *testing.T) {
 	g.Model(&model.Price{}).Where("asset_id = ?", aaplID).Count(&priceCount)
 	if priceCount != 1 {
 		t.Errorf("price observations for asset %d = %d, want 1", aaplID, priceCount)
+	}
+}
+
+// TestSyncHoldings_DriftAfterAnchorWritesAdjustment proves the trust-feed
+// path: once an anchor exists for the asset, a snapshot that differs from the
+// fold produces an adjustment for the residual (not a second opening_balance)
+// and adopts the snapshot. This mirrors a holding whose quantity drifts
+// between two syncs.
+func TestSyncHoldings_DriftAfterAnchorWritesAdjustment(t *testing.T) {
+	g := openPlaidTestDB(t)
+	// Plaid reports 8 shares.
+	svc, userID, accountID, aaplID, item := seedHoldingsFixture(t, g, decimal.NewFromInt(8))
+	ctx := context.Background()
+	t.Cleanup(func() {
+		g.Unscoped().Where("user_id = ?", userID).Delete(&model.AccountBalanceObservation{})
+	})
+
+	// Simulate a prior sync that established an opening_balance anchor of 10,
+	// so the fold is 10 before this run. Plaid's 8 is then a -2 drift.
+	anchorDesc := "Opening balance"
+	anchor := &model.Transaction{
+		UserID:          userID,
+		AccountID:       accountID,
+		AssetID:         aaplID,
+		Kind:            model.KindOpeningBalance,
+		Amount:          decimal.NewFromInt(10),
+		Description:     &anchorDesc,
+		TransactionDate: time.Now().UTC(),
+		Source:          "system",
+	}
+	if err := g.Create(anchor).Error; err != nil {
+		t.Fatalf("seed anchor: %v", err)
+	}
+
+	if _, err := svc.SyncHoldings(ctx, userID, item.PlaidItemID); err != nil {
+		t.Fatalf("SyncHoldings: %v", err)
+	}
+
+	txRepo := repository.NewTransactionRepository(g)
+	fold, err := txRepo.FoldQuantity(ctx, userID, accountID, aaplID)
+	if err != nil {
+		t.Fatalf("fold: %v", err)
+	}
+	if !fold.Equal(decimal.NewFromInt(8)) {
+		t.Errorf("fold = %s, want 8 (10 leg − 2 adjustment)", fold)
+	}
+	var adj []model.Transaction
+	if err := g.Where("user_id = ? AND kind = ?", userID, model.KindAdjustment).Find(&adj).Error; err != nil {
+		t.Fatalf("load adjustments: %v", err)
+	}
+	if len(adj) != 1 || !adj[0].Amount.Equal(decimal.NewFromInt(-2)) {
+		t.Fatalf("adjustments = %+v, want a single -2 row", adj)
+	}
+	// Exactly one opening_balance row — the seeded anchor; SyncHoldings did
+	// not write a second one.
+	var openings int64
+	g.Model(&model.Transaction{}).
+		Where("user_id = ? AND kind = ?", userID, model.KindOpeningBalance).Count(&openings)
+	if openings != 1 {
+		t.Errorf("opening_balance rows = %d, want 1 (the pre-existing anchor only)", openings)
 	}
 }

--- a/backend/internal/service/plaid/investments_service.go
+++ b/backend/internal/service/plaid/investments_service.go
@@ -16,11 +16,11 @@ import (
 	"log"
 	"time"
 
-	"github.com/shopspring/decimal"
 	"gorm.io/gorm"
 
 	"github.com/gregwym/offbook/backend/internal/model"
 	"github.com/gregwym/offbook/backend/internal/repository"
+	"github.com/gregwym/offbook/backend/internal/service"
 	"github.com/gregwym/offbook/backend/internal/service/valuation"
 )
 
@@ -363,10 +363,13 @@ func (s *Service) SyncHoldings(ctx context.Context, userID int64, plaidItemID st
 	result := HoldingsReconcileResult{Holdings: len(snapshot.Holdings)}
 	accountIDCache := map[string]accountRef{}
 
+	now := time.Now().UTC()
 	err = s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		acctRepo := repository.NewAccountRepository(tx)
 		posRepo := repository.NewPositionRepository(tx)
 		priceRepo := repository.NewPriceRepository(tx)
+		txRepo := repository.NewTransactionRepository(tx)
+		obsRepo := repository.NewBalanceObservationRepository(tx)
 
 		for _, h := range snapshot.Holdings {
 			ref, err := resolveAccount(ctx, acctRepo, userID, h.PlaidAccountID, accountIDCache)
@@ -379,20 +382,25 @@ func (s *Service) SyncHoldings(ctx context.Context, userID int64, plaidItemID st
 				continue
 			}
 
-			// Compare with what's there now. Re-derive via Recompute
-			// only on disagreement; if Plaid agrees with our position
-			// row we skip the recompute.
+			// Reconcile the holding quantity into the ledger (ADR-0017):
+			// Plaid's snapshot is the reported truth, and ReconcilePosition
+			// writes an opening_balance anchor (first encounter / no trade
+			// legs) or a typed adjustment (drift from trade-derived fold) for
+			// the delta — never a synthetic *trade*. After it returns the fold
+			// equals h.Quantity, so the position upsert below keeps
+			// positions.quantity == Σ transactions.amount for this asset.
 			existing, err := findLivePosition(ctx, tx, userID, ref.ID, assetID)
 			if err != nil {
 				return err
 			}
-			derivedQty := decimal.Zero
-			if existing != nil {
-				derivedQty = existing.Quantity
+			rec, err := service.ReconcilePosition(ctx, txRepo, obsRepo,
+				userID, ref.ID, assetID, h.Quantity, now, "plaid")
+			if err != nil {
+				return fmt.Errorf("plaid: reconcile holding (acct=%d asset=%d): %w", ref.ID, assetID, err)
 			}
-			if !derivedQty.Equal(h.Quantity) {
-				log.Printf("plaid: holdings reconcile drift (acct=%d asset=%d derived=%s plaid=%s) — adopting Plaid; no synthetic txns",
-					ref.ID, assetID, derivedQty.String(), h.Quantity.String())
+			if rec != nil {
+				log.Printf("plaid: holdings reconcile drift (acct=%d asset=%d plaid=%s) — wrote %s of %s",
+					ref.ID, assetID, h.Quantity.String(), rec.Kind, rec.Amount.String())
 				result.PositionsAdjusted++
 			}
 			pos := &model.Position{


### PR DESCRIPTION
Part of epic #270 / #293. Completes the Plaid reconciliation half of ADR-0017 by routing `SyncHoldings` through the same `ReconcilePosition` primitive used for cash (slice 2b, #297).

## What changed
- **`SyncHoldings`** no longer silently overwrites the derived position with Plaid's snapshot. For each holding it now calls `ReconcilePosition(reported = h.Quantity)`, which writes:
  - an **`opening_balance`** anchor on first encounter (no prior reconciling row — fold starts at 0), or
  - a typed **`adjustment`** for the residual when the trade-derived fold drifts from the snapshot.
  After it returns the fold equals `h.Quantity`, so the position upsert (which also carries Plaid's cost basis) keeps `Σ transactions.amount == positions.quantity` for the security.
- Drift is now counted/logged off `ReconcilePosition`'s return rather than a raw `existing.Quantity` diff.

## Invariant preserved
ADR-0013 §3 said "no synthetic trade rows." ADR-0017 refines that to "never invent a *trade*" — reconciling rows are explicit, typed, `source=system` facts, not fabricated buy/sell legs. The rewritten test asserts exactly that: a reconciling row **is** written, but **zero** `trade_leg`/`flow` rows are invented.

## Tests
- `TestSyncHoldings_ReconcilesViaLedgerNotSyntheticTrades` (rewrite of the old `…WithoutSyntheticTxns`): opening_balance written, `fold == position`, no trade/flow rows fabricated.
- `TestSyncHoldings_DriftAfterAnchorWritesAdjustment`: with a prior anchor of 10 and a snapshot of 8, a single `-2` adjustment is written and no second opening_balance.

Full `make verify` green (vet, `-race -p 1`, contract-check, frontend build).

## Closes out #293
With cash (slice 2b) + holdings (this PR) both reconciled, every Plaid position-writing path now folds through the ledger. This is the last behavioral piece of #293 — unblocks #282 (unified valuation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)