### PR TITLE
deploy-dev: prune dangling images after rebuild (#322)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,11 +57,17 @@ bootstrap-dev:
 # Settings → About, #310), recreates only backend + frontend (--no-deps leaves
 # postgres + the Tailscale sidecar running), and prints the new /health version.
 # Migrations run on backend boot. There is no CD — this is the manual deploy.
+#
+# After recreating it prunes DANGLING images — the untagged layers orphaned when
+# the :latest tag moved to the new build — so repeated deploys don't fill the
+# disk (matters on the Pi's SD card). Dangling-only: it never removes tagged or
+# in-use images, so the running stack is safe.
 deploy-dev:
 	@SHA="$$(git rev-parse --short HEAD)"; \
 		echo "Building offbook-dev at $$SHA…"; \
 		GIT_SHA="$$SHA" $(DEV_COMPOSE) build backend frontend
 	@$(DEV_COMPOSE) up -d --no-deps backend frontend
+	@printf 'Pruning dangling images… '; docker image prune -f | tail -1
 	@printf 'Deployed offbook-dev → '; curl -fsS http://localhost:8000/api/v1/health && echo
 
 # deploy redeploys a REMOTE host over SSH by running deploy-dev *on* that host,


### PR DESCRIPTION
Closes #322.

`deploy-dev` now runs `docker image prune -f` after recreating the stack, reclaiming the dangling layers each rebuild orphans (the `:latest` tag moves to the new image, leaving the old one untagged). Over many deploys — especially with the auto-deploy timer — these accumulate and fill the disk, which bites on a Pi SD card.

Recipe order: build → `up` → **prune** → health. It reports reclaimed space (`Total reclaimed space: …`).

**Safe:** `docker image prune` (no `-a`) removes only *dangling* images — untagged and not referenced by any container. The running stack's tagged `:latest` images and any other tagged images are never touched.

The remote `deploy DEPLOY_HOST=...` target inherits this automatically, since it runs `deploy-dev` on the host.

Out of scope: build-cache pruning (`docker builder prune`) — separate, and it slows the next build.

## Verification
- `make -n deploy-dev` shows `docker image prune -f | tail -1` between `up` and the health check ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)