### PR TITLE
#332 Phase 1: extractor seam for statement import (no AI)

### DIFF
--- a/backend/internal/handler/transaction_handler.go
+++ b/backend/internal/handler/transaction_handler.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"errors"
+	"io"
 	"net/http"
 	"strconv"
 	"time"
@@ -16,11 +17,14 @@ import (
 )
 
 type TransactionHandler struct {
-	svc *service.TransactionService
+	svc      *service.TransactionService
+	registry *ingestion.Registry
 }
 
 func NewTransactionHandler(s *service.TransactionService) *TransactionHandler {
-	return &TransactionHandler{svc: s}
+	// Phase-1 registry: CSV only. ADR-0019 phase 2 swaps in a registry that
+	// also routes application/pdf and image/* to the AI extractor.
+	return &TransactionHandler{svc: s, registry: ingestion.NewDefaultRegistry()}
 }
 
 func (h *TransactionHandler) Register(g *gin.RouterGroup) {
@@ -264,17 +268,18 @@ func (h *TransactionHandler) Delete(c *gin.Context) {
 	c.Status(http.StatusNoContent)
 }
 
-// Import ingests a CSV statement into the path account. Multipart form fields:
+// Import ingests a statement file into the path account. Multipart form fields:
 //
-//	file            — the CSV file (required)
+//	file            — the statement file (required); CSV today, PDF/photo later
 //	commit          — "true" writes new rows; otherwise (default) preview only
-//	date_col        — optional header-name override for the date column
-//	amount_col      — optional header-name override for the amount column
-//	description_col — optional header-name override for the description column
+//	date_col        — optional header-name override for the date column (CSV)
+//	amount_col      — optional header-name override for the amount column (CSV)
+//	description_col — optional header-name override for the description (CSV)
 //
-// Omitted *_col fields are auto-detected from common header aliases. The
-// response is an ImportResult: per-row new/duplicate/error classification plus
-// totals. A preview run writes nothing.
+// The registry selects an extractor by the upload's MIME type (CSV-only in
+// phase 1). Omitted *_col fields are auto-detected from common header aliases.
+// The response is an ImportResult: per-row new/duplicate/error classification
+// plus totals. A preview run writes nothing.
 func (h *TransactionHandler) Import(c *gin.Context) {
 	id, ok := parseID(c)
 	if !ok {
@@ -291,19 +296,29 @@ func (h *TransactionHandler) Import(c *gin.Context) {
 		return
 	}
 	defer func() { _ = f.Close() }()
-
-	mapping := ingestion.ColumnMapping{
-		Date:        c.PostForm("date_col"),
-		Amount:      c.PostForm("amount_col"),
-		Description: c.PostForm("description_col"),
+	data, err := io.ReadAll(f)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "cannot read uploaded file", "code": "INVALID_REQUEST"})
+		return
 	}
-	parsed, err := ingestion.Parse(f, mapping)
+
+	doc := ingestion.Document{
+		Filename: fileHeader.Filename,
+		MIME:     fileHeader.Header.Get("Content-Type"),
+		Data:     data,
+		CSVMapping: ingestion.ColumnMapping{
+			Date:        c.PostForm("date_col"),
+			Amount:      c.PostForm("amount_col"),
+			Description: c.PostForm("description_col"),
+		},
+	}
+	ext, err := h.registry.For(doc.MIME).Extract(c.Request.Context(), doc)
 	if err != nil {
 		h.writeImportParseError(c, err)
 		return
 	}
 	commit := c.PostForm("commit") == "true"
-	res, err := h.svc.ImportCSV(c.Request.Context(), auth.MustUserID(c.Request.Context()), id, parsed, commit)
+	res, err := h.svc.ImportStatement(c.Request.Context(), auth.MustUserID(c.Request.Context()), id, ext, commit)
 	if err != nil {
 		h.writeServiceError(c, err)
 		return

--- a/backend/internal/service/ingestion/csv.go
+++ b/backend/internal/service/ingestion/csv.go
@@ -73,6 +73,11 @@ type ParsedRow struct {
 	// Err is non-empty when this row could not be parsed; Date/Amount are then
 	// zero and the row is excluded from import.
 	Err string `json:"error,omitempty"`
+	// Confidence is the extractor's certainty in this row, 0–1. Deterministic
+	// parsing (CSV) sets 1.0 for valid rows — there is no ambiguity once the
+	// columns are mapped. The AI extractor (ADR-0019 phase 2) reports a real
+	// per-row confidence the import service gates "needs review" on.
+	Confidence float64 `json:"confidence"`
 }
 
 // Valid reports whether the row parsed cleanly and can be imported.
@@ -227,6 +232,8 @@ func parseRecord(line int, rec []string, idx fieldIndex) ParsedRow {
 	row.Amount = amt
 
 	row.Description = field(rec, idx.description)
+	// Deterministic parse: a cleanly parsed row is fully trusted.
+	row.Confidence = 1.0
 	return row
 }
 

--- a/backend/internal/service/ingestion/extractor.go
+++ b/backend/internal/service/ingestion/extractor.go
@@ -1,0 +1,120 @@
+package ingestion
+
+import (
+	"bytes"
+	"context"
+	"strings"
+)
+
+// Document is a raw uploaded statement awaiting extraction. Data holds the
+// full bytes (not a stream) because non-CSV extractors — the AI vision path in
+// ADR-0019 phase 2 — need the whole document, and re-reading a multipart
+// stream is awkward.
+type Document struct {
+	Filename string
+	MIME     string
+	Data     []byte
+	// CSVMapping is an optional per-import column override, honored only by the
+	// CSV extractor (columns are auto-detected when it is zero). Other
+	// extractors ignore it.
+	CSVMapping ColumnMapping
+}
+
+// Extraction is the neutral, source-tagged output every Extractor produces:
+// the rows to import plus optional CSV echo metadata for the column-mapping
+// fallback UI. Source is the value written to transactions.source.
+type Extraction struct {
+	Source  string        `json:"source"`
+	Rows    []ParsedRow   `json:"-"`
+	Mapping ColumnMapping `json:"mapping"`
+	Headers []string      `json:"headers"`
+}
+
+// Extractor turns a Document into a neutral Extraction. The deterministic CSV
+// extractor is the only implementation today; the AI extractor (ADR-0019
+// phase 2) joins the registry for PDF/photo and unmappable-CSV fallback.
+type Extractor interface {
+	// Extract parses the document into rows. It returns the same domain errors
+	// the underlying parser does (e.g. *UnmappableError) so the handler can map
+	// them to 4xx codes.
+	Extract(ctx context.Context, doc Document) (*Extraction, error)
+	// Handles reports whether this extractor can process the given MIME type.
+	Handles(mime string) bool
+	// Name is a short stable identifier ("csv") used in logs and provenance.
+	Name() string
+}
+
+// CSVExtractor adapts the deterministic CSV parser to the Extractor interface.
+// Stateless.
+type CSVExtractor struct{}
+
+// Name implements Extractor.
+func (CSVExtractor) Name() string { return "csv" }
+
+// Handles matches the MIME types browsers and OSes attach to .csv uploads.
+// text/plain is included because many clients send CSVs as plain text.
+func (CSVExtractor) Handles(mime string) bool {
+	switch normalizeMIME(mime) {
+	case "text/csv", "application/csv", "text/plain", "application/vnd.ms-excel":
+		return true
+	default:
+		return false
+	}
+}
+
+// Extract parses the document bytes as CSV. doc.CSVMapping (when non-empty)
+// overrides column auto-detection.
+func (CSVExtractor) Extract(_ context.Context, doc Document) (*Extraction, error) {
+	res, err := Parse(bytes.NewReader(doc.Data), doc.CSVMapping)
+	if err != nil {
+		return nil, err
+	}
+	return &Extraction{
+		Source:  "csv",
+		Rows:    res.Rows,
+		Mapping: res.Mapping,
+		Headers: res.Headers,
+	}, nil
+}
+
+// Registry routes a Document to the Extractor that handles its MIME type. The
+// fallback handles anything no registered extractor claims — in phase 1 that is
+// the CSV extractor, preserving the pre-registry behavior of attempting a CSV
+// parse on any upload.
+type Registry struct {
+	extractors []Extractor
+	fallback   Extractor
+}
+
+// NewRegistry builds a registry with the given fallback (required) and any
+// number of MIME-specific extractors tried ahead of it.
+func NewRegistry(fallback Extractor, others ...Extractor) *Registry {
+	return &Registry{extractors: others, fallback: fallback}
+}
+
+// NewDefaultRegistry returns the phase-1 registry: CSV only, as both the sole
+// extractor and the fallback. ADR-0019 phase 2 will register the AI extractor
+// for application/pdf and image/* ahead of this fallback.
+func NewDefaultRegistry() *Registry {
+	return NewRegistry(CSVExtractor{})
+}
+
+// For returns the extractor that handles mime, or the fallback when none does.
+func (r *Registry) For(mime string) Extractor {
+	for _, e := range r.extractors {
+		if e.Handles(mime) {
+			return e
+		}
+	}
+	return r.fallback
+}
+
+// normalizeMIME lowercases and strips any "; charset=..." parameter so
+// "text/csv; charset=utf-8" matches "text/csv".
+func normalizeMIME(mime string) string {
+	mime = strings.ToLower(strings.TrimSpace(mime))
+	if i := strings.IndexByte(mime, ';'); i >= 0 {
+		mime = strings.TrimSpace(mime[:i])
+	}
+	return mime
+}

--- a/backend/internal/service/ingestion/extractor_test.go
+++ b/backend/internal/service/ingestion/extractor_test.go
@@ -1,0 +1,85 @@
+package ingestion
+
+import (
+	"context"
+	"testing"
+)
+
+func TestCSVExtractor_Handles(t *testing.T) {
+	cases := []struct {
+		mime string
+		want bool
+	}{
+		{"text/csv", true},
+		{"text/csv; charset=utf-8", true},
+		{"TEXT/CSV", true},
+		{"application/csv", true},
+		{"application/vnd.ms-excel", true},
+		{"text/plain", true},
+		{"application/pdf", false},
+		{"image/png", false},
+		{"", false},
+	}
+	for _, c := range cases {
+		t.Run(c.mime, func(t *testing.T) {
+			if got := (CSVExtractor{}).Handles(c.mime); got != c.want {
+				t.Errorf("Handles(%q) = %v, want %v", c.mime, got, c.want)
+			}
+		})
+	}
+}
+
+func TestCSVExtractor_Extract(t *testing.T) {
+	csv := "Date,Description,Amount\n2026-05-15,Coffee,-4.50\n"
+	doc := Document{MIME: "text/csv", Data: []byte(csv)}
+	ext, err := CSVExtractor{}.Extract(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+	if ext.Source != "csv" {
+		t.Errorf("source = %q, want csv", ext.Source)
+	}
+	if len(ext.Rows) != 1 {
+		t.Fatalf("rows = %d, want 1", len(ext.Rows))
+	}
+	if r := ext.Rows[0]; !r.Valid() || r.Confidence != 1.0 {
+		t.Errorf("row valid=%v confidence=%v, want true/1.0", r.Valid(), r.Confidence)
+	}
+	// CSV echo metadata is populated for the manual-mapping fallback UI.
+	if len(ext.Headers) != 3 || ext.Mapping.Amount == "" {
+		t.Errorf("expected CSV echo metadata, got headers=%v mapping=%+v", ext.Headers, ext.Mapping)
+	}
+}
+
+func TestCSVExtractor_ExtractPropagatesUnmappable(t *testing.T) {
+	// No mappable columns → the extractor surfaces *UnmappableError unchanged so
+	// the handler can return IMPORT_UNMAPPABLE.
+	doc := Document{MIME: "text/csv", Data: []byte("foo,bar\n1,2\n")}
+	_, err := CSVExtractor{}.Extract(context.Background(), doc)
+	var unmappable *UnmappableError
+	if !asUnmappable(err, &unmappable) {
+		t.Fatalf("err = %v, want *UnmappableError", err)
+	}
+}
+
+func TestRegistry_For(t *testing.T) {
+	reg := NewDefaultRegistry()
+	// Phase 1: CSV is the fallback, so any MIME routes to it.
+	for _, mime := range []string{"text/csv", "application/pdf", "image/png", ""} {
+		if got := reg.For(mime).Name(); got != "csv" {
+			t.Errorf("For(%q) = %q, want csv (phase-1 fallback)", mime, got)
+		}
+	}
+}
+
+// asUnmappable is a tiny errors.As shim kept local so the test reads cleanly.
+func asUnmappable(err error, target **UnmappableError) bool {
+	if err == nil {
+		return false
+	}
+	u, ok := err.(*UnmappableError)
+	if ok {
+		*target = u
+	}
+	return ok
+}

--- a/backend/internal/service/transaction_import.go
+++ b/backend/internal/service/transaction_import.go
@@ -24,6 +24,12 @@ const (
 	ImportError     ImportRowStatus = "error"     // failed to parse, skipped
 )
 
+// reviewConfidenceThreshold gates "needs review": a new row whose extractor
+// confidence is below this is flagged for the user to confirm before commit.
+// Deterministic CSV rows are confidence 1.0, so they never trip it — the gate
+// only bites once the AI extractor (ADR-0019 phase 2) reports real confidence.
+const reviewConfidenceThreshold = 0.8
+
 // ImportRowResult is the per-row outcome surfaced to the UI for both preview
 // (commit=false) and commit (commit=true) runs.
 type ImportRowResult struct {
@@ -34,34 +40,49 @@ type ImportRowResult struct {
 	ExternalID  string          `json:"external_id,omitempty"`
 	Status      ImportRowStatus `json:"status"`
 	Error       string          `json:"error,omitempty"`
+	// Confidence is the extractor's certainty (0–1) for this row. NeedsReview is
+	// set when a new row's confidence is below reviewConfidenceThreshold; the UI
+	// surfaces these and blocks one-click commit until acknowledged.
+	Confidence  float64 `json:"confidence"`
+	NeedsReview bool    `json:"needs_review"`
 }
 
-// ImportResult summarizes a CSV import attempt. On a preview run nothing is
-// written and InsertedCount is 0; the counts let the UI render "N new, M
-// duplicates, K errors" before the user commits.
+// ImportResult summarizes a statement import attempt. On a preview run nothing
+// is written and InsertedCount is 0; the counts let the UI render "N new, M
+// duplicates, K errors" before the user commits. ReviewCount is how many new
+// rows need review.
 type ImportResult struct {
 	Committed      bool                    `json:"committed"`
+	Source         string                  `json:"source"`
 	Mapping        ingestion.ColumnMapping `json:"mapping"`
 	Headers        []string                `json:"headers"`
 	TotalRows      int                     `json:"total_rows"`
 	NewCount       int                     `json:"new_count"`
 	DuplicateCount int                     `json:"duplicate_count"`
 	ErrorCount     int                     `json:"error_count"`
+	ReviewCount    int                     `json:"review_count"`
 	InsertedCount  int                     `json:"inserted_count"`
 	Rows           []ImportRowResult       `json:"rows"`
 }
 
-// ImportCSV classifies parsed statement rows against the target account and,
-// when commit is true, inserts the new ones. Transactions are deduped on a
-// content-derived external_id (date|amount|description + per-file occurrence
-// index) so re-importing the same file is idempotent, while two genuinely
-// identical lines in one file both survive. source='csv'; uncategorized rows
-// are run through the user's categorization rules on insert.
-func (s *TransactionService) ImportCSV(ctx context.Context, userID, accountID int64, parsed *ingestion.ParseResult, commit bool) (*ImportResult, error) {
+// ImportStatement classifies extracted statement rows against the target
+// account and, when commit is true, inserts the new ones. Transactions are
+// deduped on a content-derived external_id (date|amount|description +
+// per-file occurrence index, prefixed by source) so re-importing the same
+// file is idempotent, while two genuinely identical lines in one file both
+// survive. The source ("csv", and pdf/photo in ADR-0019 phase 2) comes from
+// the extraction; uncategorized rows are run through the user's categorization
+// rules on insert.
+func (s *TransactionService) ImportStatement(ctx context.Context, userID, accountID int64, ext *ingestion.Extraction, commit bool) (*ImportResult, error) {
 	// fetchOwnedAccount rejects another user's account and gives us the asset.
 	account, err := s.fetchOwnedAccount(ctx, userID, accountID)
 	if err != nil {
 		return nil, err
+	}
+
+	source := ext.Source
+	if source == "" {
+		source = "csv" // defensive: every extractor sets this
 	}
 
 	// Pass 1: derive a stable external_id per valid row.
@@ -70,15 +91,15 @@ func (s *TransactionService) ImportCSV(ctx context.Context, userID, accountID in
 		eid string // empty for invalid rows
 	}
 	occ := map[string]int{}
-	rows := make([]computed, 0, len(parsed.Rows))
-	validIDs := make([]string, 0, len(parsed.Rows))
-	for _, row := range parsed.Rows {
+	rows := make([]computed, 0, len(ext.Rows))
+	validIDs := make([]string, 0, len(ext.Rows))
+	for _, row := range ext.Rows {
 		c := computed{row: row}
 		if row.Valid() {
 			base := dedupKey(row)
 			n := occ[base]
 			occ[base]++
-			c.eid = csvExternalID(base, n)
+			c.eid = importExternalID(source, base, n)
 			validIDs = append(validIDs, c.eid)
 		}
 		rows = append(rows, c)
@@ -101,9 +122,10 @@ func (s *TransactionService) ImportCSV(ctx context.Context, userID, accountID in
 
 	res := &ImportResult{
 		Committed: commit,
-		Mapping:   parsed.Mapping,
-		Headers:   parsed.Headers,
-		TotalRows: len(parsed.Rows),
+		Source:    source,
+		Mapping:   ext.Mapping,
+		Headers:   ext.Headers,
+		TotalRows: len(ext.Rows),
 	}
 	var toInsert []model.Transaction
 	seen := map[string]struct{}{} // guards in-file dup external_ids
@@ -115,6 +137,7 @@ func (s *TransactionService) ImportCSV(ctx context.Context, userID, accountID in
 			Amount:      c.row.Amount,
 			Description: c.row.Description,
 			ExternalID:  c.eid,
+			Confidence:  c.row.Confidence,
 		}
 		_, isDup := existing[c.eid]
 		_, isSeen := seen[c.eid]
@@ -130,8 +153,14 @@ func (s *TransactionService) ImportCSV(ctx context.Context, userID, accountID in
 			seen[c.eid] = struct{}{}
 			rr.Status = ImportNew
 			res.NewCount++
+			// Low-confidence new rows are flagged for the user to confirm.
+			// Deterministic CSV rows are 1.0 and never trip this.
+			if c.row.Confidence < reviewConfidenceThreshold {
+				rr.NeedsReview = true
+				res.ReviewCount++
+			}
 			if commit {
-				toInsert = append(toInsert, buildCSVTxn(userID, account, c.row, c.eid, compiled))
+				toInsert = append(toInsert, buildImportTxn(userID, account, source, c.row, c.eid, compiled))
 			}
 		}
 		res.Rows = append(res.Rows, rr)
@@ -150,7 +179,7 @@ func (s *TransactionService) ImportCSV(ctx context.Context, userID, accountID in
 	return res, nil
 }
 
-func buildCSVTxn(userID int64, account *model.Account, row ingestion.ParsedRow, eid string, compiled []categorization.CompiledRule) model.Transaction {
+func buildImportTxn(userID int64, account *model.Account, source string, row ingestion.ParsedRow, eid string, compiled []categorization.CompiledRule) model.Transaction {
 	eidCopy := eid
 	t := model.Transaction{
 		UserID:          userID,
@@ -159,7 +188,7 @@ func buildCSVTxn(userID int64, account *model.Account, row ingestion.ParsedRow, 
 		Kind:            model.KindFlow,
 		Amount:          row.Amount,
 		TransactionDate: row.Date,
-		Source:          "csv",
+		Source:          source,
 		ExternalID:      &eidCopy,
 	}
 	if desc := strings.TrimSpace(row.Description); desc != "" {
@@ -181,10 +210,11 @@ func dedupKey(row ingestion.ParsedRow) string {
 	}, "|")
 }
 
-// csvExternalID hashes the content key + occurrence index into a short, stable
-// id. 8 bytes (16 hex chars) is ample collision resistance for a single
-// account's statement history.
-func csvExternalID(base string, occurrence int) string {
+// importExternalID hashes the content key + occurrence index into a short,
+// stable id, prefixed by source so the same statement re-imported as a
+// different format doesn't masquerade as a duplicate. 8 bytes (16 hex chars)
+// is ample collision resistance for a single account's statement history.
+func importExternalID(source, base string, occurrence int) string {
 	sum := sha256.Sum256([]byte(fmt.Sprintf("%s|%d", base, occurrence)))
-	return "csv:" + hex.EncodeToString(sum[:8])
+	return source + ":" + hex.EncodeToString(sum[:8])
 }

--- a/backend/internal/service/transaction_import_test.go
+++ b/backend/internal/service/transaction_import_test.go
@@ -2,7 +2,6 @@ package service_test
 
 import (
 	"context"
-	"strings"
 	"testing"
 	"time"
 
@@ -45,13 +44,16 @@ func newImportSvc(t *testing.T) (svc *service.TransactionService, userID, accoun
 	return svc, userID, acc.ID, g
 }
 
-func mustParse(t *testing.T, csv string) *ingestion.ParseResult {
+// mustExtract runs the fixture CSV through the CSV extractor, producing the
+// neutral Extraction that ImportStatement consumes.
+func mustExtract(t *testing.T, csv string) *ingestion.Extraction {
 	t.Helper()
-	res, err := ingestion.Parse(strings.NewReader(csv), ingestion.ColumnMapping{})
+	doc := ingestion.Document{MIME: "text/csv", Data: []byte(csv)}
+	ext, err := ingestion.CSVExtractor{}.Extract(context.Background(), doc)
 	if err != nil {
-		t.Fatalf("parse fixture: %v", err)
+		t.Fatalf("extract fixture: %v", err)
 	}
-	return res
+	return ext
 }
 
 func liveTxnCount(t *testing.T, g *gorm.DB, accountID int64) int64 {
@@ -63,14 +65,14 @@ func liveTxnCount(t *testing.T, g *gorm.DB, accountID int64) int64 {
 	return n
 }
 
-func TestImportCSV_PreviewWritesNothing(t *testing.T) {
+func TestImportStatement_PreviewWritesNothing(t *testing.T) {
 	svc, userID, accountID, g := newImportSvc(t)
 	ctx := context.Background()
 	csv := "Date,Description,Amount\n2026-05-15,Coffee,-4.50\n2026-05-16,Paycheck,2000.00\n"
 
-	res, err := svc.ImportCSV(ctx, userID, accountID, mustParse(t, csv), false)
+	res, err := svc.ImportStatement(ctx, userID, accountID, mustExtract(t, csv), false)
 	if err != nil {
-		t.Fatalf("ImportCSV preview: %v", err)
+		t.Fatalf("ImportStatement preview: %v", err)
 	}
 	if res.Committed {
 		t.Error("preview marked committed")
@@ -81,17 +83,29 @@ func TestImportCSV_PreviewWritesNothing(t *testing.T) {
 	if res.InsertedCount != 0 {
 		t.Errorf("preview inserted %d rows, want 0", res.InsertedCount)
 	}
+	// Deterministic CSV rows are fully trusted: confidence 1.0, never flagged.
+	if res.ReviewCount != 0 {
+		t.Errorf("review_count = %d, want 0 for deterministic CSV", res.ReviewCount)
+	}
+	if res.Source != "csv" {
+		t.Errorf("source = %q, want csv", res.Source)
+	}
+	for _, r := range res.Rows {
+		if r.Confidence != 1.0 || r.NeedsReview {
+			t.Errorf("row line %d: confidence=%v needs_review=%v, want 1.0/false", r.Line, r.Confidence, r.NeedsReview)
+		}
+	}
 	if n := liveTxnCount(t, g, accountID); n != 0 {
 		t.Errorf("preview persisted %d rows, want 0", n)
 	}
 }
 
-func TestImportCSV_CommitThenReimportIsIdempotent(t *testing.T) {
+func TestImportStatement_CommitThenReimportIsIdempotent(t *testing.T) {
 	svc, userID, accountID, g := newImportSvc(t)
 	ctx := context.Background()
 	csv := "Date,Description,Amount\n2026-05-15,Coffee,-4.50\n2026-05-16,Paycheck,2000.00\n"
 
-	first, err := svc.ImportCSV(ctx, userID, accountID, mustParse(t, csv), true)
+	first, err := svc.ImportStatement(ctx, userID, accountID, mustExtract(t, csv), true)
 	if err != nil {
 		t.Fatalf("first commit: %v", err)
 	}
@@ -104,7 +118,7 @@ func TestImportCSV_CommitThenReimportIsIdempotent(t *testing.T) {
 
 	// Re-import the identical file: every row should now be a duplicate and
 	// nothing new is written.
-	second, err := svc.ImportCSV(ctx, userID, accountID, mustParse(t, csv), true)
+	second, err := svc.ImportStatement(ctx, userID, accountID, mustExtract(t, csv), true)
 	if err != nil {
 		t.Fatalf("second commit: %v", err)
 	}
@@ -117,16 +131,16 @@ func TestImportCSV_CommitThenReimportIsIdempotent(t *testing.T) {
 	}
 }
 
-func TestImportCSV_IdenticalRowsInFileBothSurvive(t *testing.T) {
+func TestImportStatement_IdenticalRowsInFileBothSurvive(t *testing.T) {
 	svc, userID, accountID, g := newImportSvc(t)
 	ctx := context.Background()
 	// Two genuinely identical lines (e.g. two $4.50 coffees same day) must both
 	// import — the per-file occurrence index disambiguates their external_ids.
 	csv := "Date,Description,Amount\n2026-05-15,Coffee,-4.50\n2026-05-15,Coffee,-4.50\n"
 
-	res, err := svc.ImportCSV(ctx, userID, accountID, mustParse(t, csv), true)
+	res, err := svc.ImportStatement(ctx, userID, accountID, mustExtract(t, csv), true)
 	if err != nil {
-		t.Fatalf("ImportCSV: %v", err)
+		t.Fatalf("ImportStatement: %v", err)
 	}
 	if res.NewCount != 2 || res.InsertedCount != 2 {
 		t.Errorf("new=%d inserted=%d, want 2/2 (identical rows both kept)", res.NewCount, res.InsertedCount)
@@ -136,7 +150,7 @@ func TestImportCSV_IdenticalRowsInFileBothSurvive(t *testing.T) {
 	}
 
 	// And re-importing that same two-line file stays idempotent.
-	again, err := svc.ImportCSV(ctx, userID, accountID, mustParse(t, csv), true)
+	again, err := svc.ImportStatement(ctx, userID, accountID, mustExtract(t, csv), true)
 	if err != nil {
 		t.Fatalf("re-import: %v", err)
 	}
@@ -145,14 +159,14 @@ func TestImportCSV_IdenticalRowsInFileBothSurvive(t *testing.T) {
 	}
 }
 
-func TestImportCSV_ErrorRowsSkipped(t *testing.T) {
+func TestImportStatement_ErrorRowsSkipped(t *testing.T) {
 	svc, userID, accountID, g := newImportSvc(t)
 	ctx := context.Background()
 	csv := "Date,Description,Amount\nnot-a-date,Bad,-1.00\n2026-05-16,Good,-2.00\n"
 
-	res, err := svc.ImportCSV(ctx, userID, accountID, mustParse(t, csv), true)
+	res, err := svc.ImportStatement(ctx, userID, accountID, mustExtract(t, csv), true)
 	if err != nil {
-		t.Fatalf("ImportCSV: %v", err)
+		t.Fatalf("ImportStatement: %v", err)
 	}
 	if res.ErrorCount != 1 || res.NewCount != 1 || res.InsertedCount != 1 {
 		t.Errorf("err=%d new=%d inserted=%d, want 1/1/1", res.ErrorCount, res.NewCount, res.InsertedCount)
@@ -162,14 +176,14 @@ func TestImportCSV_ErrorRowsSkipped(t *testing.T) {
 	}
 }
 
-func TestImportCSV_RejectsForeignAccount(t *testing.T) {
+func TestImportStatement_RejectsForeignAccount(t *testing.T) {
 	svc, _, accountID, _ := newImportSvc(t)
 	ctx := context.Background()
 	csv := "Date,Description,Amount\n2026-05-15,Coffee,-4.50\n"
 
 	// A different user importing into the first user's account must be rejected.
 	otherUser := int64(-1) // no such user owns accountID
-	_, err := svc.ImportCSV(ctx, otherUser, accountID, mustParse(t, csv), true)
+	_, err := svc.ImportStatement(ctx, otherUser, accountID, mustExtract(t, csv), true)
 	if err == nil {
 		t.Fatal("expected error importing into a non-owned account, got nil")
 	}

--- a/frontend/src/types/transaction.ts
+++ b/frontend/src/types/transaction.ts
@@ -63,16 +63,23 @@ export type ImportRowResult = {
   external_id?: string
   status: ImportRowStatus
   error?: string
+  // confidence is the extractor's certainty (0–1). Deterministic CSV rows are
+  // 1.0; the AI extractor (ADR-0019 phase 2) reports real values. needs_review
+  // flags low-confidence new rows the UI surfaces before commit.
+  confidence: number
+  needs_review: boolean
 }
 
 export type ImportResult = {
   committed: boolean
+  source: string
   mapping: ColumnMapping
   headers: string[]
   total_rows: number
   new_count: number
   duplicate_count: number
   error_count: number
+  review_count: number
   inserted_count: number
   rows: ImportRowResult[]
 }


### PR DESCRIPTION
**Phase 1 of #332** (ADR-0019). A behavior-preserving refactor that turns the CSV-only importer into the source-agnostic seam the AI extractor plugs into. **No AI, no egress, no schema change** — CSV import behaves identically.

## What changed

- **`ingestion`** — new `Extractor` interface + `CSVExtractor` + `Registry` (MIME dispatch). Phase 1 registers CSV as the fallback, so any upload still routes to the CSV parser exactly as before. `ParsedRow` gains `Confidence` (deterministic parse = `1.0`).
- **service** — `ImportCSV` → `ImportStatement(*ingestion.Extraction)`. `source` and the `external_id` prefix now come from the extraction (still `"csv"` → idempotency preserved). `ImportRowResult` gains `confidence`/`needs_review`; `ImportResult` gains `source`/`review_count`. `needs_review` trips below a `0.8` confidence threshold — never reached by deterministic CSV, ready for the AI path.
- **handler** — reads file bytes, selects an extractor via the registry by MIME, calls `ImportStatement`. Same route, same request/response shape for CSV.
- **frontend** — mirrors the new fields in `types/transaction.ts`. No UI behavior change (all rows are confidence 1.0).

## Why it's safe

- Same `/accounts/:id/transactions/import` route — no contract-check / golden-routes drift.
- Dedup `external_id` output is byte-identical for CSV (`csv:` prefix unchanged).
- `make verify` green: vet, `-race -p 1` suite, contract-check, schema-check, frontend lint + build.

## Next

Phase 2 registers the AI `DocumentExtractor` for `application/pdf` + `image/*` (and unmappable-CSV fallback) ahead of the CSV fallback; the preview/dedup/commit pipeline and this seam don't change.

Part of #332.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
