### PR TITLE
#341: personal allocation endpoint; un-hardcode Insights allocation band

### DIFF
--- a/backend/internal/handler/dashboard_handler.go
+++ b/backend/internal/handler/dashboard_handler.go
@@ -27,6 +27,19 @@ func (h *DashboardHandler) Register(g *gin.RouterGroup) {
 	g.GET("/dashboard/spend-by-category", h.SpendByCategory)
 	g.GET("/dashboard/cash-flow", h.CashFlow)
 	g.GET("/dashboard/net-worth", h.NetWorth)
+	g.GET("/dashboard/allocation", h.Allocation)
+}
+
+// Allocation returns the user's positions rolled up by asset kind, valued
+// in their primary currency (#341) — the personal counterpart of
+// /h/insights/allocation.
+func (h *DashboardHandler) Allocation(c *gin.Context) {
+	items, err := h.svc.Allocation(c.Request.Context(), auth.MustUserID(c.Request.Context()))
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error(), "code": "INTERNAL"})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"data": items, "total": int64(len(items))})
 }
 
 // SpendByCategory handles ?from=YYYY-MM-DD&to=YYYY-MM-DD. Either bound

--- a/backend/internal/repository/dashboard_repo.go
+++ b/backend/internal/repository/dashboard_repo.go
@@ -91,6 +91,13 @@ type DashboardRepository interface {
 	// excluded by construction (a trade's security leg is never fiat).
 	// Returns rows ordered by gross DESC.
 	TradeSummaryByKind(ctx context.Context, userID int64, from, to time.Time) ([]TradeKindAggregate, error)
+	// ListPositionsForAllocation returns every live position owned by the
+	// user with its asset kind, for the personal allocation rollup (#341) —
+	// the user-scoped analogue of the household aggregator repo method of
+	// the same name. Pricing is NOT done in SQL: the caller values each
+	// position through the shared valuation derivation so an unpriced asset
+	// surfaces as incomplete rather than silently $0 (#282).
+	ListPositionsForAllocation(ctx context.Context, userID int64) ([]AllocationPosition, error)
 }
 
 // TradeKindAggregate is one row of the trade rollup surfaced to the AI
