### PR TITLE
Pull-based auto-deploy for dev (poll origin/main → make deploy-dev) (#318)

### DIFF
--- a/infra/auto-deploy/README.md
+++ b/infra/auto-deploy/README.md
@@ -1,0 +1,99 @@
+# Pull-based auto-deploy (dev)
+
+Auto-redeploys the `offbook-dev` stack on a self-hosted host (e.g. a Raspberry
+Pi) whenever `origin/main` moves — **no GitHub Actions, no inbound webhook.**
+
+A systemd timer polls `origin/main` every ~2 minutes. When the running build's
+SHA (reported by `GET /health`, see [ADR-0016](../../docs/ADR/0016-tailscale-per-instance-deployment.md)
+and `#310`) differs from `origin/main`, it fast-forwards `main` and runs
+`make deploy-dev`. Because it only ever fetches and builds `main` (never PR/fork
+code) and makes only outbound connections, it works behind NAT/Tailscale and
+adds no attack surface — unlike a self-hosted GitHub Actions runner on a public
+repo.
+
+## One-time host setup
+
+1. **Docker.** Install Docker Engine + the compose v2 plugin (64-bit OS):
+
+   ```sh
+   curl -fsSL https://get.docker.com | sh
+   sudo usermod -aG docker "$USER"   # log out/in so the group takes effect
+   ```
+
+2. **Clone** the repo where the service expects it (default `~/offbook`):
+
+   ```sh
+   git clone https://github.com/gregwym/offbook.git ~/offbook
+   cd ~/offbook
+   ```
+
+3. **Env.** Create `.env` (gitignored) with at least a real `SESSION_SECRET`,
+   plus any Plaid / Claude keys you want this instance to have:
+
+   ```sh
+   cp .env.example .env
+   # edit .env: SESSION_SECRET=$(openssl rand -hex 32), etc.
+   ```
+
+4. **Bring the full stack up once** — including postgres and the Tailscale
+   sidecar. `make deploy-dev` only rebuilds backend+frontend (`--no-deps`,
+   sidecar omitted), so postgres and Tailscale must already be running under
+   the `offbook-dev` project first:
+
+   ```sh
+   TS_AUTHKEY=tskey-auth-... TS_HOSTNAME=offbook-dev \
+     docker compose -p offbook-dev \
+       -f docker-compose.yml \
+       -f docker-compose.tailscale.yml \
+       up -d --build
+   ```
+
+   The node comes up at `offbook-dev.<tailnet>.ts.net` (first cert ~30s). See
+   `infra/tailscale/README.md`. `TS_*` are only needed for this one-time boot;
+   the timer never touches the sidecar again.
+
+5. **Install the timer.** Edit `User=` and the two paths in the unit if you're
+   not using `pi` / `~/offbook`, then:
+
+   ```sh
+   sudo cp infra/auto-deploy/offbook-deploy-dev.service /etc/systemd/system/
+   sudo cp infra/auto-deploy/offbook-deploy-dev.timer   /etc/systemd/system/
+   sudo systemctl daemon-reload
+   sudo systemctl enable --now offbook-deploy-dev.timer
+   ```
+
+## Operating it
+
+```sh
+# Watch deploys as they happen
+journalctl -u offbook-deploy-dev -f
+
+# Force a check now (instead of waiting for the next tick)
+sudo systemctl start offbook-deploy-dev.service
+
+# See when the timer next fires
+systemctl list-timers offbook-deploy-dev.timer
+
+# Pause / resume auto-deploy
+sudo systemctl disable --now offbook-deploy-dev.timer
+sudo systemctl enable  --now offbook-deploy-dev.timer
+```
+
+## Notes
+
+- **Idempotent / self-healing.** No redeploy when already current. A failed
+  build leaves the running version behind `origin/main`, so the next tick
+  retries. If the backend is down, `/health` is unreachable → treated as
+  "needs deploy" → the stack is rebuilt and recovers.
+- **Single-flight.** A build can outlast the 2-minute interval; an `flock`
+  guard skips overlapping runs rather than stacking them.
+- **Manual deploys still work** — `make deploy-dev` (local) or
+  `make deploy DEPLOY_HOST=...` (from a laptop) coexist with the timer.
+- **Local edits on the host block deploys** on purpose: `git merge --ff-only`
+  fails loudly if the checkout has diverged, rather than clobbering it. Keep
+  the deploy checkout clean.
+- **Private repo later?** Anonymous `git fetch` works because the repo is
+  public. If you make it private, give the host a read-only deploy key or a
+  token-backed remote so the fetch keeps working.
+- **prod** is not wired here yet — there's no `make deploy-prod` target. When
+  it lands, copy this directory to an `offbook-prod`-flavored timer.

--- a/infra/auto-deploy/auto-deploy-dev.sh
+++ b/infra/auto-deploy/auto-deploy-dev.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Poll origin and redeploy the local offbook-dev stack when the branch moves.
+#
+# Pull-based by design: it only ever fetches and builds the deploy branch
+# (default `main`), never PR/fork code, and needs no inbound webhook — so it
+# works behind NAT/Tailscale and adds no attack surface. Intended to run on a
+# timer on the deploy host (see offbook-deploy-dev.{service,timer}).
+#
+# "What's running" is read from the build SHA in GET /health (#310), not from
+# the checkout, so a failed build is retried on the next tick (the running
+# version stays behind until a build actually succeeds).
+#
+# Reuses `make deploy-dev` for the actual build + recreate.
+#
+# Env overrides:
+#   OFFBOOK_REPO           repo checkout path        (default: $HOME/offbook)
+#   OFFBOOK_DEPLOY_BRANCH  branch to track           (default: main)
+#   OFFBOOK_HEALTH_URL     local health endpoint     (default: http://localhost:8000/api/v1/health)
+set -euo pipefail
+
+REPO="${OFFBOOK_REPO:-$HOME/offbook}"
+BRANCH="${OFFBOOK_DEPLOY_BRANCH:-main}"
+HEALTH_URL="${OFFBOOK_HEALTH_URL:-http://localhost:8000/api/v1/health}"
+
+# Single-flight: a build can outlast the timer interval, so skip overlapping
+# runs rather than stack them up.
+exec 9>"${TMPDIR:-/tmp}/offbook-auto-deploy-dev.lock"
+if ! flock -n 9; then
+	echo "auto-deploy: a run is already in progress, skipping"
+	exit 0
+fi
+
+cd "$REPO"
+
+git fetch --quiet origin "$BRANCH"
+remote="$(git rev-parse --short "origin/$BRANCH")"
+
+# Ground truth for "what's deployed" is the running build's reported SHA.
+# Empty (backend down / unreachable) is treated as "needs deploy" so a crashed
+# stack self-heals on the next tick.
+deployed="$(curl -fsS "$HEALTH_URL" 2>/dev/null | grep -oE '"version":"[^"]+"' | cut -d'"' -f4 || true)"
+
+if [ -n "$deployed" ] && [ "$deployed" = "$remote" ]; then
+	exit 0 # already running origin/$BRANCH
+fi
+
+echo "auto-deploy: deployed=${deployed:-none} -> origin/$BRANCH=$remote; redeploying"
+git checkout --quiet "$BRANCH"
+git merge --ff-only --quiet "origin/$BRANCH"
+make deploy-dev

--- a/infra/auto-deploy/offbook-deploy-dev.service
+++ b/infra/auto-deploy/offbook-deploy-dev.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=Offbook dev auto-deploy (poll origin/main, redeploy on change)
+# Docker must be up; we also want the network before fetching.
+After=docker.service network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+# --- EDIT THESE for your host ---
+# User must be in the `docker` group and own the repo checkout.
+User=pi
+Environment=OFFBOOK_REPO=/home/pi/offbook
+# systemd gives services a minimal PATH; include where docker/compose/make live.
+Environment=PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+ExecStart=/home/pi/offbook/infra/auto-deploy/auto-deploy-dev.sh
+# Don't hammer on repeated failures; the timer will try again next interval.
+TimeoutStartSec=1800

--- a/infra/auto-deploy/offbook-deploy-dev.timer
+++ b/infra/auto-deploy/offbook-deploy-dev.timer
@@ -1,0 +1,13 @@
+[Unit]
+Description=Poll origin/main and redeploy offbook-dev every 2 minutes
+
+[Timer]
+# First check shortly after boot, then every 2 minutes while the host is up.
+OnBootSec=2min
+OnUnitActiveSec=2min
+AccuracySec=15s
+# Catch up with a single run if the host was asleep/off across a tick.
+Persistent=true
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
Closes #318.

The "right setup" for auto-redeploying dev on the Pi without GitHub Actions: a **pull-based systemd timer** that polls `origin/main` every ~2 min and runs `make deploy-dev` when it moves.

Why polling over a webhook: outbound-only, so it works behind NAT/Tailscale with no ingress and no secrets. And it only ever fetches + builds `main` (never PR/fork code), so the public-repo self-hosted-runner risk doesn't apply.

## Added — `infra/auto-deploy/`
- **`auto-deploy-dev.sh`** — `git fetch`, compare the running build's `/health` version (#310) to `origin/main`; if different, ff-only merge + `make deploy-dev`. Uses the *deployed* SHA (not the checkout) as ground truth, so a failed build retries next tick and a crashed backend self-heals. `flock` single-flight guards against a build outlasting the interval.
- **`offbook-deploy-dev.service` / `.timer`** — systemd templates (edit `User=` / paths).
- **`README.md`** — one-time host bootstrap (Docker install, clone, `.env`, full stack up *with* the tailscale override once so postgres + sidecar exist) + timer install + ops commands.

## How it runs
```
push to main → (≤2 min) timer fires → fetch → deployed sha != origin/main?
  → git checkout main && git merge --ff-only && make deploy-dev → /health ticks to new sha
```

## Verification
- `bash -n` clean ✅
- Health-version extraction tested against the live backend: extracts `bf876ab`, compares to `origin/main` `eee3140` → correctly would redeploy ✅
- ⚠️ systemd units + the on-Pi flow are host-side — not exercised in this session (no Pi here). The `make deploy-dev` they call *is* proven.

Notes: SD card is fine for this (build cost accepted per the ask); prod isn't wired (no `deploy-prod` target yet) — that's a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)