### PR TITLE
#282 (slice B): unify personal net-worth trend on ledger-fold valuation

### DIFF
--- a/backend/internal/repository/dashboard_repo.go
+++ b/backend/internal/repository/dashboard_repo.go
@@ -73,14 +73,6 @@ type CashFlowMonth struct {
 	Net     decimal.Decimal
 }
 
-// NetWorthMonth is one row of the net-worth trend chart. Date is the
-// month-end day (e.g. 2026-05-31 for May 2026). Total is the
-// back-derived account-balance total at that point.
-type NetWorthMonth struct {
-	Date  time.Time
-	Total decimal.Decimal
-}
-
 // DashboardRepository runs the read-only aggregation queries that power the
 // dashboard. All queries are scoped to the requesting user_id.
 type DashboardRepository interface {
@@ -93,11 +85,6 @@ type DashboardRepository interface {
 	// calendar months ending at the month containing `now`. Income/outflow
 	// are positive; transfers excluded.
 	CashFlowByMonth(ctx context.Context, userID int64, now time.Time, months int) ([]CashFlowMonth, error)
-	// NetWorthByMonth returns approximated month-end account totals for the
-	// last `months` months ending at `now`. The current month's row uses
-	// the current persisted balance; older months back-derive by undoing
-	// transactions between the row's month-end and now.
-	NetWorthByMonth(ctx context.Context, userID int64, now time.Time, months int) ([]NetWorthMonth, error)
 	// TradeSummaryByKind aggregates security-leg counts and gross
 	// notional (|security qty × latest_price_to_primary|) over [from, to),
 	// grouped by the asset's kind ('equity', 'crypto', …). Fiat legs are
@@ -318,75 +305,6 @@ func (r *dashboardRepo) CashFlowByMonth(ctx context.Context, userID int64, now t
 		} else {
 			out = append(out, CashFlowMonth{Month: m, Inflow: decimal.Zero, Outflow: decimal.Zero, Net: decimal.Zero})
 		}
-	}
-	return out, nil
-}
-
-// NetWorthByMonth approximates month-end balances by walking backwards
-// from the current persisted total. Methodology: today's net worth is the
-// sum of live accounts.balance. Subtract all transactions dated after
-// month-end to back-derive the balance at month-end.
-//
-// This is an approximation — non-transactional balance changes (manual
-// edits to accounts.balance, currency conversion gaps, etc.) won't be
-// reflected. Documented in the chart caption. A future enhancement could
-// snapshot daily balances; for M5 this gets us a trendline.
-func (r *dashboardRepo) NetWorthByMonth(ctx context.Context, userID int64, now time.Time, months int) ([]NetWorthMonth, error) {
-	if months <= 0 {
-		months = 12
-	}
-	now = now.UTC()
-	// Current net worth, computed from positions × latest prices per ADR-0013.
-	var cur string
-	if err := r.db.WithContext(ctx).Raw(netWorthQuery, userID).Scan(&cur).Error; err != nil {
-		return nil, err
-	}
-	curD, _ := decimal.NewFromString(cur)
-
-	// Month boundaries: monthEnd[i] is the last day of the i-th month
-	// (oldest first). For "last 12 months ending now", the newest row is
-	// the current month-end (today's date capped at month-end).
-	startMonth := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC).AddDate(0, -months+1, 0)
-	out := make([]NetWorthMonth, 0, months)
-	for i := 0; i < months; i++ {
-		first := startMonth.AddDate(0, i, 0)
-		// Day before next month-first = month-end.
-		monthEnd := first.AddDate(0, 1, 0).AddDate(0, 0, -1)
-		out = append(out, NetWorthMonth{Date: monthEnd})
-	}
-
-	// For every month, sum transactions with transaction_date > monthEnd
-	// → those are the moves that happened between that point and now.
-	// Subtract from current total. We issue ONE query that fetches all
-	// transactions newer than the oldest month boundary, then bucket in Go.
-	type txRow struct {
-		Date   time.Time
-		Amount string
-	}
-	var txns []txRow
-	if err := r.db.WithContext(ctx).Raw(`
-		SELECT transaction_date AS date, amount::text AS amount
-		FROM transactions
-		WHERE deleted_at IS NULL
-		  AND user_id = ?
-		  AND transaction_date > ?
-	`, userID, out[0].Date).Scan(&txns).Error; err != nil {
-		return nil, err
-	}
-
-	// Compute cumulative "since" sum per boundary by sorting boundaries and
-	// transactions, walking through. For len(out) ≤ 24 a quadratic loop
-	// is fine; not bothering to optimize.
-	for i := range out {
-		boundary := out[i].Date
-		undo := decimal.Zero
-		for _, t := range txns {
-			if t.Date.UTC().After(boundary) {
-				amt, _ := decimal.NewFromString(t.Amount)
-				undo = undo.Add(amt)
-			}
-		}
-		out[i].Total = curD.Sub(undo)
 	}
 	return out, nil
 }

