### PR TITLE
Add make deploy DEPLOY_HOST=... remote redeploy over SSH (#316)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,16 @@
 .DEFAULT_GOAL := help
 
-.PHONY: help verify acceptance qa-smoke qa-suite deploy-dev
+.PHONY: help verify acceptance qa-smoke qa-suite deploy-dev deploy
 
 # Local Tailscale dev stack (ADR-0016). Omits docker-compose.tailscale.yml on
 # purpose: the sidecar is authenticated and long-lived, so deploy-dev rebuilds
 # only the app images and never touches the sidecar or postgres.
 DEV_COMPOSE := docker compose -p offbook-dev -f docker-compose.yml
+
+# Remote deploy target (see the `deploy` target below). DEPLOY_HOST is required;
+# DEPLOY_PATH is where the repo is checked out on that host.
+DEPLOY_HOST ?=
+DEPLOY_PATH ?= ~/offbook
 
 ACCEPTANCE_DIR := acceptance
 ACCEPTANCE_BASE_URL ?= http://localhost:15173
@@ -19,7 +24,8 @@ help:
 	@printf '%s\n' '  command make qa-smoke            Run the baseline acceptance smoke suite'
 	@printf '%s\n' '  command make qa-suite QA_SUITE=plaid  Run one acceptance suite or spec pattern'
 	@printf '%s\n' '  command make verify              Run the backend CI mirror from backend/'
-	@printf '%s\n' '  command make deploy-dev          Rebuild + recreate the offbook-dev stack at the current HEAD'
+	@printf '%s\n' '  command make deploy-dev          Rebuild + recreate the local offbook-dev stack at the current HEAD'
+	@printf '%s\n' '  command make deploy DEPLOY_HOST=user@host  Redeploy a remote host over SSH (current HEAD; push first)'
 	@printf '%s\n' ''
 	@printf '%s\n' 'Backend-only targets live in backend/Makefile; run them from backend/ with command make <target>.'
 
@@ -37,6 +43,24 @@ deploy-dev:
 		GIT_SHA="$$SHA" $(DEV_COMPOSE) build backend frontend
 	@$(DEV_COMPOSE) up -d --no-deps backend frontend
 	@printf 'Deployed offbook-dev → '; curl -fsS http://localhost:8000/api/v1/health && echo
+
+# deploy redeploys a REMOTE host over SSH by running deploy-dev *on* that host,
+# not by driving a remote Docker socket. Running it remotely means the deploy
+# uses the remote's own .env, named volumes, and Docker daemon — so no secrets
+# or config from your machine leak into the remote (which DOCKER_HOST=ssh:// +
+# `env_file: .env` would cause). It deploys whatever commit YOU have checked out
+# locally (parity with deploy-dev), so push it to origin first.
+#
+# Remote prerequisites (an ADR-0016 self-host box already meets these): the repo
+# checked out at DEPLOY_PATH, Docker + make installed, and the offbook-dev stack
+# provisioned once (postgres volume + authenticated Tailscale sidecar).
+#
+#   command make deploy DEPLOY_HOST=user@host [DEPLOY_PATH=/srv/offbook]
+deploy:
+	@test -n "$(DEPLOY_HOST)" || { echo 'Set DEPLOY_HOST=user@host — e.g. command make deploy DEPLOY_HOST=greg@offbook-host' >&2; exit 2; }
+	@SHA="$$(git rev-parse --short HEAD)"; \
+		echo "Deploying $$SHA → $(DEPLOY_HOST):$(DEPLOY_PATH) over ssh…"; \
+		ssh "$(DEPLOY_HOST)" "set -e; cd $(DEPLOY_PATH) && git fetch --quiet origin && git checkout --quiet $$SHA && make deploy-dev"
 
 acceptance:
 	@./scripts/qa-assert-role.sh


### PR DESCRIPTION
Closes #316.

One command from your laptop to redeploy a remote Offbook host:

```
command make deploy DEPLOY_HOST=user@host [DEPLOY_PATH=/srv/offbook]
```

## How
Runs the existing `deploy-dev` **on the remote** over SSH:

```
ssh DEPLOY_HOST 'cd DEPLOY_PATH && git fetch origin && git checkout <your local SHA> && make deploy-dev'
```

So the remote builds + recreates backend/frontend with its own `.env`, named volumes, and Docker daemon, and prints its `/health` version. Deploys whatever commit you have checked out locally (parity with `deploy-dev`) — **push it to origin first**.

## Why this and not `DOCKER_HOST=ssh://`
Driving the remote Docker socket from your laptop would have compose read `env_file: .env` **locally** and inject your machine's `.env` (SESSION_SECRET, Plaid keys, CLAUDE_API_KEY) into the remote container, and resolve bind-mount paths on the remote. Running the deploy on the remote avoids both — no secret/config bleed, correct per-host config. Trade-off: the remote must have the repo + Docker + make (an ADR-0016 self-host box already does).

## Remote prerequisites
- Repo checked out at `DEPLOY_PATH` (default `~/offbook`), Docker + make installed.
- offbook-dev stack provisioned once (postgres volume + authenticated Tailscale sidecar).

## Verification
- `command make help` lists the target ✅
- `command make -n deploy DEPLOY_HOST=… DEPLOY_PATH=…` expands to the expected ssh command ✅
- `command make deploy` (no host) errors with exit 2 ✅
- ⚠️ Not exercised against a live remote (no host available in this session) — dry-run validated only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)