### PR TITLE
Merge bootstrap into deploy; TS_AUTHKEY only at first boot (#326)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,7 +19,7 @@ PORT=8000
 FRONTEND_URL=http://localhost:5173
 MIGRATIONS_PATH=migrations
 
-# ─── Deploy (make bootstrap / make deploy) ──────────────────────────────────
+# ─── Deploy (make deploy) ────────────────────────────────────────────────────
 # This env file is the single source of truth for the instance it configures.
 # OFFBOOK_PROJECT is the compose project name; OFFBOOK_COMPOSE_FILES is the
 # colon-separated overlay list the deploy targets bring up. Dev runs the base
@@ -30,10 +30,12 @@ OFFBOOK_PROJECT=offbook-dev
 OFFBOOK_COMPOSE_FILES=docker-compose.yml:docker-compose.tailscale.yml
 
 # ─── Tailscale sidecar (docker-compose.tailscale.yml) ───────────────────────
-# Per-instance, tagged auth key (tskey-...): https://login.tailscale.com/admin/settings/keys
-TS_AUTHKEY=
 # MagicDNS hostname → https://<TS_HOSTNAME>.<tailnet>.ts.net
 TS_HOSTNAME=offbook-dev
+# NOTE: TS_AUTHKEY is intentionally NOT stored here. It's only needed the first
+# time the sidecar is created — pass it once on the command line:
+#   command make deploy TS_AUTHKEY=tskey-...
+# After that the sidecar runs from its state volume and `make deploy` needs no key.
 # Optional extra tailscaled flags (e.g. --advertise-tags=tag:offbook). Leave
 # unset when your auth key already auto-applies a tag.
 # TS_EXTRA_ARGS=

--- a/.env.prod.example
+++ b/.env.prod.example
@@ -8,21 +8,22 @@
 # compose variable substitution (TS_*) and as the backend container's
 # env_file (SESSION_SECRET, FRONTEND_URL).
 #
-# Deploy with:  command make bootstrap ENV_FILE=.env.prod   (first boot)
-#               command make deploy    ENV_FILE=.env.prod   (updates)
+# Deploy with:  command make deploy ENV_FILE=.env.prod TS_AUTHKEY=tskey-...  (first boot)
+#               command make deploy ENV_FILE=.env.prod                       (updates)
 
-# ─── Deploy (make bootstrap / make deploy) ────────────────────────────────────
+# ─── Deploy (make deploy) ─────────────────────────────────────────────────────
 # Compose project + overlay list for this instance. Prod composes the base
 # stack, the prod override (no host ports, prod DB volume), and the sidecar.
 OFFBOOK_PROJECT=offbook-prod
 OFFBOOK_COMPOSE_FILES=docker-compose.yml:docker-compose.prod.yml:docker-compose.tailscale.yml
 
 # ─── Tailscale sidecar (docker-compose.tailscale.yml) ─────────────────────────
-# Mint a per-instance, tagged (tag:offbook) auth key at:
-#   https://login.tailscale.com/admin/settings/keys
-TS_AUTHKEY=
 # MagicDNS hostname for this instance. Final URL: https://<TS_HOSTNAME>.<tailnet>.ts.net
 TS_HOSTNAME=offbook-prod
+# NOTE: TS_AUTHKEY is NOT stored here — pass it once at first boot:
+#   command make deploy ENV_FILE=.env.prod TS_AUTHKEY=tskey-...
+# Mint a per-instance, tagged (tag:offbook) key at:
+#   https://login.tailscale.com/admin/settings/keys
 # Optional. Extra flags for `tailscaled`. Leave unset if your auth key
 # auto-applies a tag (the recommended setup for ACL-restricted reusable keys).
 # Set e.g. `--advertise-tags=tag:offbook` only if you mint untagged keys.

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,17 @@
 .DEFAULT_GOAL := help
 
-.PHONY: help verify acceptance qa-smoke qa-suite require-env bootstrap deploy
+.PHONY: help verify acceptance qa-smoke qa-suite require-env deploy
 
-# bootstrap/deploy are env-agnostic — ENV_FILE selects the instance (ADR-0016).
-# Each env file is the single source of truth for an instance: it declares
-# OFFBOOK_PROJECT (compose project name) and OFFBOOK_COMPOSE_FILES (its overlay
-# list, incl. the tailscale sidecar) alongside its secrets/TS_*/DB.
-#   make deploy                  -> dev   (.env)
+# deploy is env-agnostic — ENV_FILE selects the instance (ADR-0016). Each env
+# file is the single source of truth for an instance: it declares OFFBOOK_PROJECT
+# (compose project name) and OFFBOOK_COMPOSE_FILES (its overlay list, incl. the
+# tailscale sidecar) alongside its secrets/TS_HOSTNAME/DB.
+#   make deploy                     -> dev   (.env)
 #   make deploy ENV_FILE=.env.prod  -> prod
 ENV_FILE ?= .env
+# TS_AUTHKEY is passed ONLY on first boot (to register the sidecar), never stored
+# in the env file. Pass it on the command line: make deploy TS_AUTHKEY=tskey-...
+TS_AUTHKEY ?=
 # Read project + overlay files from the env file (custom OFFBOOK_* vars, not
 # COMPOSE_FILE, so stray `docker compose` calls aren't affected). Missing file
 # -> empty; the require-env prerequisite turns that into a clear error.
@@ -30,8 +33,8 @@ help:
 	@printf '%s\n' '  command make qa-smoke            Run the baseline acceptance smoke suite'
 	@printf '%s\n' '  command make qa-suite QA_SUITE=plaid  Run one acceptance suite or spec pattern'
 	@printf '%s\n' '  command make verify              Run the backend CI mirror from backend/'
-	@printf '%s\n' '  command make bootstrap [ENV_FILE=.env]   First boot: full stack (postgres + sidecar), stamped, per the env file'
-	@printf '%s\n' '  command make deploy    [ENV_FILE=.env]   Rebuild + recreate app, prune; .env=dev, ENV_FILE=.env.prod=prod'
+	@printf '%s\n' '  command make deploy [ENV_FILE=.env]      Deploy/update an instance (.env=dev, ENV_FILE=.env.prod=prod).'
+	@printf '%s\n' '                                           First boot only: add TS_AUTHKEY=tskey-... to register the sidecar.'
 	@printf '%s\n' ''
 	@printf '%s\n' 'Backend-only targets live in backend/Makefile; run them from backend/ with command make <target>.'
 
@@ -44,38 +47,37 @@ require-env:
 	@test -f "$(ENV_FILE)" || { echo "Env file '$(ENV_FILE)' not found — copy .env.example to .env (or .env.prod.example to .env.prod) and fill it in." >&2; exit 2; }
 	@test -n "$(OFFBOOK_PROJECT)" || { echo "OFFBOOK_PROJECT missing from $(ENV_FILE) — add OFFBOOK_PROJECT and OFFBOOK_COMPOSE_FILES (see .env.example)." >&2; exit 2; }
 
-# bootstrap is the ONE-TIME first boot for an instance: it brings up the full
-# stack — postgres + backend + frontend + the Tailscale sidecar — as declared by
-# the env file's OFFBOOK_COMPOSE_FILES, stamped with the current SHA so /health
-# reports a real commit from the start (not "dev"). Compose fail-fasts if the
-# env file is missing TS_AUTHKEY/TS_HOSTNAME/SESSION_SECRET. After this, use
-# deploy (or the auto-deploy timer) for updates.
-#   command make bootstrap                    # dev   (.env)
-#   command make bootstrap ENV_FILE=.env.prod # prod
-bootstrap: require-env
-	@SHA="$$(git rev-parse --short HEAD)"; \
-		echo "Bootstrapping $(OFFBOOK_PROJECT) @ $$SHA from $(ENV_FILE)…"; \
-		GIT_SHA="$$SHA" $(COMPOSE) up -d --build
-	@printf 'Bootstrapped $(OFFBOOK_PROJECT) → '; \
-		$(COMPOSE) exec -T backend wget -qO- http://localhost:8000/api/v1/health 2>/dev/null && echo \
-		|| echo '(backend still starting — check /health shortly)'
-
-# deploy updates an already-bootstrapped instance from whatever is checked out:
-# it stamps the binary with the current short SHA (surfaced at GET /health and
-# Settings → About, #310) and recreates only backend + frontend (--no-deps leaves
-# postgres + the sidecar running). Migrations run on backend boot.
+# deploy is the single command for an instance — first boot AND updates. It
+# stamps the build with the current short SHA (surfaced at GET /health and
+# Settings → About, #310), then prunes dangling images (so repeated deploys
+# don't fill the disk — matters on the Pi's SD card) and reports /health.
 #
-# It then prunes DANGLING images — the untagged layers orphaned when the :latest
-# tag moved to the new build — so repeated deploys don't fill the disk (matters
-# on the Pi's SD card). Dangling-only: tagged / in-use images are never touched.
+# It auto-detects the Tailscale sidecar:
+#   • Sidecar already up  -> app-only update: recreate ONLY backend+frontend
+#     (--no-deps leaves postgres + the sidecar running). No TS_AUTHKEY needed.
+#   • Sidecar not up (first boot) -> bring up the FULL stack. This needs the auth
+#     key ONCE to register the sidecar; pass it on the command line and don't
+#     store it:  make deploy TS_AUTHKEY=tskey-...
 #
 # Env-agnostic — the env file picks the instance:
-#   command make deploy                    # dev   (.env)
-#   command make deploy ENV_FILE=.env.prod # prod
+#   command make deploy                                   # dev   (.env)
+#   command make deploy ENV_FILE=.env.prod                # prod
+#   command make deploy TS_AUTHKEY=tskey-...              # first boot
 deploy: require-env
 	@SHA="$$(git rev-parse --short HEAD)"; \
-		echo "Deploying $(OFFBOOK_PROJECT) @ $$SHA from $(ENV_FILE)…"; \
-		GIT_SHA="$$SHA" $(COMPOSE) up -d --no-deps --build backend frontend
+	if [ -n "$$($(COMPOSE) ps -q tailscale 2>/dev/null)" ]; then \
+		echo "Deploying $(OFFBOOK_PROJECT) @ $$SHA from $(ENV_FILE) (app update; sidecar up)…"; \
+		GIT_SHA="$$SHA" $(COMPOSE) up -d --no-deps --build backend frontend; \
+	else \
+		if $(COMPOSE) config --services 2>/dev/null | grep -qx tailscale && [ -z "$(TS_AUTHKEY)" ]; then \
+			echo "First boot needs the Tailscale auth key once — re-run:" >&2; \
+			echo "    command make deploy$(if $(filter-out .env,$(ENV_FILE)), ENV_FILE=$(ENV_FILE)) TS_AUTHKEY=tskey-..." >&2; \
+			echo "(mint a per-instance key at https://login.tailscale.com/admin/settings/keys — it is not stored)" >&2; \
+			exit 2; \
+		fi; \
+		echo "First boot: bringing up the full $(OFFBOOK_PROJECT) stack @ $$SHA…"; \
+		TS_AUTHKEY="$(TS_AUTHKEY)" GIT_SHA="$$SHA" $(COMPOSE) up -d --build; \
+	fi
 	@printf 'Pruning dangling images… '; docker image prune -f | tail -1
 	@printf 'Deployed $(OFFBOOK_PROJECT) → '; \
 		$(COMPOSE) exec -T backend wget -qO- http://localhost:8000/api/v1/health 2>/dev/null && echo \

--- a/docker-compose.tailscale.yml
+++ b/docker-compose.tailscale.yml
@@ -2,23 +2,28 @@
 # https://${TS_HOSTNAME}.<tailnet>.ts.net. Instance-agnostic: compose with any
 # base stack; instance identity comes from the compose project name.
 #
-# Required env (no defaults — intentional, fail-fast):
+# Env (soft defaults — see below):
 #   TS_AUTHKEY   Tailscale auth key (tskey-...). Prefer per-instance, tagged.
+#                ONLY consumed when the sidecar is first created/recreated.
 #   TS_HOSTNAME  MagicDNS name for this node (e.g. offbook-dev, offbook-prod).
 #
-# Example:
-#   TS_AUTHKEY=tskey-... TS_HOSTNAME=offbook-dev \
-#     docker compose -p offbook-dev \
-#       -f docker-compose.yml -f docker-compose.tailscale.yml up -d
+# These use `:-` (default empty) rather than `:?` (fail-fast) so an app-only
+# `up --no-deps backend frontend` — which parses this file but doesn't touch the
+# sidecar — doesn't demand them. `make deploy` guards TS_AUTHKEY at first boot
+# (when the sidecar is actually created); after that the sidecar runs from its
+# state volume and needs neither value again.
+#
+# Example (first boot):
+#   command make deploy TS_AUTHKEY=tskey-...   # TS_HOSTNAME comes from the env file
 #
 # See ADR-0016 for rationale.
 services:
   tailscale:
     image: tailscale/tailscale:latest
-    hostname: ${TS_HOSTNAME:?TS_HOSTNAME required (the MagicDNS name for this instance)}
+    hostname: ${TS_HOSTNAME:-}
     environment:
-      TS_AUTHKEY: ${TS_AUTHKEY:?TS_AUTHKEY required (per-instance Tailscale auth key)}
-      TS_HOSTNAME: ${TS_HOSTNAME}
+      TS_AUTHKEY: ${TS_AUTHKEY:-}
+      TS_HOSTNAME: ${TS_HOSTNAME:-}
       TS_STATE_DIR: /var/lib/tailscale
       TS_USERSPACE: "true"
       # Optional. Pass extra `tailscaled` flags here, e.g. --advertise-tags=tag:X.

--- a/infra/auto-deploy/README.md
+++ b/infra/auto-deploy/README.md
@@ -28,29 +28,27 @@ repo.
    ```
 
 3. **Env.** Create `.env` (gitignored) — the single source of truth for this
-   instance. Fill in `SESSION_SECRET`, `TS_AUTHKEY` (and `TS_HOSTNAME`), and any
-   Plaid / Claude keys. The `OFFBOOK_PROJECT` + `OFFBOOK_COMPOSE_FILES` defaults
-   from the example already select the dev stack + sidecar:
+   instance. Fill in `SESSION_SECRET`, `TS_HOSTNAME`, and any Plaid / Claude
+   keys. The `OFFBOOK_PROJECT` + `OFFBOOK_COMPOSE_FILES` defaults from the example
+   already select the dev stack + sidecar. **`TS_AUTHKEY` is not stored here** —
+   it's passed once at first boot (next step):
 
    ```sh
    cp .env.example .env
-   # edit .env: SESSION_SECRET=$(openssl rand -hex 32), TS_AUTHKEY=tskey-..., etc.
+   # edit .env: SESSION_SECRET=$(openssl rand -hex 32), TS_HOSTNAME=offbook-dev, etc.
    ```
 
-4. **Bring the full stack up once** with `bootstrap` — this creates postgres +
-   backend + frontend + the Tailscale sidecar (per `OFFBOOK_COMPOSE_FILES`).
-   (`deploy` can't do first boot: it runs `--no-deps`, so postgres and Tailscale
-   must already exist.) `bootstrap` stamps the build with the current SHA, just
-   like `deploy`, so `/health` reports a real commit from the start instead of
-   `dev`:
+4. **First boot.** Run `deploy` with the Tailscale auth key once — `deploy`
+   sees the sidecar isn't up yet, so it brings up the full stack (postgres +
+   backend + frontend + sidecar), stamped with the current SHA:
 
    ```sh
-   make bootstrap          # reads .env (ENV_FILE defaults to .env)
+   make deploy TS_AUTHKEY=tskey-...      # reads .env (ENV_FILE defaults to .env)
    ```
 
    The node comes up at `offbook-dev.<tailnet>.ts.net` (first cert ~30s). See
-   `infra/tailscale/README.md`. The sidecar is only created here; the timer
-   (and `deploy`) never recreate it.
+   `infra/tailscale/README.md`. Every later `make deploy` detects the sidecar is
+   already up and recreates only backend+frontend — no `TS_AUTHKEY` needed.
 
 5. **Install the timer.** Edit `User=` and the two paths in the unit if you're
    not using `pi` / `~/offbook`, then:

--- a/infra/auto-deploy/auto-deploy-dev.sh
+++ b/infra/auto-deploy/auto-deploy-dev.sh
@@ -10,7 +10,8 @@
 # the checkout, so a failed build is retried on the next tick (the running
 # version stays behind until a build actually succeeds).
 #
-# Reuses `make deploy-dev` for the actual build + recreate.
+# Reuses `make deploy` for the actual build + recreate (sidecar already up, so
+# no TS_AUTHKEY needed — the timer only runs after first boot).
 #
 # Env overrides:
 #   OFFBOOK_REPO           repo checkout path        (default: $HOME/offbook)


### PR DESCRIPTION
Closes #326. Final shape of the deploy command, per your direction.

## One command
`make deploy` now handles **first boot and updates**, auto-detecting the Tailscale sidecar:

- **Sidecar up** → app-only update: recreate `backend`+`frontend` (`--no-deps`, postgres + sidecar untouched), prune, report `/health`. **No `TS_AUTHKEY` needed.**
- **Sidecar not up** (first boot) → full `up -d --build`. Needs the auth key **once** to register the sidecar:
  ```sh
  make deploy TS_AUTHKEY=tskey-...
  ```
  Missing it → clear error telling you to pass it (also echoes the right `ENV_FILE=` when prod).

`bootstrap` is gone — that was the only thing it did that `deploy` couldn't.

## TS_AUTHKEY no longer stored
- Removed `TS_AUTHKEY` from `.env.example` / `.env.prod.example`. It's passed once on the command line at first boot, never persisted. `TS_HOSTNAME` stays (per-instance name, not a secret).
- Softened `docker-compose.tailscale.yml` `${TS_AUTHKEY:?}`/`${TS_HOSTNAME:?}` → `:-`, so an app-only deploy (which *parses* the overlay but never touches the sidecar) no longer fails config validation for a missing key. The first-boot requirement now lives in the `deploy` guard.

## Why this also settles "why two commands?"
The only real difference was: bootstrap creates the sidecar/DB (needs the key); deploy swaps app code (`--no-deps`, never restarts DB/sidecar, no key). Folding the sidecar-presence check into `deploy` collapses that into one command while keeping the safe `--no-deps` update path (a plain converging `up` would recreate the sidecar if `TS_AUTHKEY` were removed from the env — fragile; this isn't).

## Migration for the running Pi
Its `.env` needs `OFFBOOK_PROJECT`, `OFFBOOK_COMPOSE_FILES`, `TS_HOSTNAME` (drop `TS_AUTHKEY`). Then `make deploy` sees the sidecar running and updates the app — no key.

## Verification
- `docker compose … config -q` with **no** `TS_AUTHKEY` → now passes (was the bug) ✅
- Sidecar detection: `config --services` lists `tailscale`, `ps -q tailscale` empty when not running ✅
- `make deploy` (sidecar down, no key) → exit 2 with the "pass `TS_AUTHKEY` once" message (incl. correct `ENV_FILE=`) ✅
- `make help` shows the single `deploy` line ✅
- (First-boot `up` branch not run locally — would build/start a stack; logic is the standard full `up -d --build`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)