### PR TITLE
Env-agnostic bootstrap/deploy via ENV_FILE; drop remote SSH deploy (#324)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,25 @@ PORT=8000
 FRONTEND_URL=http://localhost:5173
 MIGRATIONS_PATH=migrations
 
+# ─── Deploy (make bootstrap / make deploy) ──────────────────────────────────
+# This env file is the single source of truth for the instance it configures.
+# OFFBOOK_PROJECT is the compose project name; OFFBOOK_COMPOSE_FILES is the
+# colon-separated overlay list the deploy targets bring up. Dev runs the base
+# stack + the Tailscale sidecar. For pure local dev WITHOUT Tailscale (e.g.
+# `docker compose up` on a laptop), set OFFBOOK_COMPOSE_FILES=docker-compose.yml
+# and leave TS_* blank.
+OFFBOOK_PROJECT=offbook-dev
+OFFBOOK_COMPOSE_FILES=docker-compose.yml:docker-compose.tailscale.yml
+
+# ─── Tailscale sidecar (docker-compose.tailscale.yml) ───────────────────────
+# Per-instance, tagged auth key (tskey-...): https://login.tailscale.com/admin/settings/keys
+TS_AUTHKEY=
+# MagicDNS hostname → https://<TS_HOSTNAME>.<tailnet>.ts.net
+TS_HOSTNAME=offbook-dev
+# Optional extra tailscaled flags (e.g. --advertise-tags=tag:offbook). Leave
+# unset when your auth key already auto-applies a tag.
+# TS_EXTRA_ARGS=
+
 # Auth (required from M2.5+). Generate with: openssl rand -hex 32
 #
 # DUAL PURPOSE — read before rotating:

--- a/.env.prod.example
+++ b/.env.prod.example
@@ -7,6 +7,15 @@
 # .env.prod is gitignored. The same file is loaded both as `--env-file` for
 # compose variable substitution (TS_*) and as the backend container's
 # env_file (SESSION_SECRET, FRONTEND_URL).
+#
+# Deploy with:  command make bootstrap ENV_FILE=.env.prod   (first boot)
+#               command make deploy    ENV_FILE=.env.prod   (updates)
+
+# ─── Deploy (make bootstrap / make deploy) ────────────────────────────────────
+# Compose project + overlay list for this instance. Prod composes the base
+# stack, the prod override (no host ports, prod DB volume), and the sidecar.
+OFFBOOK_PROJECT=offbook-prod
+OFFBOOK_COMPOSE_FILES=docker-compose.yml:docker-compose.prod.yml:docker-compose.tailscale.yml
 
 # ─── Tailscale sidecar (docker-compose.tailscale.yml) ─────────────────────────
 # Mint a per-instance, tagged (tag:offbook) auth key at:

--- a/Makefile
+++ b/Makefile
@@ -1,19 +1,22 @@
 .DEFAULT_GOAL := help
 
-.PHONY: help verify acceptance qa-smoke qa-suite bootstrap-dev deploy-dev deploy
+.PHONY: help verify acceptance qa-smoke qa-suite require-env bootstrap deploy
 
-# Local Tailscale dev stack (ADR-0016). Omits docker-compose.tailscale.yml on
-# purpose: the sidecar is authenticated and long-lived, so deploy-dev rebuilds
-# only the app images and never touches the sidecar or postgres.
-DEV_COMPOSE := docker compose -p offbook-dev -f docker-compose.yml
-# Full stack incl. the Tailscale sidecar — used by bootstrap-dev for first boot,
-# when postgres + the sidecar don't exist yet.
-DEV_COMPOSE_FULL := docker compose -p offbook-dev -f docker-compose.yml -f docker-compose.tailscale.yml
-
-# Remote deploy target (see the `deploy` target below). DEPLOY_HOST is required;
-# DEPLOY_PATH is where the repo is checked out on that host.
-DEPLOY_HOST ?=
-DEPLOY_PATH ?= ~/offbook
+# bootstrap/deploy are env-agnostic — ENV_FILE selects the instance (ADR-0016).
+# Each env file is the single source of truth for an instance: it declares
+# OFFBOOK_PROJECT (compose project name) and OFFBOOK_COMPOSE_FILES (its overlay
+# list, incl. the tailscale sidecar) alongside its secrets/TS_*/DB.
+#   make deploy                  -> dev   (.env)
+#   make deploy ENV_FILE=.env.prod  -> prod
+ENV_FILE ?= .env
+# Read project + overlay files from the env file (custom OFFBOOK_* vars, not
+# COMPOSE_FILE, so stray `docker compose` calls aren't affected). Missing file
+# -> empty; the require-env prerequisite turns that into a clear error.
+OFFBOOK_PROJECT := $(shell sed -n 's/^OFFBOOK_PROJECT=//p' $(ENV_FILE) 2>/dev/null)
+OFFBOOK_FILES := $(shell sed -n 's/^OFFBOOK_COMPOSE_FILES=//p' $(ENV_FILE) 2>/dev/null | tr ':' ' ')
+# Compose invocation for the selected instance: explicit project + overlays from
+# the env file, with the env file as the interpolation/secret source.
+COMPOSE := docker compose --env-file $(ENV_FILE) -p $(OFFBOOK_PROJECT) $(foreach f,$(OFFBOOK_FILES),-f $(f))
 
 ACCEPTANCE_DIR := acceptance
 ACCEPTANCE_BASE_URL ?= http://localhost:15173
@@ -27,66 +30,56 @@ help:
 	@printf '%s\n' '  command make qa-smoke            Run the baseline acceptance smoke suite'
 	@printf '%s\n' '  command make qa-suite QA_SUITE=plaid  Run one acceptance suite or spec pattern'
 	@printf '%s\n' '  command make verify              Run the backend CI mirror from backend/'
-	@printf '%s\n' '  command make bootstrap-dev TS_AUTHKEY=tskey-...  First boot: bring up the FULL stack (postgres + sidecar), stamped'
-	@printf '%s\n' '  command make deploy-dev          Rebuild + recreate the local offbook-dev stack at the current HEAD'
-	@printf '%s\n' '  command make deploy DEPLOY_HOST=user@host  Redeploy a remote host over SSH (current HEAD; push first)'
+	@printf '%s\n' '  command make bootstrap [ENV_FILE=.env]   First boot: full stack (postgres + sidecar), stamped, per the env file'
+	@printf '%s\n' '  command make deploy    [ENV_FILE=.env]   Rebuild + recreate app, prune; .env=dev, ENV_FILE=.env.prod=prod'
 	@printf '%s\n' ''
 	@printf '%s\n' 'Backend-only targets live in backend/Makefile; run them from backend/ with command make <target>.'
 
 verify:
 	@$(MAKE) -C backend verify
 
-# bootstrap-dev is the ONE-TIME first boot: it brings up the full stack —
-# postgres + backend + frontend + the Tailscale sidecar — because deploy-dev
-# (--no-deps, no tailscale override) can't create those. Crucially it stamps
-# the build with the current SHA (GIT_SHA), same as deploy-dev, so /health
-# reports a real commit from the very first boot instead of "dev". After this,
-# use deploy-dev (or the auto-deploy timer) for updates.
-#   command make bootstrap-dev TS_AUTHKEY=tskey-auth-... [TS_HOSTNAME=offbook-dev]
-bootstrap-dev:
-	@test -n "$${TS_AUTHKEY:-}" || { echo 'Set TS_AUTHKEY=tskey-... — first boot registers the Tailscale sidecar. TS_HOSTNAME defaults to offbook-dev.' >&2; exit 2; }
-	@SHA="$$(git rev-parse --short HEAD)"; \
-		echo "Bootstrapping offbook-dev @ $$SHA (postgres + backend + frontend + tailscale)…"; \
-		GIT_SHA="$$SHA" TS_HOSTNAME="$${TS_HOSTNAME:-offbook-dev}" $(DEV_COMPOSE_FULL) up -d --build
-	@printf 'Bootstrapped offbook-dev → '; \
-		curl -fsS http://localhost:8000/api/v1/health 2>/dev/null && echo \
-		|| echo '(backend still starting — check GET /health in a few seconds)'
+# require-env: shared guard for bootstrap/deploy — the env file must exist and
+# declare OFFBOOK_PROJECT. Keeps an empty $(COMPOSE) (missing -p/-f) from running.
+require-env:
+	@test -f "$(ENV_FILE)" || { echo "Env file '$(ENV_FILE)' not found — copy .env.example to .env (or .env.prod.example to .env.prod) and fill it in." >&2; exit 2; }
+	@test -n "$(OFFBOOK_PROJECT)" || { echo "OFFBOOK_PROJECT missing from $(ENV_FILE) — add OFFBOOK_PROJECT and OFFBOOK_COMPOSE_FILES (see .env.example)." >&2; exit 2; }
 
-# deploy-dev redeploys the local offbook-dev stack from whatever is checked out.
-# It stamps the binary with the current short SHA (surfaced at GET /health and
-# Settings → About, #310), recreates only backend + frontend (--no-deps leaves
-# postgres + the Tailscale sidecar running), and prints the new /health version.
-# Migrations run on backend boot. There is no CD — this is the manual deploy.
-#
-# After recreating it prunes DANGLING images — the untagged layers orphaned when
-# the :latest tag moved to the new build — so repeated deploys don't fill the
-# disk (matters on the Pi's SD card). Dangling-only: it never removes tagged or
-# in-use images, so the running stack is safe.
-deploy-dev:
+# bootstrap is the ONE-TIME first boot for an instance: it brings up the full
+# stack — postgres + backend + frontend + the Tailscale sidecar — as declared by
+# the env file's OFFBOOK_COMPOSE_FILES, stamped with the current SHA so /health
+# reports a real commit from the start (not "dev"). Compose fail-fasts if the
+# env file is missing TS_AUTHKEY/TS_HOSTNAME/SESSION_SECRET. After this, use
+# deploy (or the auto-deploy timer) for updates.
+#   command make bootstrap                    # dev   (.env)
+#   command make bootstrap ENV_FILE=.env.prod # prod
+bootstrap: require-env
 	@SHA="$$(git rev-parse --short HEAD)"; \
-		echo "Building offbook-dev at $$SHA…"; \
-		GIT_SHA="$$SHA" $(DEV_COMPOSE) build backend frontend
-	@$(DEV_COMPOSE) up -d --no-deps backend frontend
+		echo "Bootstrapping $(OFFBOOK_PROJECT) @ $$SHA from $(ENV_FILE)…"; \
+		GIT_SHA="$$SHA" $(COMPOSE) up -d --build
+	@printf 'Bootstrapped $(OFFBOOK_PROJECT) → '; \
+		$(COMPOSE) exec -T backend wget -qO- http://localhost:8000/api/v1/health 2>/dev/null && echo \
+		|| echo '(backend still starting — check /health shortly)'
+
+# deploy updates an already-bootstrapped instance from whatever is checked out:
+# it stamps the binary with the current short SHA (surfaced at GET /health and
+# Settings → About, #310) and recreates only backend + frontend (--no-deps leaves
+# postgres + the sidecar running). Migrations run on backend boot.
+#
+# It then prunes DANGLING images — the untagged layers orphaned when the :latest
+# tag moved to the new build — so repeated deploys don't fill the disk (matters
+# on the Pi's SD card). Dangling-only: tagged / in-use images are never touched.
+#
+# Env-agnostic — the env file picks the instance:
+#   command make deploy                    # dev   (.env)
+#   command make deploy ENV_FILE=.env.prod # prod
+deploy: require-env
+	@SHA="$$(git rev-parse --short HEAD)"; \
+		echo "Deploying $(OFFBOOK_PROJECT) @ $$SHA from $(ENV_FILE)…"; \
+		GIT_SHA="$$SHA" $(COMPOSE) up -d --no-deps --build backend frontend
 	@printf 'Pruning dangling images… '; docker image prune -f | tail -1
-	@printf 'Deployed offbook-dev → '; curl -fsS http://localhost:8000/api/v1/health && echo
-
-# deploy redeploys a REMOTE host over SSH by running deploy-dev *on* that host,
-# not by driving a remote Docker socket. Running it remotely means the deploy
-# uses the remote's own .env, named volumes, and Docker daemon — so no secrets
-# or config from your machine leak into the remote (which DOCKER_HOST=ssh:// +
-# `env_file: .env` would cause). It deploys whatever commit YOU have checked out
-# locally (parity with deploy-dev), so push it to origin first.
-#
-# Remote prerequisites (an ADR-0016 self-host box already meets these): the repo
-# checked out at DEPLOY_PATH, Docker + make installed, and the offbook-dev stack
-# provisioned once (postgres volume + authenticated Tailscale sidecar).
-#
-#   command make deploy DEPLOY_HOST=user@host [DEPLOY_PATH=/srv/offbook]
-deploy:
-	@test -n "$(DEPLOY_HOST)" || { echo 'Set DEPLOY_HOST=user@host — e.g. command make deploy DEPLOY_HOST=greg@offbook-host' >&2; exit 2; }
-	@SHA="$$(git rev-parse --short HEAD)"; \
-		echo "Deploying $$SHA → $(DEPLOY_HOST):$(DEPLOY_PATH) over ssh…"; \
-		ssh "$(DEPLOY_HOST)" "set -e; cd $(DEPLOY_PATH) && git fetch --quiet origin && git checkout --quiet $$SHA && make deploy-dev"
+	@printf 'Deployed $(OFFBOOK_PROJECT) → '; \
+		$(COMPOSE) exec -T backend wget -qO- http://localhost:8000/api/v1/health 2>/dev/null && echo \
+		|| echo '(backend still starting — check /health shortly)'
 
 acceptance:
 	@./scripts/qa-assert-role.sh

--- a/infra/auto-deploy/README.md
+++ b/infra/auto-deploy/README.md
@@ -6,7 +6,7 @@ Pi) whenever `origin/main` moves — **no GitHub Actions, no inbound webhook.**
 A systemd timer polls `origin/main` every ~2 minutes. When the running build's
 SHA (reported by `GET /health`, see [ADR-0016](../../docs/ADR/0016-tailscale-per-instance-deployment.md)
 and `#310`) differs from `origin/main`, it fast-forwards `main` and runs
