### PR TITLE
Add make deploy-dev one-command redeploy (#314)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,11 @@
 .DEFAULT_GOAL := help
 
-.PHONY: help verify acceptance qa-smoke qa-suite
+.PHONY: help verify acceptance qa-smoke qa-suite deploy-dev
+
+# Local Tailscale dev stack (ADR-0016). Omits docker-compose.tailscale.yml on
+# purpose: the sidecar is authenticated and long-lived, so deploy-dev rebuilds
+# only the app images and never touches the sidecar or postgres.
+DEV_COMPOSE := docker compose -p offbook-dev -f docker-compose.yml
 
 ACCEPTANCE_DIR := acceptance
 ACCEPTANCE_BASE_URL ?= http://localhost:15173
@@ -14,11 +19,24 @@ help:
 	@printf '%s\n' '  command make qa-smoke            Run the baseline acceptance smoke suite'
 	@printf '%s\n' '  command make qa-suite QA_SUITE=plaid  Run one acceptance suite or spec pattern'
 	@printf '%s\n' '  command make verify              Run the backend CI mirror from backend/'
+	@printf '%s\n' '  command make deploy-dev          Rebuild + recreate the offbook-dev stack at the current HEAD'
 	@printf '%s\n' ''
 	@printf '%s\n' 'Backend-only targets live in backend/Makefile; run them from backend/ with command make <target>.'
 
 verify:
 	@$(MAKE) -C backend verify
+
+# deploy-dev redeploys the local offbook-dev stack from whatever is checked out.
+# It stamps the binary with the current short SHA (surfaced at GET /health and
+# Settings → About, #310), recreates only backend + frontend (--no-deps leaves
+# postgres + the Tailscale sidecar running), and prints the new /health version.
+# Migrations run on backend boot. There is no CD — this is the manual deploy.
+deploy-dev:
+	@SHA="$$(git rev-parse --short HEAD)"; \
+		echo "Building offbook-dev at $$SHA…"; \
+		GIT_SHA="$$SHA" $(DEV_COMPOSE) build backend frontend
+	@$(DEV_COMPOSE) up -d --no-deps backend frontend
+	@printf 'Deployed offbook-dev → '; curl -fsS http://localhost:8000/api/v1/health && echo
 
 acceptance:
 	@./scripts/qa-assert-role.sh


### PR DESCRIPTION
Closes #314.

Adds a root `make deploy-dev` target wrapping the manual deploy sequence used throughout this work:

```
GIT_SHA=$(git rev-parse --short HEAD) docker compose -p offbook-dev -f docker-compose.yml build backend frontend
docker compose -p offbook-dev -f docker-compose.yml up -d --no-deps backend frontend
```

- Stamps the binary with the current short SHA (surfaced at `GET /health` and Settings → About, #310).
- `--no-deps` + omitting `docker-compose.tailscale.yml` leaves postgres and the authenticated Tailscale sidecar running untouched; the recreated app containers rejoin the same network.
- Migrations run on backend boot.
- Prints the resulting `/health` version on completion.
- Listed in `make help`.

There is no CD — this just makes the manual deploy a one-liner.

## Verification
- `command make help` lists the target ✅
- `command make -n deploy-dev` expands to the expected commands ✅
- `command make deploy-dev` ran end-to-end → `{"data":{"status":"ok","version":"bf876ab"}}` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)