@@ -354,6 +361,37 @@ func (r *dashboardRepo) TradeSummaryByKind(ctx context.Context, userID int64, fr
 	for _, r := range rows {
 		gross, _ := decimal.NewFromString(r.Gross)
 		out = append(out, TradeKindAggregate{Kind: r.Kind, LegCount: r.LegCount, GrossValue: gross})
+	}
+	return out, nil
+}
+
+func (r *dashboardRepo) ListPositionsForAllocation(ctx context.Context, userID int64) ([]AllocationPosition, error) {
+	type rawRow struct {
+		AssetID  int64
+		Quantity string
+		Kind     string
+	}
+	var rows []rawRow
+	err := r.db.WithContext(ctx).Raw(`
+		SELECT p.asset_id  AS asset_id,
+		       p.quantity::text AS quantity,
+		       ass.kind    AS kind
+		FROM positions p
+		JOIN accounts a ON a.id = p.account_id AND a.deleted_at IS NULL
+		JOIN assets   ass ON ass.id = p.asset_id
+		WHERE p.deleted_at IS NULL AND p.user_id = ?
+		ORDER BY ass.kind, p.asset_id
+	`, userID).Scan(&rows).Error
+	if err != nil {
+		return nil, err
+	}
+	out := make([]AllocationPosition, 0, len(rows))
+	for _, row := range rows {
+		q, err := decimal.NewFromString(row.Quantity)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, AllocationPosition{AssetID: row.AssetID, Quantity: q, Kind: row.Kind})
 	}
 	return out, nil
 }

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -85,7 +85,8 @@ func New(cfg config.Config, gormDB *gorm.DB) *gin.Engine {
 	savingsGoalHandler := handler.NewSavingsGoalHandler(savingsGoalSvc)
 
 	// Investments wiring removed per ADR-0013 — the snapshot table is gone.
-	// Position-based portfolio + allocation aggregator lands in #238.
+	// Position-based allocation is served by /dashboard/allocation (personal,
+	// #341) and /h/insights/allocation (household, #237).
 
 	householdRepo := repository.NewHouseholdRepository(gormDB)
 	memberRepo := repository.NewHouseholdMemberRepository(gormDB)

--- a/backend/internal/router/routes.golden
+++ b/backend/internal/router/routes.golden
@@ -22,6 +22,7 @@ GET /api/v1/budgets/:id/spend
 GET /api/v1/categories
 GET /api/v1/categorization-rules
 GET /api/v1/categorization-rules/:id
+GET /api/v1/dashboard/allocation
 GET /api/v1/dashboard/budget-alerts
 GET /api/v1/dashboard/cash-flow
 GET /api/v1/dashboard/net-worth

--- a/backend/internal/service/dashboard_charts_test.go
+++ b/backend/internal/service/dashboard_charts_test.go
@@ -311,3 +311,88 @@ func TestDashboard_NetWorth_TenantIsolation(t *testing.T) {
 }
 
 func ptrStr(s string) *string { return &s }
+
+// seedAllocationPosition inserts a live position row (with cleanup) for
+// allocation tests — allocation reads current positions, not the fold.
+func seedAllocationPosition(t *testing.T, g *gorm.DB, userID, accountID, assetID int64, quantity string) {
+	t.Helper()
+	p := &model.Position{
+		UserID: userID, AccountID: accountID, AssetID: assetID,
+		Quantity: decimal.RequireFromString(quantity),
+	}
+	if err := g.Create(p).Error; err != nil {
+		t.Fatalf("seed position: %v", err)
+	}
+	t.Cleanup(func() { g.Unscoped().Delete(&model.Position{}, p.ID) })
+}
+
+// TestDashboard_Allocation_BucketsByKindAndFlagsUnpriced: positions roll up
+// by asset kind in the user's primary currency; a kind containing an unpriced
+// asset is flagged incomplete instead of silently summing to a partial value
+// (#341, #282 contract).
+func TestDashboard_Allocation_BucketsByKindAndFlagsUnpriced(t *testing.T) {
+	svc, userID, accountID, g := newDashboardSvc(t)
+	ctx := context.Background()
+	usdID := testutil.LookupUSDAssetID(t, g)
+	eurID := testutil.LookupAssetID(t, g, "EUR", "fiat")
+	btcID := testutil.LookupAssetID(t, g, "BTC", "crypto")
+
+	// fiat: 1000 USD (same-asset, prices at 1) + 100 EUR at 1.20 → 1120.
+	seedAllocationPosition(t, g, userID, accountID, usdID, "1000")
+	seedAllocationPosition(t, g, userID, accountID, eurID, "100")
+	insertNetWorthPrice(t, g, eurID, usdID, "1.20", time.Date(2026, 5, 15, 0, 0, 0, 0, time.UTC))
+	// crypto: 0.5 BTC with NO price → bucket present but incomplete, value 0.
+	seedAllocationPosition(t, g, userID, accountID, btcID, "0.5")
+
+	rows, err := svc.Allocation(ctx, userID)
+	if err != nil {
+		t.Fatalf("Allocation: %v", err)
+	}
+	byKind := map[string]service.AssetClassAllocation{}
+	for _, r := range rows {
+		byKind[r.Kind] = r
+	}
+	fiat, ok := byKind["fiat"]
+	if !ok {
+		t.Fatal("no fiat bucket")
+	}
+	if fiat.Value != "1120" || !fiat.Complete {
+		t.Errorf("fiat = {value:%s complete:%v}, want {1120 true}", fiat.Value, fiat.Complete)
+	}
+	crypto, ok := byKind["crypto"]
+	if !ok {
+		t.Fatal("no crypto bucket (unpriced asset must still surface its kind)")
+	}
+	if crypto.Complete {
+		t.Error("crypto.Complete = true, want false (BTC has no price chain)")
+	}
+	if crypto.Value != "0" {
+		t.Errorf("crypto.Value = %s, want 0 (unpriced excluded, not coerced)", crypto.Value)
+	}
+}
+
+// TestDashboard_Allocation_TenantIsolation: user B's positions never appear
+// in user A's allocation (new repository read path → multi-tenant test rule).
+func TestDashboard_Allocation_TenantIsolation(t *testing.T) {
+	svc, userA, _, g := newDashboardSvc(t)
+	ctx := context.Background()
+	userB := seedTestUser(t, g)
+	accB := &model.Account{
+		UserID: userB, Name: "AllocB-" + time.Now().Format("150405.000000"),
+		InstitutionSlug: "fixture", AccountType: "checking", Currency: "USD",
+	}
+	if err := g.Create(accB).Error; err != nil {
+		t.Fatalf("seed B account: %v", err)
+	}
+	t.Cleanup(func() { g.Unscoped().Delete(&model.Account{}, accB.ID) })
+	usdID := testutil.LookupUSDAssetID(t, g)
+	seedAllocationPosition(t, g, userB, accB.ID, usdID, "9999")
+
+	rows, err := svc.Allocation(ctx, userA)
+	if err != nil {
+		t.Fatalf("Allocation: %v", err)
+	}
+	if len(rows) != 0 {
+		t.Errorf("user A allocation has %d rows, want 0 (user B's positions must not leak)", len(rows))
+	}
+}

--- a/backend/internal/service/dashboard_service.go
+++ b/backend/internal/service/dashboard_service.go
@@ -3,8 +3,11 @@ package service
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 	"time"
+
+	"github.com/shopspring/decimal"
 
 	"github.com/gregwym/offbook/backend/internal/model"
 	"github.com/gregwym/offbook/backend/internal/repository"
@@ -211,6 +214,70 @@ func (s *DashboardService) NetWorth(ctx context.Context, userID int64, months in
 			Total:    p.Value.String(),
 			Complete: p.Complete(),
 		})
