### PR TITLE
Add make bootstrap-dev — first boot stamps GIT_SHA (#320)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,14 @@
 .DEFAULT_GOAL := help
 
-.PHONY: help verify acceptance qa-smoke qa-suite deploy-dev deploy
+.PHONY: help verify acceptance qa-smoke qa-suite bootstrap-dev deploy-dev deploy
 
 # Local Tailscale dev stack (ADR-0016). Omits docker-compose.tailscale.yml on
 # purpose: the sidecar is authenticated and long-lived, so deploy-dev rebuilds
 # only the app images and never touches the sidecar or postgres.
 DEV_COMPOSE := docker compose -p offbook-dev -f docker-compose.yml
+# Full stack incl. the Tailscale sidecar — used by bootstrap-dev for first boot,
+# when postgres + the sidecar don't exist yet.
+DEV_COMPOSE_FULL := docker compose -p offbook-dev -f docker-compose.yml -f docker-compose.tailscale.yml
 
 # Remote deploy target (see the `deploy` target below). DEPLOY_HOST is required;
 # DEPLOY_PATH is where the repo is checked out on that host.
@@ -24,6 +27,7 @@ help:
 	@printf '%s\n' '  command make qa-smoke            Run the baseline acceptance smoke suite'
 	@printf '%s\n' '  command make qa-suite QA_SUITE=plaid  Run one acceptance suite or spec pattern'
 	@printf '%s\n' '  command make verify              Run the backend CI mirror from backend/'
+	@printf '%s\n' '  command make bootstrap-dev TS_AUTHKEY=tskey-...  First boot: bring up the FULL stack (postgres + sidecar), stamped'
 	@printf '%s\n' '  command make deploy-dev          Rebuild + recreate the local offbook-dev stack at the current HEAD'
 	@printf '%s\n' '  command make deploy DEPLOY_HOST=user@host  Redeploy a remote host over SSH (current HEAD; push first)'
 	@printf '%s\n' ''
@@ -31,6 +35,22 @@ help:
 
 verify:
 	@$(MAKE) -C backend verify
+
+# bootstrap-dev is the ONE-TIME first boot: it brings up the full stack —
+# postgres + backend + frontend + the Tailscale sidecar — because deploy-dev
+# (--no-deps, no tailscale override) can't create those. Crucially it stamps
+# the build with the current SHA (GIT_SHA), same as deploy-dev, so /health
+# reports a real commit from the very first boot instead of "dev". After this,
+# use deploy-dev (or the auto-deploy timer) for updates.
+#   command make bootstrap-dev TS_AUTHKEY=tskey-auth-... [TS_HOSTNAME=offbook-dev]
+bootstrap-dev:
+	@test -n "$${TS_AUTHKEY:-}" || { echo 'Set TS_AUTHKEY=tskey-... — first boot registers the Tailscale sidecar. TS_HOSTNAME defaults to offbook-dev.' >&2; exit 2; }
+	@SHA="$$(git rev-parse --short HEAD)"; \
+		echo "Bootstrapping offbook-dev @ $$SHA (postgres + backend + frontend + tailscale)…"; \
+		GIT_SHA="$$SHA" TS_HOSTNAME="$${TS_HOSTNAME:-offbook-dev}" $(DEV_COMPOSE_FULL) up -d --build
+	@printf 'Bootstrapped offbook-dev → '; \
+		curl -fsS http://localhost:8000/api/v1/health 2>/dev/null && echo \
+		|| echo '(backend still starting — check GET /health in a few seconds)'
 
 # deploy-dev redeploys the local offbook-dev stack from whatever is checked out.
 # It stamps the binary with the current short SHA (surfaced at GET /health and

--- a/infra/auto-deploy/README.md
+++ b/infra/auto-deploy/README.md
@@ -35,22 +35,20 @@ repo.
    # edit .env: SESSION_SECRET=$(openssl rand -hex 32), etc.
    ```
 
-4. **Bring the full stack up once** — including postgres and the Tailscale
-   sidecar. `make deploy-dev` only rebuilds backend+frontend (`--no-deps`,
-   sidecar omitted), so postgres and Tailscale must already be running under
-   the `offbook-dev` project first:
+4. **Bring the full stack up once** with `bootstrap-dev` — this creates
+   postgres + backend + frontend + the Tailscale sidecar. (`deploy-dev` can't
+   do first boot: it runs `--no-deps` without the sidecar override, so postgres
+   and Tailscale must already exist.) `bootstrap-dev` stamps the build with the
+   current SHA, exactly like `deploy-dev`, so `/health` reports a real commit
+   from the start instead of `dev`:
 
    ```sh
-   TS_AUTHKEY=tskey-auth-... TS_HOSTNAME=offbook-dev \
-     docker compose -p offbook-dev \
-       -f docker-compose.yml \
-       -f docker-compose.tailscale.yml \
-       up -d --build
+   TS_AUTHKEY=tskey-auth-... make bootstrap-dev      # TS_HOSTNAME defaults to offbook-dev
    ```
 
    The node comes up at `offbook-dev.<tailnet>.ts.net` (first cert ~30s). See
-   `infra/tailscale/README.md`. `TS_*` are only needed for this one-time boot;
-   the timer never touches the sidecar again.
+   `infra/tailscale/README.md`. `TS_AUTHKEY` is only needed for this one-time
+   boot; the timer (and `deploy-dev`) never touch the sidecar again.
 
 5. **Install the timer.** Edit `User=` and the two paths in the unit if you're
    not using `pi` / `~/offbook`, then:


### PR DESCRIPTION
Closes #320.

Fixes the gap you hit: the auto-deploy guide's first-boot step used a plain `docker compose up --build`, which doesn't pass `GIT_SHA`, so `/health` reported `version: "dev"` instead of the commit.

## Why first boot couldn't already be `deploy-dev`
`deploy-dev` runs `--no-deps` and omits the Tailscale override, so it only rebuilds backend+frontend — it can't create postgres or the sidecar. First boot genuinely needs the full `up`. The bug was that that `up` wasn't passing `GIT_SHA`.

## Fix
New `make bootstrap-dev`:
- Full first-boot bring-up (base + tailscale override): postgres + backend + frontend + sidecar.
- Stamps the build with `GIT_SHA=$(git rev-parse --short HEAD)` — same as `deploy-dev` — so `/health` shows a real commit from the start.
- Requires `TS_AUTHKEY` (errors clearly if unset); `TS_HOSTNAME` defaults to `offbook-dev`.
- `infra/auto-deploy/README.md` step 4 now uses `TS_AUTHKEY=… make bootstrap-dev`.

Flow is now consistent: `bootstrap-dev` once (stamped) → `deploy-dev` / auto-deploy timer for updates (stamped).

## Verification
- `make help` lists it ✅
- `make -n bootstrap-dev` expands to `GIT_SHA=<sha> TS_HOSTNAME=offbook-dev docker compose -f … -f docker-compose.tailscale.yml up -d --build` ✅
- `make bootstrap-dev` with `TS_AUTHKEY` unset → exits 2 before any docker action ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)