### PR TITLE
#293 (slice 2d): positions regeneration command — prove positions == fold

### DIFF
--- a/backend/cmd/positions-rebuild/main.go
+++ b/backend/cmd/positions-rebuild/main.go
@@ -1,0 +1,70 @@
+// Regenerate positions from the transaction ledger (ADR-0017): positions is a
+// cache, not a source of truth. This rebuilds positions.quantity = Σ
+// transactions.amount per (account, asset) — and the average-cost basis — so a
+// drifted or wiped positions table can be reconstructed entirely from facts.
+//
+// Usage: cd backend && APP_ENV=dev go run ./cmd/positions-rebuild <user_id|all>
+//
+// Effect: for each (account, asset) pair with transactions, recompute quantity
+// + cost basis via the same valuation path the trade/Plaid surfaces use and
+// upsert the position. Idempotent; one transaction per user.
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+	"strconv"
+
+	"gorm.io/gorm"
+
+	"github.com/gregwym/offbook/backend/internal/config"
+	"github.com/gregwym/offbook/backend/internal/db"
+	"github.com/gregwym/offbook/backend/internal/model"
+	"github.com/gregwym/offbook/backend/internal/repository"
+	"github.com/gregwym/offbook/backend/internal/service"
+)
+
+func main() {
+	if len(os.Args) != 2 {
+		log.Fatal("usage: positions-rebuild <user_id|all>")
+	}
+
+	cfg := config.MustLoad()
+	gormDB, err := db.Open(cfg.DatabaseURL)
+	if err != nil {
+		log.Fatalf("db open: %v", err)
+	}
+
+	prices := repository.NewPriceRepository(gormDB)
+	users := repository.NewUserRepository(gormDB)
+	ctx := context.Background()
+
+	var ids []int64
+	if os.Args[1] == "all" {
+		ids, err = allUserIDs(gormDB)
+		if err != nil {
+			log.Fatalf("list users: %v", err)
+		}
+	} else {
+		id, err := strconv.ParseInt(os.Args[1], 10, 64)
+		if err != nil {
+			log.Fatalf("invalid user_id: %v", err)
+		}
+		ids = []int64{id}
+	}
+
+	for _, id := range ids {
+		res, err := service.RebuildPositions(ctx, gormDB, prices, users, id)
+		if err != nil {
+			log.Fatalf("rebuild user %d: %v", id, err)
+		}
+		log.Printf("user %d: rebuilt %d position(s) across %d (account, asset) pair(s)", id, res.Updated, res.Pairs)
+	}
+}
+
+func allUserIDs(g *gorm.DB) ([]int64, error) {
+	var ids []int64
+	err := g.Model(&model.User{}).Where("deleted_at IS NULL").Order("id").Pluck("id", &ids).Error
+	return ids, err
+}