+	}
+	return out, nil
+}
+
+// AssetClassAllocation is one row of the personal allocation rollup — the
+// total value of the user's positions whose asset kind matches, in the
+// user's primary currency. Wire-identical to the household aggregator's
+// allocation row so the Insights band renders both scopes from one shape.
+// Complete is false when at least one position of this kind had no fresh
+// price, so Value is a partial sum (#282).
+type AssetClassAllocation struct {
+	Kind     string `json:"kind"`
+	Value    string `json:"value"`
+	Complete bool   `json:"complete"`
+}
+
+// Allocation returns the user's positions rolled up by asset kind
+// (fiat / equity / fund / crypto / …), valued at now in the user's primary
+// currency via the single valuation derivation (#282, #341) — the personal
+// analogue of the household aggregator's Allocation. An unpriced position
+// marks its kind incomplete instead of contributing a silent $0.
+func (s *DashboardService) Allocation(ctx context.Context, userID int64) ([]AssetClassAllocation, error) {
+	user, err := s.users.GetByID(ctx, userID)
+	if err != nil {
+		return nil, err
+	}
+	positions, err := s.repo.ListPositionsForAllocation(ctx, userID)
+	if err != nil {
+		return nil, err
+	}
+
+	now := s.now().UTC()
+	type bucket struct {
+		value    decimal.Decimal
+		complete bool
+		order    int
+	}
+	buckets := map[string]*bucket{}
+	order := 0
+	ensure := func(kind string) *bucket {
+		b, ok := buckets[kind]
+		if !ok {
+			b = &bucket{value: decimal.Zero, complete: true, order: order}
+			order++
+			buckets[kind] = b
+		}
+		return b
+	}
+	for _, p := range positions {
+		b := ensure(p.Kind)
+		v, err := s.val.Value(ctx, model.Position{AssetID: p.AssetID, Quantity: p.Quantity}, now, user.PrimaryCurrencyAssetID)
+		if errors.Is(err, valuation.ErrStalePrice) {
+			b.complete = false
+			continue
+		}
+		if err != nil {
+			return nil, fmt.Errorf("value position (asset=%d): %w", p.AssetID, err)
+		}
+		b.value = b.value.Add(v)
+	}
+
+	out := make([]AssetClassAllocation, len(buckets))
+	for kind, b := range buckets {
+		out[b.order] = AssetClassAllocation{Kind: kind, Value: b.value.String(), Complete: b.complete}
 	}
 	return out, nil
 }

