### PR TITLE
#291: serve valuation-derived account balance; drop dead a.balance reads

### DIFF
--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -40,7 +40,11 @@ func New(cfg config.Config, gormDB *gorm.DB) *gin.Engine {
 	plaidItemRepo := repository.NewPlaidItemRepository(gormDB)
 	assetRepo := repository.NewAssetRepository(gormDB)
 	positionRepo := repository.NewPositionRepository(gormDB)
-	accountSvc := service.NewAccountService(gormDB, accountRepo, assetRepo, positionRepo).WithPlaidItemRepo(plaidItemRepo)
+	priceRepo := repository.NewPriceRepository(gormDB)
+	valuationSvc := valuation.NewService(positionRepo, priceRepo, assetRepo, accountRepo)
+	accountSvc := service.NewAccountService(gormDB, accountRepo, assetRepo, positionRepo).
+		WithPlaidItemRepo(plaidItemRepo).
+		WithValuation(valuationSvc)
 	accountHandler := handler.NewAccountHandler(accountSvc)
 
 	// PII flow: pii_repo is wired ONLY into pii_service, which is wired ONLY
@@ -57,7 +61,6 @@ func New(cfg config.Config, gormDB *gorm.DB) *gin.Engine {
 		WithJobRepo(repository.NewIngestionJobRepository(gormDB))
 	transactionHandler := handler.NewTransactionHandler(transactionSvc)
 
-	priceRepo := repository.NewPriceRepository(gormDB)
 	tradeSvc := service.NewTradeService(gormDB, accountRepo, assetRepo, transactionRepo, positionRepo, priceRepo, userRepo)
 	tradeHandler := handler.NewTradeHandler(tradeSvc)
 	assetHandler := handler.NewAssetHandler(assetRepo)
@@ -69,7 +72,6 @@ func New(cfg config.Config, gormDB *gorm.DB) *gin.Engine {
 	ruleHandler := handler.NewCategorizationRuleHandler(ruleSvc)
 
 	dashboardRepo := repository.NewDashboardRepository(gormDB)
-	valuationSvc := valuation.NewService(positionRepo, priceRepo, assetRepo, accountRepo)
 	dashboardSvc := service.NewDashboardService(dashboardRepo, transactionRepo, userRepo, valuationSvc)
 
 	budgetRepo := repository.NewBudgetRepository(gormDB)

--- a/backend/internal/service/account_response.go
+++ b/backend/internal/service/account_response.go
@@ -3,6 +3,8 @@ package service
 import (
 	"time"
 
+	"github.com/shopspring/decimal"
+
 	"github.com/gregwym/offbook/backend/internal/model"
 )
 
@@ -20,4 +22,14 @@ type AccountResponse struct {
 	LastSyncStatus *string    `json:"last_sync_status"`
 	LastSyncedAt   *time.Time `json:"last_synced_at"`
 	LastSyncError  *string    `json:"last_sync_error"`
+
+	// Balance is the valuation-derived account value — Σ positions × prices
+	// in the account's primary quote asset, at response time. ADR-0013
+	// dropped the stored scalar, so this is the only balance the API serves
+	// (#291). Marshals as a decimal string.
+	Balance decimal.Decimal `json:"balance"`
+	// BalanceComplete is false when any position's price chain was stale or
+	// missing, i.e. Balance is a partial sum rather than the whole story —
+	// the #282 "no wrong-but-confident totals" contract.
+	BalanceComplete bool `json:"balance_complete"`
 }

--- a/backend/internal/service/account_service.go
+++ b/backend/internal/service/account_service.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/gregwym/offbook/backend/internal/model"
 	"github.com/gregwym/offbook/backend/internal/repository"
+	"github.com/gregwym/offbook/backend/internal/service/valuation"
 )
 
 // Domain errors. Handlers map these to HTTP status codes.
@@ -74,6 +75,7 @@ type AccountService struct {
 	assetRepo     repository.AssetRepository
 	positionRepo  repository.PositionRepository
 	plaidItemRepo repository.PlaidItemRepository
+	valuationSvc  *valuation.Service
 }
 
 func NewAccountService(
@@ -90,6 +92,15 @@ func NewAccountService(
 // construction stays a one-liner.
 func (s *AccountService) WithPlaidItemRepo(p repository.PlaidItemRepository) *AccountService {
 	s.plaidItemRepo = p
+	return s
+}
+
+// WithValuation injects the valuation service that derives each account's
+// balance from positions × prices (ADR-0013). Same optional-dependency
+// pattern as WithPlaidItemRepo; without it, responses carry a zero balance
+// marked incomplete so it can't be mistaken for a real total.
+func (s *AccountService) WithValuation(v *valuation.Service) *AccountService {
+	s.valuationSvc = v
 	return s
 }
 
@@ -289,6 +300,9 @@ func (s *AccountService) GetResponse(ctx context.Context, userID, id int64) (*Ac
 		return nil, err
 	}
 	resp := s.buildResponse(a, items)
+	if err := s.fillBalances(ctx, userID, []*AccountResponse{&resp}); err != nil {
+		return nil, err
+	}
 	return &resp, nil
 }
 
@@ -303,10 +317,52 @@ func (s *AccountService) ListResponse(ctx context.Context, userID int64, f repos
 		return nil, 0, err
 	}
 	out := make([]AccountResponse, 0, len(accounts))
+	ptrs := make([]*AccountResponse, 0, len(accounts))
 	for i := range accounts {
 		out = append(out, s.buildResponse(&accounts[i], items))
+		ptrs = append(ptrs, &out[len(out)-1])
+	}
+	if err := s.fillBalances(ctx, userID, ptrs); err != nil {
+		return nil, 0, err
 	}
 	return out, total, nil
+}
+
+// fillBalances derives each response's Balance from positions × prices via
+// the valuation service (#291). One ListByUserID query feeds every account;
+// each account is valued in its own primary quote asset. A stale/missing
+// price chain drops that position from the sum and flips BalanceComplete to
+// false (#282) — never a silent $0 masquerading as the full value.
+func (s *AccountService) fillBalances(ctx context.Context, userID int64, resps []*AccountResponse) error {
+	if len(resps) == 0 {
+		return nil
+	}
+	if s.valuationSvc == nil {
+		// No valuation wiring (unit tests): mark the zero balance incomplete
+		// so it reads as "unknown", not "empty account".
+		for _, r := range resps {
+			r.BalanceComplete = false
+		}
+		return nil
+	}
+	positions, err := s.positionRepo.ListByUserID(ctx, userID)
+	if err != nil {
+		return fmt.Errorf("list positions for balances: %w", err)
+	}
+	byAccount := make(map[int64][]model.Position)
+	for _, p := range positions {
+		byAccount[p.AccountID] = append(byAccount[p.AccountID], p)
+	}
+	now := time.Now().UTC()
+	for _, r := range resps {
+		val, err := s.valuationSvc.ValuePositions(ctx, byAccount[r.ID], now, r.PrimaryQuoteAssetID)
+		if err != nil {
+			return fmt.Errorf("value account %d: %w", r.ID, err)
+		}
+		r.Balance = val.Value
+		r.BalanceComplete = val.Complete()
+	}
+	return nil
 }
 
 // loadPlaidItems indexes the user's PlaidItem rows by plaid_item_id (the

--- a/backend/internal/service/account_service_test.go
+++ b/backend/internal/service/account_service_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/gregwym/offbook/backend/internal/model"
 	"github.com/gregwym/offbook/backend/internal/repository"
 	"github.com/gregwym/offbook/backend/internal/service"
+	"github.com/gregwym/offbook/backend/internal/service/valuation"
 )
 
 func loadRepoDotenv() {
@@ -321,4 +322,85 @@ func TestAccountService_Create_OpeningBalanceIsLedgerFact(t *testing.T) {
 	if !agg.Income.IsZero() || !agg.Spending.IsZero() {
 		t.Errorf("income=%s spending=%s, want 0/0 (opening_balance excluded from flow)", agg.Income, agg.Spending)
 	}
+}
+
+// TestListResponse_DerivedBalance verifies the accounts API serves the
+// valuation-derived balance (#291): the opening cash position values at
+// quantity in the account's own quote asset, and an unpriced position flips
+// balance_complete to false instead of silently contributing $0 (#282).
+func TestListResponse_DerivedBalance(t *testing.T) {
+	svc, userID, g := newAccountSvc(t)
+	svc.WithValuation(valuation.NewService(
+		repository.NewPositionRepository(g),
+		repository.NewPriceRepository(g),
+		repository.NewAssetRepository(g),
+		repository.NewAccountRepository(g),
+	))
+	ctx := context.Background()
+
+	in := validInput(tcSuffix(8))
+	in.OpeningBalance = decimal.RequireFromString("123.45")
+	acct, err := svc.Create(ctx, userID, in)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	find := func(t *testing.T) service.AccountResponse {
+		t.Helper()
+		resps, _, err := svc.ListResponse(ctx, userID, repository.AccountFilter{})
+		if err != nil {
+			t.Fatalf("list response: %v", err)
+		}
+		for _, r := range resps {
+			if r.ID == acct.ID {
+				return r
+			}
+		}
+		t.Fatalf("account %d not in list response", acct.ID)
+		return service.AccountResponse{}
+	}
+
+	t.Run("cash position values at quantity", func(t *testing.T) {
+		r := find(t)
+		if !r.Balance.Equal(decimal.RequireFromString("123.45")) {
+			t.Errorf("balance = %s, want 123.45", r.Balance)
+		}
+		if !r.BalanceComplete {
+			t.Error("balance_complete = false, want true (same-asset cash needs no price)")
+		}
+	})
+
+	t.Run("unpriced position flips balance_complete", func(t *testing.T) {
+		assetRepo := repository.NewAssetRepository(g)
+		btc, err := assetRepo.EnsureBySymbolKind(ctx, "BTC", model.AssetKindCrypto, "Bitcoin")
+		if err != nil {
+			t.Fatalf("ensure BTC asset: %v", err)
+		}
+		posRepo := repository.NewPositionRepository(g)
+		if err := posRepo.Upsert(ctx, &model.Position{
+			UserID:    userID,
+			AccountID: acct.ID,
+			AssetID:   btc.ID,
+			Quantity:  decimal.RequireFromString("0.5"),
+		}); err != nil {
+			t.Fatalf("upsert BTC position: %v", err)
+		}
+
+		r := find(t)
+		if !r.Balance.Equal(decimal.RequireFromString("123.45")) {
+			t.Errorf("balance = %s, want 123.45 (unpriced BTC excluded, not $0-coerced)", r.Balance)
+		}
+		if r.BalanceComplete {
+			t.Error("balance_complete = true, want false (BTC has no price chain)")
+		}
+
+		single, err := svc.GetResponse(ctx, userID, acct.ID)
+		if err != nil {
+			t.Fatalf("get response: %v", err)
+		}
+		if !single.Balance.Equal(r.Balance) || single.BalanceComplete != r.BalanceComplete {
+			t.Errorf("GetResponse balance=%s complete=%v, want %s/%v (must match ListResponse)",
+				single.Balance, single.BalanceComplete, r.Balance, r.BalanceComplete)
+		}
+	})
 }

--- a/frontend/src/pages/AccountsPage.tsx
+++ b/frontend/src/pages/AccountsPage.tsx
@@ -209,7 +209,6 @@ function AccountFormModal({ mode, account, onClose, onSubmit }: FormProps) {
   const [institution, setInstitution] = useState(account?.institution_slug ?? '')
   const [accountType, setAccountType] = useState<AccountType>(account?.account_type ?? 'checking')
   const [currency, setCurrency] = useState(account?.currency ?? 'USD')
-  const [balance, setBalance] = useState(account?.balance ?? '0')
   const [lastFour, setLastFour] = useState(account?.last_four ?? '')
   const [isActive, setIsActive] = useState(account?.is_active ?? true)
   const [submitting, setSubmitting] = useState(false)
@@ -237,7 +236,6 @@ function AccountFormModal({ mode, account, onClose, onSubmit }: FormProps) {
         institution_slug: institution.trim(),
         account_type: accountType,
         currency: currency.trim().toUpperCase(),
-        balance,
         last_four: lastFour.trim() === '' ? null : lastFour.trim(),
         is_active: isActive,
       })
@@ -274,14 +272,11 @@ function AccountFormModal({ mode, account, onClose, onSubmit }: FormProps) {
               <input className={inputClass} value={currency} maxLength={3} onChange={(e) => setCurrency(e.target.value.toUpperCase())} />
             </Field>
           </div>
-          <div className="grid grid-cols-2 gap-3">
-            <Field label="Balance">
-              <input className={inputClass} value={balance} onChange={(e) => setBalance(e.target.value)} inputMode="decimal" />
-            </Field>
-            <Field label="Last 4 (optional)">
-              <input className={inputClass} value={lastFour ?? ''} maxLength={4} onChange={(e) => setLastFour(e.target.value)} />
-            </Field>
-          </div>
+          {/* No balance field: balance is derived from positions × prices
+              (ADR-0013) — to change it, record a transaction or trade. */}
+          <Field label="Last 4 (optional)">
+            <input className={inputClass} value={lastFour ?? ''} maxLength={4} onChange={(e) => setLastFour(e.target.value)} />
+          </Field>
           <label className="flex items-center gap-2 text-sm text-gray-700">
             <input type="checkbox" checked={isActive} onChange={(e) => setIsActive(e.target.checked)} />
             Active

--- a/frontend/src/store/accountsStore.ts
+++ b/frontend/src/store/accountsStore.ts
@@ -55,7 +55,10 @@ export const useAccountsStore = create<State>((set, get) => ({
     set({ error: null })
     try {
       const acct = await apiUpdate(id, input)
-      set({ accounts: get().accounts.map((a) => (a.id === id ? acct : a)) })
+      // Refetch instead of splicing the PATCH response in: that response is
+      // the bare account row, without the derived balance and sync fields
+      // the list shape carries.
+      await get().fetch()
       return acct
     } catch (err) {
       set({ error: errMsg(err) })

--- a/frontend/src/types/account.ts
+++ b/frontend/src/types/account.ts
@@ -15,7 +15,11 @@ export type Account = {
   // (per ADR-0013). Derived server-side from the chosen currency on
   // create — clients shouldn't try to mutate it.
   primary_quote_asset_id: number
+  // balance is derived server-side from positions × prices (ADR-0013) on
+  // GET responses. balance_complete=false means some position had no fresh
+  // price, so balance is a partial sum — never treat it as the full value.
   balance: string
+  balance_complete: boolean
   last_four?: string | null
   plaid_account_id?: string | null
   plaid_item_id?: string | null
@@ -58,7 +62,9 @@ export type CreateAccountInput = {
 }
 
 // UpdateAccountInput is a sparse patch; only provided fields are mutated.
-export type UpdateAccountInput = Partial<CreateAccountInput>
+// balance is excluded: it only exists on create (as the opening position);
+// afterwards balance is derived and changed via transactions/trades.
+export type UpdateAccountInput = Partial<Omit<CreateAccountInput, 'balance'>>
 
 // AccountPII mirrors the map[string]string returned by GET /accounts/:id/pii.
 // The allowlist matches backend service.allowedAccountPIIFields.


### PR DESCRIPTION
Closes #291. First M12 (Trustworthy Overview) item.

## What

- **Backend**: `AccountResponse` gains `balance` — Σ positions × prices in the account's primary quote asset via `valuation.ValuePositions` — and `balance_complete`, false when any position's price chain was stale/missing (#282 contract: a partial sum is flagged, never silently presented as the full value). One `ListByUserID` position query feeds the whole list. Injected via `WithValuation` (same optional-dep pattern as `WithPlaidItemRepo`); when absent, the zero balance is marked incomplete so it can't be mistaken for a real total.
- **Frontend**: `Account` type gains `balance_complete`; the Accounts edit modal drops its dead Balance field (PATCH never accepted `balance` post-ADR-0013 — typing there did nothing); the accounts store refetches after update so derived balance + sync fields survive an edit; `UpdateAccountInput` excludes `balance` at the type level.
- AccountsPage and the Insights "Accounts feeding this" band both consume the same accounts API, so both surfaces now show real values instead of blank/0.

## Tests

- `TestListResponse_DerivedBalance`: opening cash position values at quantity (complete); an unpriced BTC position is excluded from the sum and flips `balance_complete` to false (not $0-coerced); `GetResponse` matches `ListResponse`.
- `make verify` green (vet, `-race -p 1` tests, contract-check, frontend lint + build).

Rendering the `balance_complete` signal in the UI is #339 (next M12 item).

🤖 Generated with [Claude Code](https://claude.com/claude-code)