--- a/backend/internal/repository/transaction_repo.go
+++ b/backend/internal/repository/transaction_repo.go
@@ -100,6 +100,11 @@ type TransactionRepository interface {
 	// already exists for the (account, asset) pair. The first reconciling
 	// write is an opening_balance anchor; later ones are adjustments.
 	HasReconcilingTxn(ctx context.Context, userID, accountID, assetID int64) (bool, error)
+	// DistinctAccountAssetPairs returns every (account_id, asset_id) pair that
+	// has at least one non-deleted transaction for the user. Used by the
+	// positions rebuild to materialize positions.quantity = Σ amount per pair
+	// (ADR-0017) — proving positions is a pure fold of the ledger.
+	DistinctAccountAssetPairs(ctx context.Context, userID int64) ([]AccountAssetPair, error)
 	// ListForCategorizationScope returns a chunk of non-deleted transactions
 	// for the user, ordered by id ASC for cursor-style pagination. Callers
 	// drive a loop by passing the last returned row's id as afterID on the
@@ -428,6 +433,26 @@ func (r *transactionRepo) FoldQuantity(ctx context.Context, userID, accountID, a
 		return decimal.Zero, err
 	}
 	return d, nil
+}
+
+// AccountAssetPair identifies one (account, asset) position key. Returned by
+// DistinctAccountAssetPairs for the positions rebuild.
+type AccountAssetPair struct {
+	AccountID int64
+	AssetID   int64
+}
+
+func (r *transactionRepo) DistinctAccountAssetPairs(ctx context.Context, userID int64) ([]AccountAssetPair, error) {
+	var out []AccountAssetPair
+	if err := r.db.WithContext(ctx).
+		Model(&model.Transaction{}).
+		Distinct("account_id", "asset_id").
+		Where("user_id = ? AND deleted_at IS NULL", userID).
+		Order("account_id, asset_id").
+		Find(&out).Error; err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (r *transactionRepo) HasReconcilingTxn(ctx context.Context, userID, accountID, assetID int64) (bool, error) {

--- a/backend/internal/service/positions_rebuild.go
+++ b/backend/internal/service/positions_rebuild.go
@@ -1,0 +1,94 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"gorm.io/gorm"
+
+	"github.com/gregwym/offbook/backend/internal/model"
+	"github.com/gregwym/offbook/backend/internal/repository"
+	"github.com/gregwym/offbook/backend/internal/service/valuation"
+)
+
+// RebuildPositionsResult summarizes a regeneration pass.
+type RebuildPositionsResult struct {
+	// Pairs is the number of (account, asset) keys with transactions.
+	Pairs int
+	// Updated is the number of position rows upserted.
+	Updated int
+}
+
+// RebuildPositions regenerates positions from the transaction ledger for one
+// user, demonstrating the ADR-0017 invariant that positions is a pure fold of
+// transactions: positions.quantity == Σ non-deleted transactions.amount per
+// (account, asset). For every such pair it recomputes quantity (+ average-cost
+// basis via valuation.Recompute) and upserts the position. Safe to re-run.
+//
+// When a trade's cost basis can't be priced (no trade-date FX), the pair still
+// gets its quantity materialized from the raw fold with cost basis left
+// unknown — the quantity invariant must hold even when valuation can't.
+//
+// The whole pass runs in one transaction so positions never observe a
+// half-rebuilt state.
+func RebuildPositions(
+	ctx context.Context,
+	db *gorm.DB,
+	prices repository.PriceRepository,
+	users repository.UserRepository,
+	userID int64,
+) (RebuildPositionsResult, error) {
+	user, err := users.GetByID(ctx, userID)
+	if err != nil {
+		return RebuildPositionsResult{}, fmt.Errorf("rebuild positions: load user: %w", err)
+	}
+
+	var res RebuildPositionsResult
+	err = db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		txRepo := repository.NewTransactionRepository(tx)
+		posRepo := repository.NewPositionRepository(tx)
+
+		pairs, err := txRepo.DistinctAccountAssetPairs(ctx, userID)
+		if err != nil {
+			return fmt.Errorf("rebuild positions: list pairs: %w", err)
+		}
+		res.Pairs = len(pairs)
+
+		for _, p := range pairs {
+			rc, err := valuation.Recompute(ctx, txRepo, prices, userID, p.AccountID, p.AssetID, user.PrimaryCurrencyAssetID)
+			if err != nil {
+				if !errors.Is(err, valuation.ErrFXUnavailable) {
+					return fmt.Errorf("rebuild positions: recompute (acct=%d asset=%d): %w", p.AccountID, p.AssetID, err)
+				}
+				// Cost basis needs an FX rate we don't have. Fall back to the
+				// raw fold so quantity is still correct; cost basis stays NULL.
+				qty, ferr := txRepo.FoldQuantity(ctx, userID, p.AccountID, p.AssetID)
+				if ferr != nil {
+					return fmt.Errorf("rebuild positions: fold fallback (acct=%d asset=%d): %w", p.AccountID, p.AssetID, ferr)
+				}
+				rc = valuation.RecomputeResult{Quantity: qty}
+			}
+
+			pos := &model.Position{
+				UserID:    userID,
+				AccountID: p.AccountID,
+				AssetID:   p.AssetID,
+				Quantity:  rc.Quantity,
+			}
+			if rc.HasCostBasis {
+				cb := rc.CostBasis
+				pos.CostBasis = &cb
+			}
+			if err := posRepo.Upsert(ctx, pos); err != nil {
+				return fmt.Errorf("rebuild positions: upsert (acct=%d asset=%d): %w", p.AccountID, p.AssetID, err)
+			}
+			res.Updated++
+		}
+		return nil
+	})
+	if err != nil {
+		return RebuildPositionsResult{}, err
+	}
+	return res, nil
+}