--- a/frontend/src/api/dashboard.ts
+++ b/frontend/src/api/dashboard.ts
@@ -1,5 +1,6 @@
 import { apiClient, type ApiItem, type ApiList } from './client'
 import type {
+  AssetClassAllocation,
   BudgetAlert,
   CashFlowMonth,
   DashboardPeriod,
@@ -32,5 +33,10 @@ export async function getCashFlow(months = 12): Promise<CashFlowMonth[]> {
 
 export async function getNetWorth(months = 12): Promise<NetWorthPoint[]> {
   const res = await apiClient.get<ApiList<NetWorthPoint>>('/dashboard/net-worth', { params: { months } })
+  return res.data.data
+}
+
+export async function getAllocation(): Promise<AssetClassAllocation[]> {
+  const res = await apiClient.get<ApiList<AssetClassAllocation>>('/dashboard/allocation')
   return res.data.data
 }

--- a/frontend/src/hooks/useScopedInsights.ts
+++ b/frontend/src/hooks/useScopedInsights.ts
@@ -10,7 +10,7 @@ import { useEffect, useState } from 'react'
 import { listAccounts } from '../api/accounts'
 import { getBudgetSpend, listBudgets } from '../api/budgets'
 import { listCategories } from '../api/categories'
-import { getDashboardSummary, getNetWorth } from '../api/dashboard'
+import { getAllocation, getDashboardSummary, getNetWorth } from '../api/dashboard'
 import {
   getBudgetPace,
   getGoalProgress,
@@ -37,10 +37,9 @@ export type InsightsTrendPoint = {
 export type InsightsAllocationRow = {
   kind: string
   value: string
-  // weight_pct present for personal portfolio (server-computed), absent
-  // for household (would require a sum-then-divide that we don't bother
-  // with here — UI can compute if needed).
-  weight_pct?: string
+  // false when a position of this kind had no fresh price — `value` is a
+  // partial sum (#282). Rendering of the flag lands with #339.
+  complete: boolean
 }
 
 export type InsightsBudgetRow = {
@@ -127,16 +126,11 @@ export function useScopedInsights(): Result {
 }
 
 async function loadPersonal(): Promise<InsightsData> {
-  // Allocation band has no data source in personal scope right now —
-  // the legacy /investments/portfolio endpoint was removed per ADR-0013
-  // and its position-based replacement lands in M10b #238. Until then
-  // the band renders its empty state ("No investments yet…") via the
-  // empty allocation array below. Household scope is unaffected — it
-  // goes through the aggregator's /h/insights/allocation route.
-  const [summary, trend, budgets, goals, accountsResp, categories] =
+  const [summary, trend, allocation, budgets, goals, accountsResp, categories] =
     await Promise.all([
       getDashboardSummary('current_month'),
       getNetWorth(12),
+      getAllocation(),
       listBudgets(),
       listGoals(),
       listAccounts({}),
@@ -176,8 +170,7 @@ async function loadPersonal(): Promise<InsightsData> {
     spending: summary.spending,
     by_category: summary.by_category,
     net_worth_trend: trend.map((p) => ({ date: p.date.slice(0, 10), value: p.total })),
-    allocation: [], // see header comment — restored when M10b #238 lands
-
+    allocation: allocation.map((a) => ({ kind: a.kind, value: a.value, complete: a.complete })),
     budgets: budgetRows,
     goals: goals.map((g) => ({
       id: g.id,
@@ -232,7 +225,7 @@ async function loadHousehold(): Promise<InsightsData> {
     spending: dashboard.spending,
     by_category: dashboard.by_category,
     net_worth_trend: trend.map((p) => ({ date: p.date.slice(0, 10), value: p.value })),
-    allocation: allocation.map((a) => ({ kind: a.kind, value: a.value })),
+    allocation: allocation.map((a) => ({ kind: a.kind, value: a.value, complete: a.complete })),
     budgets: budgetRows,
     goals: goalProgress.map((g) => ({
       id: g.goal_id,

--- a/frontend/src/types/dashboard.ts
+++ b/frontend/src/types/dashboard.ts
@@ -50,3 +50,14 @@ export type NetWorthPoint = {
   // `total` is a partial sum (#282).
   complete: boolean
 }
+
+// AssetClassAllocation mirrors backend service.AssetClassAllocation (#341).
+// Wire-identical to the household aggregator's allocation row, so the
+// Insights band renders both scopes from one shape.
+export type AssetClassAllocation = {
+  kind: string
+  value: string
+  // false when a position of this kind had no fresh price — `value` is a
+  // partial sum (#282).
+  complete: boolean
+}


### PR DESCRIPTION
Closes #341. Second M12 (Trustworthy Overview) item.

## What

- **Backend**: `GET /dashboard/allocation` rolls the user's live positions up by asset kind (fiat / equity / fund / crypto / …), valued at now in the user's primary currency through the single valuation derivation (#282) — the personal analogue of `/h/insights/allocation`, with a wire-identical row shape (`kind` / `value` / `complete`). An unpriced position marks its kind `complete: false` instead of contributing a silent $0. New `DashboardRepository.ListPositionsForAllocation` mirrors the household aggregator repo's query, scoped by `user_id`.
- **Frontend**: `loadPersonal` in `useScopedInsights` fetches the new endpoint instead of returning the hardcoded `allocation: []` (the "restored when M10b #238 lands" comment was stale — #238 only added the household side, so the personal band rendered its empty state forever). `InsightsAllocationRow` now carries `complete` from **both** scopes (rendering of the flag lands with #339) and drops the never-used `weight_pct`.
- Refreshed `routes.golden` for the new route; updated the stale router comment.

## Tests

- `TestDashboard_Allocation_BucketsByKindAndFlagsUnpriced`: USD + priced EUR bucket to fiat = 1120 complete; unpriced BTC surfaces a `crypto` bucket with `complete: false`, value 0 (excluded, not coerced).
- `TestDashboard_Allocation_TenantIsolation`: another user's positions never leak (new repo read path → multi-tenant test rule).
- `make verify` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