-`make deploy-dev`. Because it only ever fetches and builds `main` (never PR/fork
+`make deploy` (using the host's `.env`). Because it only ever fetches and builds `main` (never PR/fork
 code) and makes only outbound connections, it works behind NAT/Tailscale and
 adds no attack surface — unlike a self-hosted GitHub Actions runner on a public
 repo.
@@ -27,28 +27,30 @@ repo.
    cd ~/offbook
    ```
 
-3. **Env.** Create `.env` (gitignored) with at least a real `SESSION_SECRET`,
-   plus any Plaid / Claude keys you want this instance to have:
+3. **Env.** Create `.env` (gitignored) — the single source of truth for this
+   instance. Fill in `SESSION_SECRET`, `TS_AUTHKEY` (and `TS_HOSTNAME`), and any
+   Plaid / Claude keys. The `OFFBOOK_PROJECT` + `OFFBOOK_COMPOSE_FILES` defaults
+   from the example already select the dev stack + sidecar:
 
    ```sh
    cp .env.example .env
-   # edit .env: SESSION_SECRET=$(openssl rand -hex 32), etc.
+   # edit .env: SESSION_SECRET=$(openssl rand -hex 32), TS_AUTHKEY=tskey-..., etc.
    ```
 
-4. **Bring the full stack up once** with `bootstrap-dev` — this creates
-   postgres + backend + frontend + the Tailscale sidecar. (`deploy-dev` can't
-   do first boot: it runs `--no-deps` without the sidecar override, so postgres
-   and Tailscale must already exist.) `bootstrap-dev` stamps the build with the
-   current SHA, exactly like `deploy-dev`, so `/health` reports a real commit
-   from the start instead of `dev`:
+4. **Bring the full stack up once** with `bootstrap` — this creates postgres +
+   backend + frontend + the Tailscale sidecar (per `OFFBOOK_COMPOSE_FILES`).
+   (`deploy` can't do first boot: it runs `--no-deps`, so postgres and Tailscale
+   must already exist.) `bootstrap` stamps the build with the current SHA, just
+   like `deploy`, so `/health` reports a real commit from the start instead of
+   `dev`:
 
    ```sh
-   TS_AUTHKEY=tskey-auth-... make bootstrap-dev      # TS_HOSTNAME defaults to offbook-dev
+   make bootstrap          # reads .env (ENV_FILE defaults to .env)
    ```
 
    The node comes up at `offbook-dev.<tailnet>.ts.net` (first cert ~30s). See
-   `infra/tailscale/README.md`. `TS_AUTHKEY` is only needed for this one-time
-   boot; the timer (and `deploy-dev`) never touch the sidecar again.
+   `infra/tailscale/README.md`. The sidecar is only created here; the timer
+   (and `deploy`) never recreate it.
 
 5. **Install the timer.** Edit `User=` and the two paths in the unit if you're
    not using `pi` / `~/offbook`, then:
@@ -85,13 +87,16 @@ sudo systemctl enable  --now offbook-deploy-dev.timer
   "needs deploy" → the stack is rebuilt and recovers.
 - **Single-flight.** A build can outlast the 2-minute interval; an `flock`
   guard skips overlapping runs rather than stacking them.
-- **Manual deploys still work** — `make deploy-dev` (local) or
-  `make deploy DEPLOY_HOST=...` (from a laptop) coexist with the timer.
+- **Manual deploys still work** — `make deploy` on the host coexists with the
+  timer (both deploy the instance configured by `.env`).
 - **Local edits on the host block deploys** on purpose: `git merge --ff-only`
   fails loudly if the checkout has diverged, rather than clobbering it. Keep
   the deploy checkout clean.
 - **Private repo later?** Anonymous `git fetch` works because the repo is
   public. If you make it private, give the host a read-only deploy key or a
   token-backed remote so the fetch keeps working.
-- **prod** is not wired here yet — there's no `make deploy-prod` target. When
-  it lands, copy this directory to an `offbook-prod`-flavored timer.
+- **prod on the same host?** `bootstrap`/`deploy` are env-agnostic — create a
+  `.env.prod` (see `.env.prod.example`) and run `make deploy ENV_FILE=.env.prod`.
+  For a prod auto-deploy timer, copy the unit and set `OFFBOOK_ENV_FILE=.env.prod`
+  in its `[Service]` `Environment=` (and probably gate prod behind tags rather
+  than every `main` push).

--- a/infra/auto-deploy/auto-deploy-dev.sh
+++ b/infra/auto-deploy/auto-deploy-dev.sh
@@ -47,4 +47,6 @@ fi
 echo "auto-deploy: deployed=${deployed:-none} -> origin/$BRANCH=$remote; redeploying"
 git checkout --quiet "$BRANCH"
 git merge --ff-only --quiet "origin/$BRANCH"
-make deploy-dev
+# Env-agnostic: deploys the instance configured by ENV_FILE (default .env).
+# Override OFFBOOK_ENV_FILE to point a prod host's timer at .env.prod.
+make deploy ENV_FILE="${OFFBOOK_ENV_FILE:-.env}"


### PR DESCRIPTION
Closes #324.

Per your point — each host already needs its own env file, so that file should *be* the instance definition, and one `make bootstrap`/`make deploy` should serve dev or prod from it. The laptop→host SSH `deploy` target is then redundant and is removed.

## What changed
- **Removed** `make deploy DEPLOY_HOST=...` (SSH remote, was #317) + `DEPLOY_*` vars. You deploy on the host now (manually or via the auto-deploy timer).
- **`bootstrap-dev` → `bootstrap`, `deploy-dev` → `deploy`**, both env-agnostic via `ENV_FILE ?= .env`:
  - `make deploy` → dev (`.env`); `make deploy ENV_FILE=.env.prod` → prod. Same for `bootstrap`. Supports dev+prod on one Pi from one checkout.
  - Each env file declares `OFFBOOK_PROJECT` (compose project) + `OFFBOOK_COMPOSE_FILES` (overlay list incl. the sidecar); the Makefile reads them and passes `--env-file` for interpolation/secrets.
  - Custom `OFFBOOK_*` vars (not `COMPOSE_FILE`) so stray `docker compose` calls aren't affected.
  - Shared `require-env` guard → clear error if the env file or `OFFBOOK_PROJECT` is missing.
- **Bonus fix:** `deploy` now composes the tailscale overlay, so recreated backend/frontend keep `restart: unless-stopped` — the old `deploy-dev` omitted the overlay and silently dropped the restart policy. Health check switched to `compose exec` so it works for prod (no host ports bound).
- `.env.example` / `.env.prod.example`: added `OFFBOOK_PROJECT` + `OFFBOOK_COMPOSE_FILES` (and `TS_*` in the dev example).
- `infra/auto-deploy/`: script runs `make deploy ENV_FILE=…`; README updated, with an env-agnostic prod-timer note.

## Migration for the running Pi
Add to its `.env`: `OFFBOOK_PROJECT=offbook-dev`, `OFFBOOK_COMPOSE_FILES=docker-compose.yml:docker-compose.tailscale.yml`, `TS_AUTHKEY=…`, `TS_HOSTNAME=offbook-dev`. Then `make deploy` works.

## Verification
- `make help` lists the new targets ✅
- `make -n deploy ENV_FILE=…` → `docker compose --env-file … -p offbook-dev -f docker-compose.yml -f docker-compose.tailscale.yml up -d --no-deps --build backend frontend` ✅
- prod env file → all three overlays + `-p offbook-prod` ✅
- `require-env` fires (missing file / missing `OFFBOOK_PROJECT`) with exit 2 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)