--- a/backend/internal/service/positions_rebuild_test.go
+++ b/backend/internal/service/positions_rebuild_test.go
@@ -1,0 +1,97 @@
+package service_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/shopspring/decimal"
+	"gorm.io/gorm"
+
+	"github.com/gregwym/offbook/backend/internal/model"
+	"github.com/gregwym/offbook/backend/internal/repository"
+	"github.com/gregwym/offbook/backend/internal/service"
+)
+
+func seedLedgerTx(t *testing.T, g *gorm.DB, userID, accountID, assetID int64, kind, amount string) {
+	t.Helper()
+	desc := kind
+	row := &model.Transaction{
+		UserID:          userID,
+		AccountID:       accountID,
+		AssetID:         assetID,
+		Kind:            kind,
+		Amount:          decimal.RequireFromString(amount),
+		Description:     &desc,
+		TransactionDate: time.Now().UTC(),
+		Source:          "manual",
+	}
+	if err := g.Create(row).Error; err != nil {
+		t.Fatalf("seed %s txn: %v", kind, err)
+	}
+}
+
+// TestRebuildPositions_MaterializesFoldPerPair proves the ADR-0017 invariant
+// that positions is a regenerable fold of the ledger: after RebuildPositions,
+// positions.quantity == Σ transactions.amount for every (account, asset),
+// even when the stored position was wrong beforehand.
+func TestRebuildPositions_MaterializesFoldPerPair(t *testing.T) {
+	g := openTestDB(t)
+	userID := seedTestUser(t, g)
+	accountID, usdID := seedReconcileAccount(t, g, userID)
+	ctx := context.Background()
+	txRepo := repository.NewTransactionRepository(g)
+	posRepo := repository.NewPositionRepository(g)
+
+	// Cash ledger folding to 5000: an opening_balance anchor plus three flows.
+	seedLedgerTx(t, g, userID, accountID, usdID, model.KindOpeningBalance, "3017.93")
+	seedLedgerTx(t, g, userID, accountID, usdID, model.KindFlow, "-5.43")
+	seedLedgerTx(t, g, userID, accountID, usdID, model.KindFlow, "2000")
+	seedLedgerTx(t, g, userID, accountID, usdID, model.KindFlow, "-12.50")
+
+	// Corrupt the cached position so the rebuild has something to correct.
+	if err := posRepo.Upsert(ctx, &model.Position{
+		UserID: userID, AccountID: accountID, AssetID: usdID, Quantity: decimal.NewFromInt(999),
+	}); err != nil {
+		t.Fatalf("seed corrupted position: %v", err)
+	}
+
+	prices := repository.NewPriceRepository(g)
+	users := repository.NewUserRepository(g)
+
+	res, err := service.RebuildPositions(ctx, g, prices, users, userID)
+	if err != nil {
+		t.Fatalf("RebuildPositions: %v", err)
+	}
+	if res.Pairs != 1 || res.Updated != 1 {
+		t.Errorf("result = %+v, want Pairs=1 Updated=1", res)
+	}
+
+	// The canonical invariant: position == fold.
+	fold, err := txRepo.FoldQuantity(ctx, userID, accountID, usdID)
+	if err != nil {
+		t.Fatalf("fold: %v", err)
+	}
+	if !fold.Equal(decimal.NewFromInt(5000)) {
+		t.Fatalf("fold = %s, want 5000 (test setup)", fold)
+	}
+	positions, err := posRepo.ListByAccountID(ctx, userID, accountID)
+	if err != nil {
+		t.Fatalf("load positions: %v", err)
+	}
+	if len(positions) != 1 {
+		t.Fatalf("positions = %d, want 1", len(positions))
+	}
+	if !positions[0].Quantity.Equal(fold) {
+		t.Errorf("position.quantity = %s, want %s (== fold)", positions[0].Quantity, fold)
+	}
+
+	// Idempotent: a second pass changes nothing.
+	if _, err := service.RebuildPositions(ctx, g, prices, users, userID); err != nil {
+		t.Fatalf("RebuildPositions #2: %v", err)
+	}
+	positions, _ = posRepo.ListByAccountID(ctx, userID, accountID)
+	if len(positions) != 1 || !positions[0].Quantity.Equal(fold) {
+		t.Errorf("after re-run, position = %+v, want single row == %s", positions, fold)
+	}
+}


### PR DESCRIPTION
Final slice of epic #270 / #293. Delivers the last open acceptance item: **positions is a regenerable fold of the ledger** (ADR-0017), proven by a rebuild path + invariant test.

## What changed
- **`service.RebuildPositions(userID)`** — for every `(account, asset)` pair with transactions, recompute `quantity` (+ average-cost basis via `valuation.Recompute`) and upsert the position, in a single DB transaction. If a trade's cost basis needs a trade-date FX rate we don't have, it falls back to the raw `FoldQuantity` so the **quantity** invariant still holds (cost basis left NULL — the honest "unknown").
- **`TransactionRepository.DistinctAccountAssetPairs`** — enumerates the position keys to rebuild.
- **`cmd/positions-rebuild <user_id|all>`** — operational wrapper to reconstruct a drifted or wiped `positions` table from facts.

## Test
`TestRebuildPositions_MaterializesFoldPerPair`: seed a cash ledger folding to 5000, corrupt the cached position to 999, rebuild, assert `position.quantity == FoldQuantity` per `(account, asset)`; idempotent on re-run.

Full `make verify` green (vet, `-race -p 1`, contract-check, frontend build).

## #293 is now complete
All scope items have landed across the slices:
1. opening balance as a transaction — #294
2. positions as a regenerable fold — **this PR** (+ reconcile wiring in #297/#298)
3. `account_balance_observations` table — #296
4. adjustment generation on divergent sync — #297 (cash) / #298 (holdings)
5. flow analytics filter by `kind` — #295

Closes #293. Also closes the #281 umbrella (transactions as the single source of quantity). Unblocks #282 (unified valuation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)