--- a/backend/internal/repository/transaction_repo.go
+++ b/backend/internal/repository/transaction_repo.go
@@ -105,6 +105,13 @@ type TransactionRepository interface {
 	// positions rebuild to materialize positions.quantity = Σ amount per pair
 	// (ADR-0017) — proving positions is a pure fold of the ledger.
 	DistinctAccountAssetPairs(ctx context.Context, userID int64) ([]AccountAssetPair, error)
+	// FoldByUserAsOf returns one synthetic position per asset for the user:
+	// quantity = Σ non-deleted transactions.amount with transaction_date <=
+	// asOf, across all the user's accounts. Assets folding to zero are
+	// omitted. Used by the unified net-worth trend (#282) to reconstruct the
+	// quantity held at a past instant from the ledger. AccountID is left zero
+	// — the caller values per asset in a single quote currency.
+	FoldByUserAsOf(ctx context.Context, userID int64, asOf time.Time) ([]model.Position, error)
 	// ListForCategorizationScope returns a chunk of non-deleted transactions
 	// for the user, ordered by id ASC for cursor-style pagination. Callers
 	// drive a loop by passing the last returned row's id as afterID on the
@@ -451,6 +458,35 @@ func (r *transactionRepo) DistinctAccountAssetPairs(ctx context.Context, userID 
 		Order("account_id, asset_id").
 		Find(&out).Error; err != nil {
 		return nil, err
+	}
+	return out, nil
+}
+
+func (r *transactionRepo) FoldByUserAsOf(ctx context.Context, userID int64, asOf time.Time) ([]model.Position, error) {
+	type row struct {
+		AssetID int64
+		Qty     string
+	}
+	var rows []row
+	if err := r.db.WithContext(ctx).Raw(`
+		SELECT asset_id, COALESCE(SUM(amount), 0)::text AS qty
+		FROM transactions
+		WHERE deleted_at IS NULL
+		  AND user_id = ?
+		  AND transaction_date <= ?
+		GROUP BY asset_id
+		HAVING COALESCE(SUM(amount), 0) <> 0
+		ORDER BY asset_id
+	`, userID, asOf).Scan(&rows).Error; err != nil {
+		return nil, err
+	}
+	out := make([]model.Position, 0, len(rows))
+	for _, r := range rows {
+		q, err := decimal.NewFromString(r.Qty)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, model.Position{UserID: userID, AssetID: r.AssetID, Quantity: q})
 	}
 	return out, nil
 }

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -16,6 +16,7 @@ import (
 	"github.com/gregwym/offbook/backend/internal/service/auth"
 	"github.com/gregwym/offbook/backend/internal/service/household"
 	plaidsvc "github.com/gregwym/offbook/backend/internal/service/plaid"
+	"github.com/gregwym/offbook/backend/internal/service/valuation"
 )
 
 func New(cfg config.Config, gormDB *gorm.DB) *gin.Engine {
@@ -65,7 +66,8 @@ func New(cfg config.Config, gormDB *gorm.DB) *gin.Engine {
 	ruleHandler := handler.NewCategorizationRuleHandler(ruleSvc)
 
 	dashboardRepo := repository.NewDashboardRepository(gormDB)
-	dashboardSvc := service.NewDashboardService(dashboardRepo)
+	valuationSvc := valuation.NewService(positionRepo, priceRepo, assetRepo, accountRepo)
+	dashboardSvc := service.NewDashboardService(dashboardRepo, transactionRepo, userRepo, valuationSvc)
 
 	budgetRepo := repository.NewBudgetRepository(gormDB)
 	budgetSvc := service.NewBudgetService(budgetRepo, categoryRepo)

--- a/backend/internal/service/dashboard_charts_test.go
+++ b/backend/internal/service/dashboard_charts_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/gregwym/offbook/backend/internal/model"
 	"github.com/gregwym/offbook/backend/internal/repository"
 	"github.com/gregwym/offbook/backend/internal/service"
+	"github.com/gregwym/offbook/backend/internal/service/valuation"
 	"github.com/gregwym/offbook/backend/internal/testutil"
 )
 
@@ -29,9 +30,47 @@ func newDashboardSvc(t *testing.T) (svc *service.DashboardService, userID, accou
 		g.Unscoped().Where("account_id = ?", acc.ID).Delete(&model.Transaction{})
 		g.Unscoped().Delete(&model.Account{}, acc.ID)
 	})
