### PR TITLE
Build SHA in /health + Settings, per-institution resync, human-readable transaction dates

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -5,7 +5,12 @@ RUN apk add --no-cache git ca-certificates
 COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
-RUN CGO_ENABLED=0 GOOS=linux go build -trimpath -ldflags="-s -w" -o /out/server ./cmd/server
+# GIT_SHA stamps internal/build.Version so GET /health reports the deployed
+# commit (#310). Defaults to "dev" for builds that don't pass the arg.
+ARG GIT_SHA=dev
+RUN CGO_ENABLED=0 GOOS=linux go build -trimpath \
+	-ldflags="-s -w -X github.com/gregwym/offbook/backend/internal/build.Version=${GIT_SHA}" \
+	-o /out/server ./cmd/server
 
 FROM alpine:3.19
 RUN apk add --no-cache ca-certificates tzdata && adduser -D -u 10001 app

--- a/backend/internal/build/build.go
+++ b/backend/internal/build/build.go
@@ -1,0 +1,14 @@
+// Package build carries build-time metadata stamped into the binary via
+// linker flags. It has no dependencies so any layer can read it without
+// creating an import cycle.
+package build
+
+// Version is the short git SHA of the build, injected at compile time with
+//
+//	-ldflags "-X github.com/gregwym/offbook/backend/internal/build.Version=<sha>"
+//
+// (see backend/Dockerfile + the GIT_SHA build-arg in docker-compose.yml).
+// It defaults to "dev" for local `go run` / `make dev` builds that don't
+// pass the flag. Surfaced through GET /api/v1/health so deploy freshness is
+// a one-request check (#310).
+var Version = "dev"

--- a/backend/internal/handler/health.go
+++ b/backend/internal/handler/health.go
@@ -8,6 +8,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"gorm.io/gorm"
 
+	"github.com/gregwym/offbook/backend/internal/build"
 	"github.com/gregwym/offbook/backend/internal/db"
 )
 
@@ -19,6 +20,13 @@ func NewHealthHandler(g *gorm.DB) *HealthHandler {
 	return &HealthHandler{db: g}
 }
 
