### PR TITLE
#282 (slice C): unify household net-worth trend on the same valuation derivation

### DIFF
--- a/backend/internal/repository/household_aggregator_repo.go
+++ b/backend/internal/repository/household_aggregator_repo.go
@@ -77,13 +77,21 @@ type HouseholdAggregatorRepository interface {
 	// primary currency. Empty accountIDs returns nil.
 	AllocationByKind(ctx context.Context, accountIDs []int64) ([]AllocationBucket, error)
 
-	// NetWorthSeries returns one daily net-worth point per day in
-	// [from, to] (inclusive), summing CURRENT positions × historical
-	// prices across accountIDs. Days with no fresh price for a position
-	// contribute 0 for that position — matches the soft-fallback behavior
-	// of the live dashboard query so the chart is renderable even when a
-	// pricing gap exists.
-	NetWorthSeries(ctx context.Context, accountIDs []int64, from, to time.Time) ([]NetWorthPoint, error)
+	// FoldByAccountSetAsOf returns one synthetic position per asset across the
+	// given account set: quantity = Σ non-deleted transactions.amount with
+	// transaction_date <= asOf. Assets folding to zero are omitted. This is the
+	// cross-user dated fold behind the unified household net-worth trend (#282)
+	// — the household analogue of TransactionRepository.FoldByUserAsOf, but
+	// scoped by account set rather than user (the aggregator is the only
+	// blessed cross-user reader). AccountID/UserID are left zero; the caller
+	// values each asset in a single household quote currency.
+	FoldByAccountSetAsOf(ctx context.Context, accountIDs []int64, asOf time.Time) ([]model.Position, error)
+
+	// HouseholdQuoteAssetID returns the asset_id the household's aggregates are
+	// denominated in: the owning member's primary_currency_asset_id. A single
+	// quote per household keeps the net-worth trend from summing across
+	// heterogeneous currencies.
+	HouseholdQuoteAssetID(ctx context.Context, householdID int64) (int64, error)
 
 	// AccountBalances returns one row per account in accountIDs with the
 	// account's current balance in its owner's primary currency. Missing
@@ -97,14 +105,6 @@ type HouseholdAggregatorRepository interface {
 // quote per position.
 type AllocationBucket struct {
 	Kind  string
-	Value decimal.Decimal
-}
-
-// NetWorthPoint is one (date, value) point of the household net-worth
-// trend. Date is the calendar day (UTC midnight); Value is the sum of
-// current positions × historical prices for that day.
-type NetWorthPoint struct {
-	Date  time.Time
 	Value decimal.Decimal
 }
 
@@ -386,42 +386,57 @@ func (r *householdAggregatorRepo) AllocationByKind(ctx context.Context, accountI
 	return out, nil
 }
 
-func (r *householdAggregatorRepo) NetWorthSeries(ctx context.Context, accountIDs []int64, from, to time.Time) ([]NetWorthPoint, error) {
-	if len(accountIDs) == 0 || !to.After(from.Add(-time.Second)) {
+func (r *householdAggregatorRepo) FoldByAccountSetAsOf(ctx context.Context, accountIDs []int64, asOf time.Time) ([]model.Position, error) {
+	if len(accountIDs) == 0 {
 		return nil, nil
 	}
-	fromDay := time.Date(from.Year(), from.Month(), from.Day(), 0, 0, 0, 0, time.UTC)
-	toDay := time.Date(to.Year(), to.Month(), to.Day(), 0, 0, 0, 0, time.UTC)
-	type rawRow struct {
-		Date  time.Time
-		Value string
+	type row struct {
+		AssetID int64
+		Qty     string
 	}
-	var rows []rawRow
-	// Cross-join generate_series with positions; price lookup is bounded by
-	// `d + 1 day` so a day's entry uses the latest price posted ON OR BEFORE
-	// end-of-that-day. LEFT JOIN keeps days with no positions at 0.
-	err := r.db.WithContext(ctx).Raw(`
-		WITH days AS (
-			SELECT generate_series(?::date, ?::date, interval '1 day')::date AS d
-		)
-		SELECT days.d AS date,
-		       COALESCE(SUM(`+fmt.Sprintf(positionValueExpr, "AND pr.as_of <= days.d + interval '1 day'")+`), 0)::text AS value
-		FROM days
-		LEFT JOIN positions p ON p.deleted_at IS NULL AND p.account_id IN ?
-		LEFT JOIN accounts  a ON a.id = p.account_id AND a.deleted_at IS NULL
-		LEFT JOIN users     u ON u.id = p.user_id
-		GROUP BY days.d
-		ORDER BY days.d
-	`, fromDay, toDay, accountIDs).Scan(&rows).Error
-	if err != nil {
+	var rows []row
+	if err := r.db.WithContext(ctx).Raw(`
+		SELECT asset_id, COALESCE(SUM(amount), 0)::text AS qty
+		FROM transactions
+		WHERE deleted_at IS NULL
+		  AND account_id IN ?
+		  AND transaction_date <= ?
+		GROUP BY asset_id
+		HAVING COALESCE(SUM(amount), 0) <> 0
+		ORDER BY asset_id
+	`, accountIDs, asOf).Scan(&rows).Error; err != nil {
 		return nil, err
 	}
-	out := make([]NetWorthPoint, 0, len(rows))
+	out := make([]model.Position, 0, len(rows))
 	for _, row := range rows {
-		v, _ := decimal.NewFromString(row.Value)
-		out = append(out, NetWorthPoint{Date: row.Date.UTC(), Value: v})
+		q, err := decimal.NewFromString(row.Qty)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, model.Position{AssetID: row.AssetID, Quantity: q})
 	}
 	return out, nil
+}
+
+func (r *householdAggregatorRepo) HouseholdQuoteAssetID(ctx context.Context, householdID int64) (int64, error) {
+	var assetID int64
+	err := r.db.WithContext(ctx).Raw(`
+		SELECT u.primary_currency_asset_id
+		FROM household_members hm
+		JOIN users u ON u.id = hm.user_id
+		WHERE hm.household_id = ?
+		  AND hm.role = 'owner'
+		  AND hm.purged_at IS NULL
+		ORDER BY hm.joined_at
+		LIMIT 1
+	`, householdID).Scan(&assetID).Error
+	if err != nil {
+		return 0, err
+	}
+	if assetID == 0 {
+		return 0, ErrNotFound
+	}
+	return assetID, nil
 }
 
 func (r *householdAggregatorRepo) AccountBalances(ctx context.Context, accountIDs []int64) ([]AccountBalanceRow, error) {

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -111,6 +111,7 @@ func New(cfg config.Config, gormDB *gorm.DB) *gin.Engine {
 	aggregator := household.NewAggregator(
 		repository.NewHouseholdAggregatorRepository(gormDB),
 		householdRepo,
+		valuationSvc,
 	)
 	aggregatorHandler := handler.NewHouseholdAggregatorHandler(aggregator, memberRepo)
 

--- a/backend/internal/service/dashboard_service.go
+++ b/backend/internal/service/dashboard_service.go
@@ -193,7 +193,7 @@ func (s *DashboardService) NetWorth(ctx context.Context, userID int64, months in
 		return nil, err
 	}
 
-	asOfs := monthEndGrid(s.now().UTC(), months)
+	asOfs := valuation.MonthEndGrid(s.now(), months)
 	// Any-age prices are acceptable for a historical trend; the freshness
 	// gate exists to flag a stale *current* price, not to blank out history.
 	series, err := s.val.WithStaleWindow(0).Series(ctx, asOfs, user.PrimaryCurrencyAssetID,
@@ -213,21 +213,6 @@ func (s *DashboardService) NetWorth(ctx context.Context, userID int64, months in
 		})
 	}
 	return out, nil
-}
-
-// monthEndGrid returns the last-instant-of-month for the trailing `months`
-// months ending in now's month, oldest first. Each boundary is 23:59:59.999…
-// UTC of the month's last day so a price/transaction dated anywhere that day
-// is included.
-func monthEndGrid(now time.Time, months int) []time.Time {
-	startMonth := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC).AddDate(0, -months+1, 0)
-	out := make([]time.Time, 0, months)
-	for i := 0; i < months; i++ {
-		firstOfNext := startMonth.AddDate(0, i+1, 0)
-		monthEnd := firstOfNext.Add(-time.Nanosecond)
-		out = append(out, monthEnd)
-	}
-	return out
 }
 
 // TradeSummary is the AI-context view of a user's trade activity over

--- a/backend/internal/service/household/aggregator.go
+++ b/backend/internal/service/household/aggregator.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/gregwym/offbook/backend/internal/model"
 	"github.com/gregwym/offbook/backend/internal/repository"
+	"github.com/gregwym/offbook/backend/internal/service/valuation"
 )
 
 // Aggregator is the SINGLE cross-user reader for household surfaces. Per
@@ -28,16 +29,19 @@ import (
 type Aggregator struct {
 	repo       repository.HouseholdAggregatorRepository
 	households repository.HouseholdRepository
+	val        *valuation.Service
 	now        func() time.Time
 }
 
 func NewAggregator(
 	repo repository.HouseholdAggregatorRepository,
 	households repository.HouseholdRepository,
+	val *valuation.Service,
 ) *Aggregator {
 	return &Aggregator{
 		repo:       repo,
 		households: households,
+		val:        val,
 		now:        time.Now,
 	}
 }
@@ -149,11 +153,14 @@ type AssetClassAllocation struct {
 }
 
 // NetWorthPoint is one (date, value) row of the household net-worth trend.
-// Date is the UTC calendar day; Value is the rolled-up net worth across
-// shared accounts owned by live members at that day.
+// Date is the month-end instant; Value is the rolled-up net worth across
+// shared accounts owned by live members at that point, in the household quote
+// currency. Complete is false when an asset held at that month-end had no
+// available price — Value is then a partial sum (#282), not a silent $0.
 type NetWorthPoint struct {
-	Date  time.Time `json:"date"`
-	Value string    `json:"value"`
+	Date     time.Time `json:"date"`
+	Value    string    `json:"value"`
+	Complete bool      `json:"complete"`
 }
 
 // AccountSummary is one row of the household account breakdown. Aggregator
@@ -469,12 +476,13 @@ func (a *Aggregator) Allocation(ctx context.Context, householdID int64) ([]Asset
 	return out, nil
 }
 
-// NetWorthTrend returns a daily net-worth series for the trailing `months`
-// calendar months ending at the aggregator's clock. Uses CURRENT positions
-// × historical prices — for a household that holds the same securities
-// today as it did 6 months ago, the curve traces price movement, not
-// rebalancing. (M10b's trade ingestion lays the foundation for a
-// quantity-history view; this one is the foundation.)
+// NetWorthTrend returns a month-end net-worth series for the trailing `months`
+// calendar months ending at the aggregator's clock, via the unified valuation
+// derivation (#282) — identical to the personal trend for the same account set
+// + quote currency. At each month-end, quantity per asset is the transaction
+// fold across the shared account set up to that date (ADR-0017), priced at
+// that date in the household quote currency. A month-end with an unpriced asset
+// is reported incomplete rather than silently understated.
 //
 // Defaults: months ≤ 0 → 12. Excludes private accounts and in-grace members
 // — same lifecycle rules as Dashboard/Allocation.
@@ -496,15 +504,32 @@ func (a *Aggregator) NetWorthTrend(ctx context.Context, householdID int64, month
 		return nil, fmt.Errorf("list shares: %w", err)
 	}
 	accountIDs := filterAccountsByUsers(shares, liveUserIDs)
-	now := a.now().UTC()
-	from := now.AddDate(0, -months, 0)
-	points, err := a.repo.NetWorthSeries(ctx, accountIDs, from, now)
+
+	quoteAssetID, err := a.repo.HouseholdQuoteAssetID(ctx, householdID)
+	if err != nil {
+		return nil, fmt.Errorf("household quote currency: %w", err)
+	}
+
+	// Same derivation + grid as the personal trend (valuation.Series over a
+	// month-end grid), differing only in the account set (shared accounts of
+	// live members) and quote currency (#282). positionsAt folds transactions
+	// across the shared set up to each month-end — historical quantity from
+	// the ledger, not today's positions.
+	asOfs := valuation.MonthEndGrid(a.now(), months)
+	series, err := a.val.WithStaleWindow(0).Series(ctx, asOfs, quoteAssetID,
+		func(ctx context.Context, asOf time.Time) ([]model.Position, error) {
+			return a.repo.FoldByAccountSetAsOf(ctx, accountIDs, asOf)
+		})
 	if err != nil {
 		return nil, fmt.Errorf("net worth series: %w", err)
 	}
-	out := make([]NetWorthPoint, 0, len(points))
-	for _, p := range points {
-		out = append(out, NetWorthPoint{Date: p.Date, Value: p.Value.String()})
+	out := make([]NetWorthPoint, 0, len(series))
+	for _, p := range series {
+		out = append(out, NetWorthPoint{
+			Date:     p.AsOf,
+			Value:    p.Value.String(),
+			Complete: p.Complete(),
+		})
 	}
 	return out, nil
 }

--- a/backend/internal/service/household/aggregator_insights_test.go
+++ b/backend/internal/service/household/aggregator_insights_test.go
@@ -60,6 +60,23 @@ func insertPrice(t *testing.T, g *gorm.DB, assetID, quoteAssetID int64, price st
 	t.Cleanup(func() { g.Unscoped().Delete(&model.Price{}, p.ID) })
 }
 
+// seedHoldingTxn seeds a ledger transaction (asset + kind) so the household
+// net-worth trend can fold quantity per asset over time (#282).
+func seedHoldingTxn(t *testing.T, g *gorm.DB, userID, accountID, assetID int64, kind string, date time.Time, amount string) {
+	t.Helper()
+	tx := &model.Transaction{
+		UserID: userID, AccountID: accountID, AssetID: assetID,
+		Kind:            kind,
+		Amount:          decimal.RequireFromString(amount),
+		TransactionDate: date,
+		Source:          "manual",
+	}
+	if err := g.Create(tx).Error; err != nil {
+		t.Fatalf("seed holding txn: %v", err)
+	}
+	t.Cleanup(func() { g.Unscoped().Delete(&model.Transaction{}, tx.ID) })
+}
+
 // TestAggregator_Allocation rolls cash + equity into kind buckets and
 // verifies private accounts are excluded.
 func TestAggregator_Allocation(t *testing.T) {
@@ -230,47 +247,37 @@ func TestAggregator_NetWorthTrend(t *testing.T) {
 	hh := seedHouseholdRow(t, g, ownerID, "NWT", 30)
 	addMember(t, g, hh.ID, ownerID, model.RoleOwner, nil)
 
-	// Account holds 100 USD + 50 EUR. EUR price history shifts mid-window.
+	// Account holds 100 USD + 50 EUR from the start of the year (ledger fold,
+	// constant quantity). EUR price appears mid-window and rises.
 	acct := seedAccount(t, g, ownerID, "mixed")
-	upsertPosition(t, g, ownerID, acct.ID, usd, "100")
-	upsertPosition(t, g, ownerID, acct.ID, eur, "50")
+	seedHoldingTxn(t, g, ownerID, acct.ID, usd, model.KindOpeningBalance, time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC), "100")
+	seedHoldingTxn(t, g, ownerID, acct.ID, eur, model.KindOpeningBalance, time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC), "50")
 	setShare(t, g, acct.ID, hh.ID, model.VisibilityBalanceAndTxns)
 
-	// 60 days ago: EUR 1.0 → net worth 150.
-	// 10 days ago: EUR 2.0 → net worth 200.
-	insertPrice(t, g, eur, usd, "1.0", time.Now().Add(-60*24*time.Hour))
-	insertPrice(t, g, eur, usd, "2.0", time.Now().Add(-10*24*time.Hour))
+	// No EUR price in March; 1.0 in April, 2.0 in May.
+	insertPrice(t, g, eur, usd, "1.0", time.Date(2026, 4, 2, 0, 0, 0, 0, time.UTC))
+	insertPrice(t, g, eur, usd, "2.0", time.Date(2026, 5, 2, 0, 0, 0, 0, time.UTC))
 
-	// Freeze the clock so the window is deterministic.
-	now := time.Now().UTC()
-	agg.SetClock(func() time.Time { return now })
+	// Freeze the clock so the month-end grid is deterministic.
+	agg.SetClock(func() time.Time { return time.Date(2026, 5, 15, 12, 0, 0, 0, time.UTC) })
 
-	out, err := agg.NetWorthTrend(ctx, hh.ID, 3) // 3 months
+	out, err := agg.NetWorthTrend(ctx, hh.ID, 3) // Mar, Apr, May
 	if err != nil {
 		t.Fatalf("NetWorthTrend: %v", err)
 	}
-	if len(out) < 30 {
-		t.Fatalf("len(out) = %d, want at least 30 points", len(out))
+	if len(out) != 3 {
+		t.Fatalf("len(out) = %d, want 3 month-end points", len(out))
 	}
-	// First point: prior to any price → 100 (USD only).
-	if out[0].Value != "100" {
-		t.Errorf("first point = %q, want 100 (EUR has no price yet → contributes 0)", out[0].Value)
+	// March: EUR unpriced → incomplete, USD-only 100.
+	if out[0].Value != "100" || out[0].Complete {
+		t.Errorf("March point = {%s complete:%v}, want {100 false} (EUR unpriced)", out[0].Value, out[0].Complete)
 	}
-	// Some middle point after the 1.0 price → 150.
-	var saw150, saw200 bool
-	for _, p := range out {
-		if p.Value == "150" {
-			saw150 = true
-		}
-		if p.Value == "200" {
-			saw200 = true
-		}
+	// April: 100 + 50×1.0 = 150. May: 100 + 50×2.0 = 200.
+	if out[1].Value != "150" || !out[1].Complete {
+		t.Errorf("April point = {%s complete:%v}, want {150 true}", out[1].Value, out[1].Complete)
 	}
-	if !saw150 {
-		t.Errorf("trend never reaches 150 (EUR=1.0 era)")
-	}
-	if !saw200 {
-		t.Errorf("trend never reaches 200 (EUR=2.0 era)")
+	if out[2].Value != "200" || !out[2].Complete {
+		t.Errorf("May point = {%s complete:%v}, want {200 true}", out[2].Value, out[2].Complete)
 	}
 }
 
@@ -288,13 +295,12 @@ func TestAggregator_NetWorthTrend_InGraceExcluded(t *testing.T) {
 
 	ownerAcct := seedAccount(t, g, ownerID, "owner")
 	leaverAcct := seedAccount(t, g, leaverID, "leaver")
-	upsertPosition(t, g, ownerID, ownerAcct.ID, usd, "100")
-	upsertPosition(t, g, leaverID, leaverAcct.ID, usd, "9999")
+	seedHoldingTxn(t, g, ownerID, ownerAcct.ID, usd, model.KindOpeningBalance, time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC), "100")
+	seedHoldingTxn(t, g, leaverID, leaverAcct.ID, usd, model.KindOpeningBalance, time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC), "9999")
 	setShare(t, g, ownerAcct.ID, hh.ID, model.VisibilityBalanceAndTxns)
 	setShare(t, g, leaverAcct.ID, hh.ID, model.VisibilityBalanceAndTxns)
 
-	now := time.Now().UTC()
-	agg.SetClock(func() time.Time { return now })
+	agg.SetClock(func() time.Time { return time.Date(2026, 5, 15, 12, 0, 0, 0, time.UTC) })
 	out, err := agg.NetWorthTrend(ctx, hh.ID, 1)
 	if err != nil {
 		t.Fatalf("NetWorthTrend: %v", err)

--- a/backend/internal/service/household/aggregator_test.go
+++ b/backend/internal/service/household/aggregator_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/gregwym/offbook/backend/internal/model"
 	"github.com/gregwym/offbook/backend/internal/repository"
 	"github.com/gregwym/offbook/backend/internal/service/household"
+	"github.com/gregwym/offbook/backend/internal/service/valuation"
 )
 
 // newAggregator wires the aggregator the same way router.go does, against
@@ -48,6 +49,12 @@ func newAggregator(t *testing.T) (*household.Aggregator, *gorm.DB) {
 	agg := household.NewAggregator(
 		repository.NewHouseholdAggregatorRepository(g),
 		repository.NewHouseholdRepository(g),
+		valuation.NewService(
+			repository.NewPositionRepository(g),
+			repository.NewPriceRepository(g),
+			repository.NewAssetRepository(g),
+			repository.NewAccountRepository(g),
+		),
 	)
 	return agg, g
 }

--- a/backend/internal/service/valuation/valuation.go
+++ b/backend/internal/service/valuation/valuation.go
@@ -168,6 +168,25 @@ func (s *Service) ValuePositions(ctx context.Context, positions []model.Position
 	return out, nil
 }
 
+// MonthEndGrid returns the last instant of each of the trailing `months`
+// calendar months ending in now's month, oldest first. Each boundary is the
+// month's final nanosecond in UTC, so a price/transaction dated anywhere that
+// day is included. Shared by personal and household trends so the same account
+// set yields the same asOf grid (#282). months <= 0 defaults to 12.
+func MonthEndGrid(now time.Time, months int) []time.Time {
+	if months <= 0 {
+		months = 12
+	}
+	now = now.UTC()
+	startMonth := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC).AddDate(0, -months+1, 0)
+	out := make([]time.Time, 0, months)
+	for i := 0; i < months; i++ {
+		firstOfNext := startMonth.AddDate(0, i+1, 0)
+		out = append(out, firstOfNext.Add(-time.Nanosecond))
+	}
+	return out
+}
+
 // SeriesPoint is one timestamped entry of a valuation series.
 type SeriesPoint struct {
 	AsOf time.Time


### PR DESCRIPTION
Third slice of #282. Brings the **household** net-worth trend onto the same derivation as the personal trend (slice B, #301), satisfying the headline acceptance: personal and household return **identical series for the same account set + quote currency**.

## What changed
- **`valuation.MonthEndGrid`** — the shared asOf grid, moved out of `dashboard_service` so both scopes build the *same* grid.
- **Aggregator repo**:
  - `FoldByAccountSetAsOf` — cross-user dated fold over the shared account set (the household analogue of `FoldByUserAsOf`, kept inside the blessed cross-user reader per ADR-0008).
  - `HouseholdQuoteAssetID` — the owning member's `primary_currency_asset_id`, so a household has **one** quote currency (no summing across heterogeneous currencies).
- **`Aggregator.NetWorthTrend`** rebuilt on `valuation.Series`. Replaces `NetWorthSeries`, which cross-joined **current** positions against a day series (assuming today's holdings were always held) and coerced missing prices to \$0. `NetWorthPoint.complete` is false when an asset was unpriced at that month-end.
- Deleted `NetWorthSeries` + the orphaned repo `NetWorthPoint` type.

## Tests
Household trend now asserts the #282 shapes on a month-end grid: flat USD + priced/unpriced EUR → a **step**, a **moving** curve, and an **incomplete** month-end (EUR unpriced → partial, not \$0). In-grace exclusion preserved. Full aggregator privacy suite green; `make verify` green.

## Next (slice D, closes #282)
Route household + personal **allocation** through `ValuePositions`, deleting `household_aggregator_repo`'s `COALESCE(price,0)` so an unpriced asset is reported incomplete there too. Then #282 closes.

Part of #282.

🤖 Generated with [Claude Code](https://claude.com/claude-code)