### PR TITLE
#282 (slice A): valuation.ValuePositions set primitive + incomplete contract

### DIFF
--- a/backend/internal/service/valuation/valuation.go
+++ b/backend/internal/service/valuation/valuation.go
@@ -120,6 +120,51 @@ func (s *Service) Value(ctx context.Context, pos model.Position, asOf time.Time,
 	return pos.Quantity.Mul(leg1).Mul(leg2), nil
 }
 
+// SetValuation is the result of valuing a set of positions in a single quote
+// currency at a point in time. It deliberately separates the priced total from
+// the positions that could not be priced, so callers can render an
+// "incomplete" figure rather than a wrong-but-confident one (#282): an unpriced
+// position contributes nothing to Value and is instead surfaced in Unpriced.
+//
+// Complete() is true when every position priced. A zero Value with a non-empty
+// Unpriced is "we don't know", distinct from a genuine zero balance.
+type SetValuation struct {
+	// Value is the sum of every position that priced fresh, in the quote asset.
+	Value decimal.Decimal
+	// Unpriced lists the asset_ids whose price chain was stale/missing at asOf.
+	// A nil/empty slice means the total is complete.
+	Unpriced []int64
+}
+
+// Complete reports whether every position in the set had a fresh price — i.e.
+// Value is the whole story, not a partial sum.
+func (v SetValuation) Complete() bool { return len(v.Unpriced) == 0 }
+
+// ValuePositions values an arbitrary set of positions in quoteAssetID at asOf
+// and reports which ones could not be priced. This is the single derivation
+// behind net worth, allocation, and trend (#282): callers assemble the
+// position set — current rows for "now", or synthetic rows carrying the
+// historical fold quantity for a past asOf — and differ only in that set and
+// the quote currency.
+//
+// Missing prices are NOT coerced to $0: a stale/absent price chain drops the
+// position from Value and records its asset in Unpriced. Other errors abort.
+func (s *Service) ValuePositions(ctx context.Context, positions []model.Position, asOf time.Time, quoteAssetID int64) (SetValuation, error) {
+	out := SetValuation{Value: decimal.Zero}
+	for _, p := range positions {
+		v, err := s.Value(ctx, p, asOf, quoteAssetID)
+		if errors.Is(err, ErrStalePrice) {
+			out.Unpriced = append(out.Unpriced, p.AssetID)
+			continue
+		}
+		if err != nil {
+			return SetValuation{}, err
+		}
+		out.Value = out.Value.Add(v)
+	}
+	return out, nil
+}
+
 // AccountBalance returns the sum of the account's positions valued at
 // asOf in the account's primary_quote_asset_id. Positions whose price
 // chain is stale contribute 0 — this matches the soft-fallback behavior