-	svc = service.NewDashboardService(repository.NewDashboardRepository(g))
+	svc = service.NewDashboardService(
+		repository.NewDashboardRepository(g),
+		repository.NewTransactionRepository(g),
+		repository.NewUserRepository(g),
+		valuation.NewService(
+			repository.NewPositionRepository(g),
+			repository.NewPriceRepository(g),
+			repository.NewAssetRepository(g),
+			repository.NewAccountRepository(g),
+		),
+	)
 	svc.SetClock(func() time.Time { return time.Date(2026, 5, 15, 12, 0, 0, 0, time.UTC) })
 	return svc, userID, acc.ID, g
+}
+
+// seedNetWorthTxn seeds a ledger transaction carrying an explicit asset + kind,
+// so the unified net-worth trend can fold quantity per asset over time.
+func seedNetWorthTxn(t *testing.T, g *gorm.DB, userID, accountID, assetID int64, kind string, date time.Time, amount string) {
+	t.Helper()
+	tx := &model.Transaction{
+		UserID: userID, AccountID: accountID, AssetID: assetID,
+		Kind:            kind,
+		Amount:          decimal.RequireFromString(amount),
+		TransactionDate: date,
+		Source:          "manual",
+	}
+	if err := g.Create(tx).Error; err != nil {
+		t.Fatalf("seed net-worth txn: %v", err)
+	}
+}
+
+func insertNetWorthPrice(t *testing.T, g *gorm.DB, assetID, quoteAssetID int64, price string, asOf time.Time) {
+	t.Helper()
+	p := &model.Price{
+		AssetID: assetID, QuoteAssetID: quoteAssetID,
+		Price: decimal.RequireFromString(price), AsOf: asOf, Source: "test",
+	}
+	if err := g.Create(p).Error; err != nil {
+		t.Fatalf("seed price: %v", err)
+	}
+	t.Cleanup(func() { g.Unscoped().Delete(&model.Price{}, p.ID) })
 }
 
 func seedChartTxn(t *testing.T, g *gorm.DB, userID, accountID int64, categoryID *int64, date time.Time, amt decimal.Decimal, isTransfer bool) {
@@ -173,23 +212,18 @@ func TestDashboard_CashFlow_EmptyMonthsPaddedZeros(t *testing.T) {
 // outflows ($-100 each) happened on May 5 and May 10. The month-end
 // rows for April and earlier should back-derive to $1200 (current +
 // undone $200 of spending).
-func TestDashboard_NetWorth_BackDerives(t *testing.T) {
+// TestDashboard_NetWorth_TradeStepsWithFlatPrices: with prices flat (USD cash,
+// quote == asset), the trend steps only when the quantity fold changes. An
+// opening balance plus a later inflow produce a step at the inflow's month.
+func TestDashboard_NetWorth_TradeStepsWithFlatPrices(t *testing.T) {
 	svc, userID, accountID, g := newDashboardSvc(t)
 	ctx := context.Background()
-
-	// Seed a position at 1000 USD — newDashboardSvc creates the account
-	// with no positions. Per ADR-0013, balance is derived from positions.
 	usdID := testutil.LookupUSDAssetID(t, g)
-	if err := g.Exec(
-		`INSERT INTO positions (user_id, account_id, asset_id, quantity, updated_at)
-		 VALUES (?, ?, ?, 1000, NOW())
-		 ON CONFLICT (account_id, asset_id) WHERE deleted_at IS NULL
-		 DO UPDATE SET quantity = EXCLUDED.quantity, updated_at = NOW()`,
-		userID, accountID, usdID).Error; err != nil {
-		t.Fatalf("seed position: %v", err)
-	}
-	seedChartTxn(t, g, userID, accountID, nil, time.Date(2026, 5, 5, 0, 0, 0, 0, time.UTC), decimal.NewFromInt(-100), false)
-	seedChartTxn(t, g, userID, accountID, nil, time.Date(2026, 5, 10, 0, 0, 0, 0, time.UTC), decimal.NewFromInt(-100), false)
+
+	// Opening balance of 1000 in February (before the window), then +500 in
+	// April. Fold: Mar-end 1000, Apr-end 1500, May-end 1500.
+	seedNetWorthTxn(t, g, userID, accountID, usdID, model.KindOpeningBalance, time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC), "1000")
+	seedNetWorthTxn(t, g, userID, accountID, usdID, model.KindFlow, time.Date(2026, 4, 10, 0, 0, 0, 0, time.UTC), "500")
 
 	rows, err := svc.NetWorth(ctx, userID, 3) // March, April, May
 	if err != nil {
@@ -198,18 +232,49 @@ func TestDashboard_NetWorth_BackDerives(t *testing.T) {
 	if len(rows) != 3 {
 		t.Fatalf("got %d rows, want 3", len(rows))
 	}
-	// rows[0] = March 2026 end (2026-03-31): subtract all transactions
-	// after that → -200 worth of outflows → balance at end-March was 1200.
-	// rows[1] = April 2026 end (2026-04-30): same, also 1200 (no April txns).
-	// rows[2] = May 2026 end (2026-05-31): no txns after that → 1000.
-	if rows[0].Total != "1200" {
-		t.Errorf("March 2026 net worth = %s, want 1200", rows[0].Total)
+	want := []string{"1000", "1500", "1500"}
+	for i, w := range want {
+		if rows[i].Total != w {
+			t.Errorf("row[%d] (%s) total = %s, want %s", i, rows[i].Date, rows[i].Total, w)
+		}
+		if !rows[i].Complete {
+			t.Errorf("row[%d] expected complete (USD == primary, always priced)", i)
+		}
 	}
-	if rows[1].Total != "1200" {
-		t.Errorf("April 2026 net worth = %s, want 1200", rows[1].Total)
+}
+
+// TestDashboard_NetWorth_PriceMovesWithNoTrades: holding a constant quantity of
+// a non-primary asset, the trend moves purely with that asset's price — and a
+// month-end before any price exists is reported incomplete, not silently $0.
+func TestDashboard_NetWorth_PriceMovesWithNoTrades(t *testing.T) {
+	svc, userID, accountID, g := newDashboardSvc(t)
+	ctx := context.Background()
+	usdID := testutil.LookupUSDAssetID(t, g)
+	eurID := testutil.LookupAssetID(t, g, "EUR", "fiat")
+
+	// Hold 100 EUR from January on — quantity never changes.
+	seedNetWorthTxn(t, g, userID, accountID, eurID, model.KindOpeningBalance, time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC), "100")
+	// No EUR price in March; price appears in April and rises in May.
+	insertNetWorthPrice(t, g, eurID, usdID, "1.20", time.Date(2026, 4, 2, 0, 0, 0, 0, time.UTC))
+	insertNetWorthPrice(t, g, eurID, usdID, "1.50", time.Date(2026, 5, 2, 0, 0, 0, 0, time.UTC))
+
+	rows, err := svc.NetWorth(ctx, userID, 3) // March, April, May
+	if err != nil {
+		t.Fatalf("NetWorth: %v", err)
 	}
-	if rows[2].Total != "1000" {
-		t.Errorf("May 2026 net worth = %s, want 1000", rows[2].Total)
+	if len(rows) != 3 {
+		t.Fatalf("got %d rows, want 3", len(rows))
+	}
+	// March: no EUR price → unpriced → incomplete, partial total 0.
+	if rows[0].Complete || rows[0].Total != "0" {
+		t.Errorf("March row = {total:%s complete:%v}, want {0 false} (EUR unpriced)", rows[0].Total, rows[0].Complete)
+	}
+	// April: 100 × 1.20 = 120; May: 100 × 1.50 = 150 — moving with price.
+	if rows[1].Total != "120" || !rows[1].Complete {
+		t.Errorf("April row = {total:%s complete:%v}, want {120 true}", rows[1].Total, rows[1].Complete)
+	}
+	if rows[2].Total != "150" || !rows[2].Complete {
+		t.Errorf("May row = {total:%s complete:%v}, want {150 true}", rows[2].Total, rows[2].Complete)
 	}
 }
 
@@ -226,7 +291,13 @@ func TestDashboard_NetWorth_TenantIsolation(t *testing.T) {
 	if err := g.Create(accB).Error; err != nil {
 		t.Fatalf("seed B: %v", err)
 	}
-	t.Cleanup(func() { g.Unscoped().Delete(&model.Account{}, accB.ID) })
+	t.Cleanup(func() {
+		g.Unscoped().Where("account_id = ?", accB.ID).Delete(&model.Transaction{})
+		g.Unscoped().Delete(&model.Account{}, accB.ID)
+	})
+	// User B has real money; the fold must stay user-scoped.
+	usdID := testutil.LookupUSDAssetID(t, g)
+	seedNetWorthTxn(t, g, userB, accB.ID, usdID, model.KindOpeningBalance, time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC), "9999")
 
 	rows, err := svc.NetWorth(ctx, userA, 3)
 	if err != nil {

--- a/backend/internal/service/dashboard_service.go
+++ b/backend/internal/service/dashboard_service.go
@@ -6,7 +6,9 @@ import (
 	"strings"
 	"time"
 
+	"github.com/gregwym/offbook/backend/internal/model"
 	"github.com/gregwym/offbook/backend/internal/repository"
+	"github.com/gregwym/offbook/backend/internal/service/valuation"
 )
 
 // Supported period keys for ?period=
@@ -67,20 +69,32 @@ type CashFlowMonth struct {
 	Net     string `json:"net"`
 }
 
-// NetWorthPoint mirrors repository.NetWorthMonth for the API.
+// NetWorthPoint is one month-end of the net-worth trend. Complete is false
+// when at least one held asset had no available price at that month-end, so
+// Total is a partial sum (#282) — the UI can flag "incomplete" rather than
+// present a confident-but-wrong figure.
 type NetWorthPoint struct {
-	Date  string `json:"date"`
-	Total string `json:"total"`
+	Date     string `json:"date"`
+	Total    string `json:"total"`
+	Complete bool   `json:"complete"`
 }
 
 // DashboardService composes the summary from the dashboard repo.
 type DashboardService struct {
-	repo repository.DashboardRepository
-	now  func() time.Time // injected so tests can fix the clock
+	repo  repository.DashboardRepository
+	txns  repository.TransactionRepository
+	users repository.UserRepository
+	val   *valuation.Service
+	now   func() time.Time // injected so tests can fix the clock
 }
 
-func NewDashboardService(repo repository.DashboardRepository) *DashboardService {
-	return &DashboardService{repo: repo, now: time.Now}
+func NewDashboardService(
+	repo repository.DashboardRepository,
+	txns repository.TransactionRepository,
+	users repository.UserRepository,
+	val *valuation.Service,
+) *DashboardService {
+	return &DashboardService{repo: repo, txns: txns, users: users, val: val, now: time.Now}
 }
 
 // SetClock overrides the time source. Tests use this; production callers
@@ -164,24 +178,56 @@ func (s *DashboardService) CashFlow(ctx context.Context, userID int64, months in
 	return out, nil
 }
 
-// NetWorth returns the trailing `months` months of back-derived month-end
-// totals. Defaults to 12.
+// NetWorth returns the trailing `months` months of month-end net worth,
+// computed by the unified valuation derivation (#282): at each month-end the
+// quantity held per asset is the transaction fold up to that date, priced at
+// that date's rate in the user's primary currency. This replaces the old
+// back-derivation, which subtracted raw transaction amounts across differing
+// assets (shares vs dollars) from a constant present-day total. Defaults to 12.
 func (s *DashboardService) NetWorth(ctx context.Context, userID int64, months int) ([]NetWorthPoint, error) {
 	if months <= 0 {
 		months = 12
 	}
-	rows, err := s.repo.NetWorthByMonth(ctx, userID, s.now(), months)
+	user, err := s.users.GetByID(ctx, userID)
 	if err != nil {
 		return nil, err
 	}
-	out := make([]NetWorthPoint, 0, len(rows))
-	for _, r := range rows {
+
+	asOfs := monthEndGrid(s.now().UTC(), months)
+	// Any-age prices are acceptable for a historical trend; the freshness
+	// gate exists to flag a stale *current* price, not to blank out history.
+	series, err := s.val.WithStaleWindow(0).Series(ctx, asOfs, user.PrimaryCurrencyAssetID,
+		func(ctx context.Context, asOf time.Time) ([]model.Position, error) {
+			return s.txns.FoldByUserAsOf(ctx, userID, asOf)
+		})
+	if err != nil {
+		return nil, err
+	}
+
+	out := make([]NetWorthPoint, 0, len(series))
+	for _, p := range series {
 		out = append(out, NetWorthPoint{
-			Date:  r.Date.Format("2006-01-02"),
-			Total: r.Total.String(),
+			Date:     p.AsOf.Format("2006-01-02"),
+			Total:    p.Value.String(),
+			Complete: p.Complete(),
 		})
 	}
 	return out, nil
+}
+
+// monthEndGrid returns the last-instant-of-month for the trailing `months`
+// months ending in now's month, oldest first. Each boundary is 23:59:59.999…
+// UTC of the month's last day so a price/transaction dated anywhere that day
+// is included.
+func monthEndGrid(now time.Time, months int) []time.Time {
+	startMonth := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC).AddDate(0, -months+1, 0)
+	out := make([]time.Time, 0, months)
+	for i := 0; i < months; i++ {
+		firstOfNext := startMonth.AddDate(0, i+1, 0)
+		monthEnd := firstOfNext.Add(-time.Nanosecond)
+		out = append(out, monthEnd)
+	}
+	return out
 }
 
 // TradeSummary is the AI-context view of a user's trade activity over

--- a/backend/internal/service/valuation/valuation.go
+++ b/backend/internal/service/valuation/valuation.go
@@ -58,12 +58,15 @@ func NewService(
 	}
 }
 
-// WithStaleWindow overrides the default 7-day tolerance. Pass a
-// non-positive value to disable the staleness check entirely (used
-// by the historical net-worth trend, where any-age price is fine).
+// WithStaleWindow returns a copy of the service with the stale tolerance
+// overridden. Pass a non-positive value to disable the staleness check
+// entirely (used by the historical net-worth trend, where any-age price is
+// fine). Copy semantics so a historical caller can't disable freshness for a
+// shared instance that also serves current reads.
 func (s *Service) WithStaleWindow(d time.Duration) *Service {
-	s.staleWindow = d
-	return s
+	cp := *s
+	cp.staleWindow = d
+	return &cp
 }
 
 // StaleWindow returns the currently-configured stale window. Useful
@@ -161,6 +164,41 @@ func (s *Service) ValuePositions(ctx context.Context, positions []model.Position
 			return SetValuation{}, err
 		}
 		out.Value = out.Value.Add(v)
+	}
+	return out, nil
+}
+
+// SeriesPoint is one timestamped entry of a valuation series.
+type SeriesPoint struct {
+	AsOf time.Time
+	SetValuation
+}
+
+// Series values a position set at each asOf and returns the aligned series.
+// positionsAt supplies the set for a given instant — current rows for "now",
+// or synthetic rows carrying the historical fold quantity for a past instant.
+// This is the single trend derivation behind both personal and household net
+// worth (#282): callers differ only in the positionsAt closure (which encodes
+// scope + tenancy) and the quote currency, so the same account set yields the
+// same series. Use WithStaleWindow(0) for historical points where any-age
+// prices are acceptable.
+func (s *Service) Series(
+	ctx context.Context,
+	asOfs []time.Time,
+	quoteAssetID int64,
+	positionsAt func(context.Context, time.Time) ([]model.Position, error),
+) ([]SeriesPoint, error) {
+	out := make([]SeriesPoint, 0, len(asOfs))
+	for _, asOf := range asOfs {
+		positions, err := positionsAt(ctx, asOf)
+		if err != nil {
+			return nil, err
+		}
+		val, err := s.ValuePositions(ctx, positions, asOf, quoteAssetID)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, SeriesPoint{AsOf: asOf, SetValuation: val})
 	}
 	return out, nil
 }


### PR DESCRIPTION
Second slice of #282. Replaces the personal net-worth trend's buggy back-derivation with the unified valuation derivation, building on the `ValuePositions` primitive from #300.

## The bug being fixed
`NetWorthByMonth` started from today's `positions × latest price` and back-derived each month-end by subtracting `Σ transactions.amount` dated after it — summing `amount` across **all assets** regardless of `asset_id`. Post-M10 a security leg's `amount` is in **shares**, so a 10-share buy "undid" 10 from a dollar total. Unit-mixing.

## What changed
- **`valuation.Service.Series(asOfs, quote, positionsAt)`** — the single trend derivation. `positionsAt` supplies the scoped position set per instant (current rows for now, or synthetic rows carrying the historical fold for a past asOf), so personal and household will return **identical series for the same account set**. Household adopts it in slice C.
- **`WithStaleWindow` now returns a copy** instead of mutating the shared service — a historical caller (window=0) can no longer disable freshness for current reads.
- **`TransactionRepository.FoldByUserAsOf`** — per-asset `Σ amount ≤ asOf` (user-scoped).
- **`DashboardService.NetWorth`** rebuilt on `Series`; **`NetWorthPoint.complete`** is false when an asset was unpriced at that month-end (partial total, not silent \$0).
- Deleted `NetWorthByMonth` + `NetWorthMonth`.

## Tests (the #282 acceptance shapes)
- flat prices + a mid-series inflow → a **step**;
- constant quantity + rising price → a **moving** curve;
- a month-end before any price exists → **incomplete**, total 0 (not silently \$0);
- tenant isolation preserved (user B's \$9999 doesn't leak into A's trend).

`make verify` green.

## Next (slice C, closes #282)
Wire household `NetWorthTrend` + allocation (personal & household) onto the same `valuation` path, delete `household_aggregator_repo`'s `COALESCE(price,0)` missing-price→\$0, and plumb the `complete`/`unpriced` flag to the API + frontend.

Part of #282.

🤖 Generated with [Claude Code](https://claude.com/claude-code)