+// Register wires the public health route. It lives on the handler (rather
+// than inline in router.go) so contract-check discovers GET /health when the
+// frontend calls it for the build-version readout (#310).
+func (h *HealthHandler) Register(g *gin.RouterGroup) {
+	g.GET("/health", h.Get)
+}
+
 func (h *HealthHandler) Get(c *gin.Context) {
 	ctx, cancel := context.WithTimeout(c.Request.Context(), 2*time.Second)
 	defer cancel()
@@ -26,12 +34,12 @@ func (h *HealthHandler) Get(c *gin.Context) {
 	if h.db != nil {
 		if err := db.Ping(ctx, h.db); err != nil {
 			c.JSON(http.StatusServiceUnavailable, gin.H{
-				"data":  gin.H{"status": "down", "db": err.Error()},
+				"data":  gin.H{"status": "down", "db": err.Error(), "version": build.Version},
 				"error": "database unreachable",
 				"code":  "DB_UNAVAILABLE",
 			})
 			return
 		}
 	}
-	c.JSON(http.StatusOK, gin.H{"data": gin.H{"status": "ok"}})
+	c.JSON(http.StatusOK, gin.H{"data": gin.H{"status": "ok", "version": build.Version}})
 }

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -146,7 +146,7 @@ func New(cfg config.Config, gormDB *gorm.DB) *gin.Engine {
 	v1 := r.Group("/api/v1")
 	{
 		// Open routes — no session required.
-		v1.GET("/health", health.Get)
+		health.Register(v1)
 		authHandler.RegisterPublic(v1)
 
 		// Authenticated routes — session middleware gates everything below.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,11 @@ services:
     build:
       context: ./backend
       dockerfile: Dockerfile
+      args:
+        # Stamp the build with the deploying commit so GET /health reports it
+        # (#310). Pass on deploy: GIT_SHA=$(git rev-parse --short HEAD) docker
+        # compose ... build. Falls back to "dev" when unset.
+        GIT_SHA: ${GIT_SHA:-dev}
     ports:
       - "8000:8000"
     environment:

--- a/frontend/src/api/health.ts
+++ b/frontend/src/api/health.ts
@@ -1,0 +1,17 @@
+import { apiClient, type ApiItem } from './client'
+
+// HealthInfo mirrors the /health envelope's data object. `version` is the
+// build's short git SHA (or "dev" for un-stamped local builds) — surfaced in
+// Settings so deploy freshness is verifiable without shell access (#310).
+export type HealthInfo = {
+  status: string
+  version?: string
+}
+
+// getHealth reads the public health endpoint. The backend returns the same
+// data shape (including `version`) on both the 200 and 503 paths; callers
+// that only want the version can ignore `status`.
+export async function getHealth(): Promise<HealthInfo> {
+  const res = await apiClient.get<ApiItem<HealthInfo>>('/health')
+  return res.data.data
+}

--- a/frontend/src/components/DateDisplay.tsx
+++ b/frontend/src/components/DateDisplay.tsx
@@ -24,7 +24,13 @@ export function DateDisplay({
 }: Props): ReactElement {
   if (!value) return <span className={className}>—</span>
 
-  const parts = value.split('-')
+  // The backend serializes DATE columns as Go time.Time → RFC3339
+  // ("2026-05-19T00:00:00Z") rather than the documented bare "2026-05-19".
+  // Take the date portion before parsing so we render a calendar date, not
+  // the raw ISO string (see #312). This is a textual slice, not a Date()
+  // parse, so it stays timezone-stable. A plain "YYYY-MM-DD" is unaffected.
+  const dateOnly = value.split('T')[0]
+  const parts = dateOnly.split('-')
   if (parts.length !== 3) return <span className={className}>{value}</span>
 
   const year = Number(parts[0])
@@ -57,7 +63,7 @@ export function DateDisplay({
   }).format(dt)
 
   return (
-    <time dateTime={value} title={value} className={className}>
+    <time dateTime={dateOnly} title={dateOnly} className={className}>
       {label}
     </time>
   )

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState, type ReactNode } from 'react'
 import { Link } from 'react-router-dom'
-import { AlertTriangle, Bot, Check, Landmark, Plug, Trash2, X } from 'lucide-react'
+import { AlertTriangle, Bot, Check, Info, Landmark, Plug, RefreshCw, Trash2, X } from 'lucide-react'
 import { TimeAgo } from '../components/TimeAgo'
 import {
   disconnectItem,
@@ -8,7 +8,10 @@ import {
   listItems,
   listSyncErrors,
   retrySyncError,
+  syncAccounts,
+  syncTransactions,
 } from '../api/plaid'
+import { getHealth } from '../api/health'
 import { getUserSettings, updateUserSettings } from '../api/userSettings'
 import type { PlaidItem, PlaidSyncError } from '../types/plaid'
 import type { UpdateUserSettingsInput, UserSettingsView } from '../types/userSettings'
@@ -22,7 +25,41 @@ export function SettingsPage() {
       </div>
       <AISettingsSection />
       <LinkedInstitutionsSection />
+      <AboutSection />
     </div>
+  )
+}
+
+// AboutSection surfaces the running build's git SHA (from GET /health) so
+// deploy freshness is verifiable from the UI without shell access (#310).
+function AboutSection() {
+  const [version, setVersion] = useState<string | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    void getHealth()
+      .then((h) => { if (!cancelled) setVersion(h.version ?? 'unknown') })
+      .catch(() => { if (!cancelled) setVersion('unknown') })
+    return () => { cancelled = true }
+  }, [])
+
+  return (
+    <section className="rounded-lg border border-gray-200 bg-white">
+      <div className="flex items-center gap-2 border-b border-gray-200 px-5 py-3">
+        <Info size={16} className="text-gray-500" />
+        <h2 className="text-base font-medium text-gray-900">About</h2>
+      </div>
+      <div className="px-5 py-4">
+        <div className="flex items-center justify-between text-sm">
+          <span className="text-gray-500">Build version</span>
+          <span className="font-mono text-gray-900">{version ?? '…'}</span>
+        </div>
+        <p className="mt-1 text-xs text-gray-500">
+          Short git SHA of the running server build. Compare against{' '}
+          <span className="font-mono">main</span> to confirm the deploy is current.
+        </p>
+      </div>
+    </section>
   )
 }
 
@@ -206,6 +243,7 @@ function LinkedInstitutionsSection() {
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [disconnecting, setDisconnecting] = useState<string | null>(null)
+  const [syncing, setSyncing] = useState<string | null>(null)
   const [errorModalItem, setErrorModalItem] = useState<PlaidItem | null>(null)
 
   const refresh = useCallback(() => {
@@ -223,6 +261,22 @@ function LinkedInstitutionsSection() {
     // itself is sync-pure, satisfying react-hooks/set-state-in-effect.
     void refresh()
   }, [refresh])
+
+  // Re-sync mirrors the initial connect flow (sync-accounts → sync-transactions)
+  // so a user can pull fresh data on demand, not only at link time (#311).
+  const onSync = async (item: PlaidItem) => {
+    setSyncing(item.plaid_item_id)
+    setError(null)
+    try {
+      await syncAccounts(item.plaid_item_id)
+      await syncTransactions(item.plaid_item_id)
+      await refresh()
+    } catch (e) {
+      setError(errMsg(e))
+    } finally {
+      setSyncing(null)
+    }
+  }
 
   const onDisconnect = async (item: PlaidItem) => {
     const label = item.institution_name ?? item.plaid_item_id
@@ -301,8 +355,18 @@ function LinkedInstitutionsSection() {
               </div>
               <button
                 type="button"
+                onClick={() => onSync(it)}
+                disabled={syncing === it.plaid_item_id || disconnecting === it.plaid_item_id}
+                className="inline-flex items-center gap-1 rounded-md border border-gray-300 px-2.5 py-1 text-xs font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50"
+                aria-label={`Sync ${it.institution_name ?? it.plaid_item_id}`}
+              >
+                <RefreshCw size={14} className={syncing === it.plaid_item_id ? 'animate-spin' : ''} />
+                {syncing === it.plaid_item_id ? 'Syncing…' : 'Sync'}
+              </button>
+              <button
+                type="button"
                 onClick={() => onDisconnect(it)}
-                disabled={disconnecting === it.plaid_item_id}
+                disabled={disconnecting === it.plaid_item_id || syncing === it.plaid_item_id}
                 className="inline-flex items-center gap-1 rounded-md border border-gray-300 px-2.5 py-1 text-xs font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50"
                 aria-label={`Disconnect ${it.institution_name ?? it.plaid_item_id}`}
               >


### PR DESCRIPTION
Addresses three owner-reported items in one pass.

## 1. Build version in Settings (closes #310)
- New `internal/build.Version`, stamped at compile time via `-ldflags -X` with a `GIT_SHA` build-arg (wired through `backend/Dockerfile` and `docker-compose.yml`; defaults to `dev`).
- Surfaced in the `GET /health` envelope (`{"data":{"status":"ok","version":"<sha>"}}`) on both the 200 and 503 paths, and in a new **Settings → About** section.
- `HealthHandler` gains a `Register()` method (route moved out of inline `router.go`) so `contract-check` can discover `/health` now that the frontend calls it.

## 2. Re-sync a linked institution (closes #311)
- Added a per-institution **Sync** button to Settings → Linked Institutions. It chains `sync-accounts → sync-transactions` (the same order as the initial connect flow) and refreshes the row's status/last-synced.
- The backend endpoints and `api/plaid.ts` wrappers already existed — they were only reachable during `/connect`.

## 3. Human-readable transaction dates (closes #312)
- Root cause: `Transaction.TransactionDate` (and `PostedDate`, `SavingsGoal.TargetDate`) are Go `time.Time`, which `json.Marshal` always renders as RFC3339 (`2026-05-19T00:00:00Z`) — even for a DATE column. `DateDisplay` expected bare `YYYY-MM-DD`, so it fell back to printing the raw ISO string.
- Fix: `DateDisplay` now takes the date portion (`value.split('T')[0]`) before parsing — a textual slice, so it stays timezone-stable. Fixes transactions, goals, and any other DATE field through the shared component at once.
- The backend's deviation from its own documented convention (DATE → `2024-01-15`) is noted in #312 as a possible follow-up; this PR fixes the display at the choke point.

## Verification
- `go build ./...`, `go vet ./...` ✅
- `contract-check`: OK — 89 frontend calls map (incl. new `/health`) ✅
- `go test ./internal/router/... ./internal/handler/... ` ✅ (`routes.golden` unchanged — same path/method)
- `pnpm lint` + `pnpm build` ✅
- No schema/migration changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)