@@ -138,20 +183,11 @@ func (s *Service) AccountBalance(ctx context.Context, userID, accountID int64, a
 	if err != nil {
 		return decimal.Zero, nil, fmt.Errorf("valuation: list positions for account %d: %w", accountID, err)
 	}
-	total := decimal.Zero
-	var stale []int64
-	for _, p := range positions {
-		v, err := s.Value(ctx, p, asOf, acct.PrimaryQuoteAssetID)
-		if errors.Is(err, ErrStalePrice) {
-			stale = append(stale, p.AssetID)
-			continue
-		}
-		if err != nil {
-			return decimal.Zero, nil, err
-		}
-		total = total.Add(v)
+	val, err := s.ValuePositions(ctx, positions, asOf, acct.PrimaryQuoteAssetID)
+	if err != nil {
+		return decimal.Zero, nil, err
 	}
-	return total, stale, nil
+	return val.Value, val.Unpriced, nil
 }
 
 // lookupRate returns the most-recent price for (assetID → quoteAssetID)

--- a/backend/internal/service/valuation/valuation_set_test.go
+++ b/backend/internal/service/valuation/valuation_set_test.go
@@ -1,0 +1,106 @@
+package valuation_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/shopspring/decimal"
+
+	"github.com/gregwym/offbook/backend/internal/model"
+	"github.com/gregwym/offbook/backend/internal/testutil"
+)
+
+// TestValuePositions_PartialPricingReportsIncomplete proves the #282 contract:
+// a position with no available price is reported as unpriced, not silently
+// counted as $0. The priced legs still sum; the unpriced asset is surfaced.
+func TestValuePositions_PartialPricingReportsIncomplete(t *testing.T) {
+	svc, g := newSvc(t)
+	ctx := context.Background()
+	usd := testutil.LookupUSDAssetID(t, g)
+	eur := testutil.LookupAssetID(t, g, "EUR", "fiat")
+	btc := testutil.LookupAssetID(t, g, "BTC", "crypto")
+
+	insertPrice(t, g, eur, usd, "1.10", time.Now().Add(-time.Hour))
+	// Deliberately no BTC price.
+
+	positions := []model.Position{
+		{AssetID: usd, Quantity: decimal.NewFromInt(1000)},
+		{AssetID: eur, Quantity: decimal.NewFromInt(100)},
+		{AssetID: btc, Quantity: decimal.RequireFromString("0.5")},
+	}
+	got, err := svc.ValuePositions(ctx, positions, time.Now(), usd)
+	if err != nil {
+		t.Fatalf("ValuePositions: %v", err)
+	}
+	if !got.Value.Equal(decimal.RequireFromString("1110")) {
+		t.Errorf("Value = %s, want 1110 (1000 USD + 100×1.10 EUR; BTC excluded)", got.Value)
+	}
+	if got.Complete() {
+		t.Error("Complete() = true, want false (BTC unpriced)")
+	}
+	if len(got.Unpriced) != 1 || got.Unpriced[0] != btc {
+		t.Errorf("Unpriced = %v, want [%d] (BTC)", got.Unpriced, btc)
+	}
+}
+
+// TestValuePositions_AllPricedIsComplete: when every position prices, the total
+// is the whole story and Complete() is true.
+func TestValuePositions_AllPricedIsComplete(t *testing.T) {
+	svc, g := newSvc(t)
+	ctx := context.Background()
+	usd := testutil.LookupUSDAssetID(t, g)
+	eur := testutil.LookupAssetID(t, g, "EUR", "fiat")
+
+	insertPrice(t, g, eur, usd, "1.25", time.Now().Add(-time.Hour))
+
+	positions := []model.Position{
+		{AssetID: usd, Quantity: decimal.NewFromInt(500)},
+		{AssetID: eur, Quantity: decimal.NewFromInt(200)},
+	}
+	got, err := svc.ValuePositions(ctx, positions, time.Now(), usd)
+	if err != nil {
+		t.Fatalf("ValuePositions: %v", err)
+	}
+	if !got.Value.Equal(decimal.RequireFromString("750")) {
+		t.Errorf("Value = %s, want 750 (500 + 200×1.25)", got.Value)
+	}
+	if !got.Complete() || len(got.Unpriced) != 0 {
+		t.Errorf("Complete=%v Unpriced=%v, want complete with no unpriced", got.Complete(), got.Unpriced)
+	}
+}
+
+// TestValuePositions_HistoricalQuantityUsesAsOfPrice: the same set valued at an
+// earlier asOf picks up that date's price, so a synthetic position carrying a
+// past fold quantity values at the past price — the basis for the unified trend.
+func TestValuePositions_HistoricalQuantityUsesAsOfPrice(t *testing.T) {
+	svc, g := newSvc(t)
+	ctx := context.Background()
+	usd := testutil.LookupUSDAssetID(t, g)
+	eur := testutil.LookupAssetID(t, g, "EUR", "fiat")
+
+	now := time.Now()
+	insertPrice(t, g, eur, usd, "1.00", now.AddDate(0, 0, -60))
+	insertPrice(t, g, eur, usd, "1.50", now.AddDate(0, 0, -1))
+
+	positions := []model.Position{{AssetID: eur, Quantity: decimal.NewFromInt(100)}}
+
+	// Disable the stale gate so an old price is acceptable for history.
+	hist := svc.WithStaleWindow(0)
+
+	past, err := hist.ValuePositions(ctx, positions, now.AddDate(0, 0, -30), usd)
+	if err != nil {
+		t.Fatalf("ValuePositions past: %v", err)
+	}
+	if !past.Value.Equal(decimal.NewFromInt(100)) {
+		t.Errorf("past Value = %s, want 100 (100×1.00 at -30d)", past.Value)
+	}
+
+	recent, err := hist.ValuePositions(ctx, positions, now, usd)
+	if err != nil {
+		t.Fatalf("ValuePositions recent: %v", err)
+	}
+	if !recent.Value.Equal(decimal.NewFromInt(150)) {
+		t.Errorf("recent Value = %s, want 150 (100×1.50)", recent.Value)
+	}
+}


### PR DESCRIPTION
First slice of #282. Adds the single set-valuation derivation every money-over-accounts surface will be unified onto, and establishes the **missing-price contract**.

Today `valuation.Service` is only exercised by its own tests — the live net-worth/allocation surfaces use bespoke raw SQL that disagrees by construction and coerces missing prices to \$0. This slice lays the shared primitive; later slices migrate the consumers and delete the bespoke queries.

## What changed
- **`valuation.Service.ValuePositions(positions, asOf, quote) → SetValuation{Value, Unpriced []assetID}`** with `Complete()`. A stale/absent price chain drops the position from `Value` and records its asset in `Unpriced` — **never silently \$0**. So a zero `Value` with a non-empty `Unpriced` means "we don't know", distinct from a genuine zero.
- **`AccountBalance` refactored onto `ValuePositions`** — one code path, same stale→excluded behavior.
- Serves both **current** quantity (asOf=now) and **historical** quantity (synthetic position carrying a past fold + `WithStaleWindow(0)`), which is the basis for the unified trend.

## Tests
- partial pricing → incomplete, unpriced asset surfaced;
- all priced → complete;
- historical asOf picks up that date's price (a position valued at -30d uses the -30d rate).

`make verify` green.

## Next
- Slice B: replace `NetWorthByMonth` (unit-mixing) + household `NetWorthSeries` (current-quantity) with historical-fold `ValuePositions` — personal & household trends identical for the same account set.
- Slice C: allocation + plumb the `complete/unpriced` flag to API/frontend; delete the `COALESCE(price,0)` missing-price→\$0.

Part of #282.

🤖 Generated with [Claude Code](https://claude.com/claude-code)