### PR TITLE
#339: render completeness/staleness signals on Insights + Accounts

### DIFF
--- a/backend/internal/repository/household_aggregator_repo.go
+++ b/backend/internal/repository/household_aggregator_repo.go
@@ -98,8 +98,11 @@ type HouseholdAggregatorRepository interface {
 
 	// AccountBalances returns one row per account in accountIDs with the
 	// account's current balance in its owner's primary currency. Missing
-	// account IDs (e.g. soft-deleted) are silently omitted.
-	AccountBalances(ctx context.Context, accountIDs []int64) ([]AccountBalanceRow, error)
+	// account IDs (e.g. soft-deleted) are silently omitted. freshAfter is
+	// the staleness cutoff for the Complete flag: a position with no price
+	// row at-or-after it (and not denominated in the owner's primary
+	// currency) marks the account incomplete (#339).
+	AccountBalances(ctx context.Context, accountIDs []int64, freshAfter time.Time) ([]AccountBalanceRow, error)
 }
 
 // AllocationPosition is one live position plus its asset kind, fed to the
@@ -113,7 +116,11 @@ type AllocationPosition struct {
 
 // AccountBalanceRow is the per-account balance contribution from
 // AccountBalances — minimal projection so handlers can join with the
-// share view to add visibility and owner info.
+// share view to add visibility and owner info. Complete is false when
+// any position in the account had no price row observed at-or-after the
+// caller's freshness cutoff (#339): Balance may still include a stale
+// valuation, but the row is flagged so the UI can render it as partial
+// rather than confidently current.
 type AccountBalanceRow struct {
 	AccountID   int64
 	Name        string
@@ -121,6 +128,7 @@ type AccountBalanceRow struct {
 	Currency    string
 	OwnerUserID int64
 	Balance     decimal.Decimal
+	Complete    bool
 }
 
 type householdAggregatorRepo struct{ db *gorm.DB }
@@ -446,7 +454,7 @@ func (r *householdAggregatorRepo) HouseholdQuoteAssetID(ctx context.Context, hou
 	return assetID, nil
 }
 
-func (r *householdAggregatorRepo) AccountBalances(ctx context.Context, accountIDs []int64) ([]AccountBalanceRow, error) {
+func (r *householdAggregatorRepo) AccountBalances(ctx context.Context, accountIDs []int64, freshAfter time.Time) ([]AccountBalanceRow, error) {
 	if len(accountIDs) == 0 {
 		return nil, nil
 	}
@@ -457,6 +465,7 @@ func (r *householdAggregatorRepo) AccountBalances(ctx context.Context, accountID
 		Currency    string
 		OwnerUserID int64
 		Balance     string
+		Complete    bool
 	}
 	var rows []rawRow
 	err := r.db.WithContext(ctx).Raw(`
@@ -465,7 +474,17 @@ func (r *householdAggregatorRepo) AccountBalances(ctx context.Context, accountID
 		       a.account_type AS account_type,
 		       qa.symbol      AS currency,
 		       a.user_id      AS owner_user_id,
-		       COALESCE(SUM(`+fmt.Sprintf(positionValueExpr, "")+`), 0)::text AS balance
+		       COALESCE(SUM(`+fmt.Sprintf(positionValueExpr, "")+`), 0)::text AS balance,
+		       COALESCE(BOOL_AND(
+		           p.id IS NULL
+		           OR p.asset_id = u.primary_currency_asset_id
+		           OR EXISTS (
+		               SELECT 1 FROM prices pr
+		               WHERE pr.asset_id = p.asset_id
+		                 AND pr.quote_asset_id = u.primary_currency_asset_id
+		                 AND pr.as_of >= ?
+		           )
+		       ), TRUE) AS complete
 		FROM accounts a
 		JOIN users     u  ON u.id = a.user_id
 		JOIN assets    qa ON qa.id = a.primary_quote_asset_id
@@ -473,7 +492,7 @@ func (r *householdAggregatorRepo) AccountBalances(ctx context.Context, accountID
 		WHERE a.deleted_at IS NULL AND a.id IN ?
 		GROUP BY a.id, a.name, a.account_type, qa.symbol, a.user_id
 		ORDER BY a.id
-	`, accountIDs).Scan(&rows).Error
+	`, freshAfter, accountIDs).Scan(&rows).Error
 	if err != nil {
 		return nil, err
 	}
@@ -487,6 +506,7 @@ func (r *householdAggregatorRepo) AccountBalances(ctx context.Context, accountID
 			Currency:    row.Currency,
 			OwnerUserID: row.OwnerUserID,
 			Balance:     b,
+			Complete:    row.Complete,
 		})
 	}
 	return out, nil

--- a/backend/internal/service/household/aggregator.go
+++ b/backend/internal/service/household/aggregator.go
@@ -178,6 +178,10 @@ type AccountSummary struct {
 	Balance     string `json:"balance"`
 	OwnerUserID int64  `json:"owner_user_id"`
 	Visibility  string `json:"visibility"`
+	// Complete is false when a position in this account had no price
+	// observed within the valuation stale window — Balance may rest on a
+	// stale rate, so the UI flags it as partial (#339, #282 contract).
+	Complete bool `json:"complete"`
 }
 
 // --- core methods ---
@@ -606,7 +610,7 @@ func (a *Aggregator) AccountSummaries(ctx context.Context, householdID int64) ([
 		meta[s.AccountID] = shareMeta{visibility: s.Visibility}
 		accountIDs = append(accountIDs, s.AccountID)
 	}
-	balances, err := a.repo.AccountBalances(ctx, accountIDs)
+	balances, err := a.repo.AccountBalances(ctx, accountIDs, a.now().Add(-a.val.StaleWindow()))
 	if err != nil {
 		return nil, fmt.Errorf("account balances: %w", err)
 	}
@@ -620,6 +624,7 @@ func (a *Aggregator) AccountSummaries(ctx context.Context, householdID int64) ([
 			Balance:     b.Balance.String(),
 			OwnerUserID: b.OwnerUserID,
 			Visibility:  meta[b.AccountID].visibility,
+			Complete:    b.Complete,
 		})
 	}
 	return out, nil

--- a/backend/internal/service/household/aggregator_insights_test.go
+++ b/backend/internal/service/household/aggregator_insights_test.go
@@ -348,3 +348,49 @@ func TestAggregator_NetWorthTrend_InGraceExcluded(t *testing.T) {
 		}
 	}
 }
+
+// TestAggregator_AccountSummaries_FlagsStalePricing: an account holding an
+// asset whose only price is older than the valuation stale window reports
+// Complete=false; fresh-priced and primary-currency-only accounts report
+// Complete=true (#339, #282 contract).
+func TestAggregator_AccountSummaries_FlagsStalePricing(t *testing.T) {
+	agg, g := newAggregator(t)
+	ctx := context.Background()
+	usd := testutil.LookupUSDAssetID(t, g)
+	fresh := seedAsset(t, g, "FRSH-"+fmt.Sprintf("%d", time.Now().UnixNano()), model.AssetKindEquity, usd)
+	stale := seedAsset(t, g, "STAL-"+fmt.Sprintf("%d", time.Now().UnixNano()), model.AssetKindEquity, usd)
+	insertPrice(t, g, fresh, usd, "10", time.Now().Add(-time.Hour))
+	insertPrice(t, g, stale, usd, "10", time.Now().Add(-30*24*time.Hour)) // outside DefaultStaleWindow
+
+	ownerID := seedUser(t, g, "summ-stale-owner")
+	hh := seedHouseholdRow(t, g, ownerID, "SummStale", 30)
+	addMember(t, g, hh.ID, ownerID, model.RoleOwner, nil)
+
+	cashAcct := seedAccount(t, g, ownerID, "cash-only")
+	freshAcct := seedAccount(t, g, ownerID, "fresh-equity")
+	staleAcct := seedAccount(t, g, ownerID, "stale-equity")
+	upsertPosition(t, g, ownerID, cashAcct.ID, usd, "100")
+	upsertPosition(t, g, ownerID, freshAcct.ID, fresh, "5")
+	upsertPosition(t, g, ownerID, staleAcct.ID, stale, "5")
+	setShare(t, g, cashAcct.ID, hh.ID, model.VisibilityBalanceOnly)
+	setShare(t, g, freshAcct.ID, hh.ID, model.VisibilityBalanceOnly)
+	setShare(t, g, staleAcct.ID, hh.ID, model.VisibilityBalanceOnly)
+
+	out, err := agg.AccountSummaries(ctx, hh.ID)
+	if err != nil {
+		t.Fatalf("AccountSummaries: %v", err)
+	}
+	byID := map[int64]household.AccountSummary{}
+	for _, s := range out {
+		byID[s.AccountID] = s
+	}
+	if !byID[cashAcct.ID].Complete {
+		t.Errorf("cash-only account Complete = false, want true (primary currency needs no price)")
+	}
+	if !byID[freshAcct.ID].Complete {
+		t.Errorf("fresh-priced account Complete = false, want true")
+	}
+	if byID[staleAcct.ID].Complete {
+		t.Errorf("stale-priced account Complete = true, want false (only price is 30d old)")
+	}
+}

--- a/frontend/src/components/PartialBadge.tsx
+++ b/frontend/src/components/PartialBadge.tsx
@@ -1,0 +1,17 @@
+// PartialBadge marks a monetary figure whose valuation is incomplete —
+// some position had no price (or only a stale one), so the number shown
+// is a partial sum, not the whole story (#282/#339). Always render it
+// next to the affected amount; never silently show a partial total.
+export function PartialBadge({ title }: { title?: string }) {
+  return (
+    <span
+      title={
+        title ??
+        'Partial value — some assets have no recent price, so this figure may understate the true amount.'
+      }
+      className="ml-1.5 inline-flex cursor-help items-center rounded border border-amber-200 bg-amber-50 px-1 py-px align-middle text-[10px] font-medium leading-4 text-amber-700"
+    >
+      partial
+    </span>
+  )
+}

--- a/frontend/src/hooks/useScopedInsights.ts
+++ b/frontend/src/hooks/useScopedInsights.ts
@@ -32,6 +32,9 @@ export type InsightsCategoryRow = {
 export type InsightsTrendPoint = {
   date: string // YYYY-MM-DD (we slice off any time component)
   value: string
+  // false when an asset held at this month-end had no available price, so
+  // `value` is a partial sum (#282/#339).
+  complete: boolean
 }
 
 export type InsightsAllocationRow = {
@@ -67,6 +70,9 @@ export type InsightsAccountRow = {
   account_type: string
   currency: string
   balance: string
+  // false when the balance includes unpriced or stale-priced positions —
+  // render as partial, never as a confident total (#339).
+  balance_complete: boolean
   source: 'plaid' | 'manual'
   last_synced_at: string | null
   owner_user_id?: number
@@ -169,7 +175,11 @@ async function loadPersonal(): Promise<InsightsData> {
     income: summary.income,
     spending: summary.spending,
     by_category: summary.by_category,
-    net_worth_trend: trend.map((p) => ({ date: p.date.slice(0, 10), value: p.total })),
+    net_worth_trend: trend.map((p) => ({
+      date: p.date.slice(0, 10),
+      value: p.total,
+      complete: p.complete,
+    })),
     allocation: allocation.map((a) => ({ kind: a.kind, value: a.value, complete: a.complete })),
     budgets: budgetRows,
     goals: goals.map((g) => ({
@@ -186,6 +196,7 @@ async function loadPersonal(): Promise<InsightsData> {
       account_type: a.account_type,
       currency: a.currency,
       balance: a.balance,
+      balance_complete: a.balance_complete,
       source: a.plaid_account_id ? 'plaid' : 'manual',
       last_synced_at: a.last_synced_at,
     })),
@@ -224,7 +235,11 @@ async function loadHousehold(): Promise<InsightsData> {
     income: dashboard.income,
     spending: dashboard.spending,
     by_category: dashboard.by_category,
-    net_worth_trend: trend.map((p) => ({ date: p.date.slice(0, 10), value: p.value })),
+    net_worth_trend: trend.map((p) => ({
+      date: p.date.slice(0, 10),
+      value: p.value,
+      complete: p.complete,
+    })),
     allocation: allocation.map((a) => ({ kind: a.kind, value: a.value, complete: a.complete })),
     budgets: budgetRows,
     goals: goalProgress.map((g) => ({
@@ -241,6 +256,7 @@ async function loadHousehold(): Promise<InsightsData> {
       account_type: a.account_type,
       currency: a.currency,
       balance: a.balance,
+      balance_complete: a.complete,
       // Household-shared accounts can be either Plaid-linked or manual,
       // but the aggregator doesn't surface that distinction (would leak
       // a per-owner plaid_item indicator). Default to "manual" badge.

--- a/frontend/src/pages/AccountsPage.tsx
+++ b/frontend/src/pages/AccountsPage.tsx
@@ -4,6 +4,7 @@ import { LineChart, Pencil, Plus, Trash2, Upload } from 'lucide-react'
 import { AccountVisibilityChip } from '../components/AccountVisibilityChip'
 import { AmountDisplay } from '../components/AmountDisplay'
 import { ImportTransactionsModal } from '../components/ImportTransactionsModal'
+import { PartialBadge } from '../components/PartialBadge'
 import { PIIPanel } from '../components/PIIPanel'
 import { SyncStatusPill } from '../components/SyncStatusPill'
 import { TradeFormModal } from '../components/TradeFormModal'
@@ -91,6 +92,7 @@ export function AccountsPage() {
                 <td className="px-4 py-2 text-gray-700">{a.last_four ?? '—'}</td>
                 <td className="px-4 py-2 text-right">
                   <AmountDisplay amount={a.balance} currency={a.currency} />
+                  {!a.balance_complete && <PartialBadge />}
                 </td>
                 <td className="px-4 py-2 text-center">
                   <span className={a.is_active ? 'text-emerald-700' : 'text-gray-400'}>

--- a/frontend/src/pages/InsightsPage.tsx
+++ b/frontend/src/pages/InsightsPage.tsx
@@ -31,6 +31,7 @@ import {
 } from 'recharts'
 import { AmountDisplay } from '../components/AmountDisplay'
 import { FALLBACK_PIE_COLORS } from '../components/chartColors'
+import { PartialBadge } from '../components/PartialBadge'
 import { useScopedInsights, type InsightsData } from '../hooks/useScopedInsights'
 import { useScopeStore } from '../store/scopeStore'
 import { SCOPE_HOUSEHOLD } from '../types/scope'
@@ -125,6 +126,7 @@ function FreshSignupEmpty() {
 // ───── Band 1: net worth headline + trend ─────
 function NetWorthBand({ data }: { data: InsightsData }) {
   const trend = data.net_worth_trend
+  const hasPartialMonths = trend.some((p) => !p.complete)
   return (
     <section className="rounded-lg border border-gray-200 bg-white p-5">
       <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
@@ -146,14 +148,56 @@ function NetWorthBand({ data }: { data: InsightsData }) {
               No trend data yet — net worth will appear here as snapshots accumulate.
             </div>
           ) : (
-            <ResponsiveContainer width="100%" height={140}>
-              <LineChart data={trend.map((p) => ({ date: p.date.slice(0, 7), total: num(p.value) }))}>
-                <XAxis dataKey="date" tick={{ fontSize: 10 }} />
-                <YAxis hide />
-                <Tooltip formatter={(v) => (typeof v === 'number' ? v.toFixed(2) : String(v))} />
-                <Line type="monotone" dataKey="total" stroke="#6366F1" strokeWidth={2} dot={false} />
-              </LineChart>
-            </ResponsiveContainer>
+            <>
+              <ResponsiveContainer width="100%" height={hasPartialMonths ? 124 : 140}>
+                <LineChart
+                  data={trend.map((p) => ({
+                    date: p.date.slice(0, 7),
+                    total: num(p.value),
+                    complete: p.complete,
+                  }))}
+                >
+                  <XAxis dataKey="date" tick={{ fontSize: 10 }} />
+                  <YAxis hide />
+                  <Tooltip
+                    formatter={(v, _name, item) => {
+                      const text = typeof v === 'number' ? v.toFixed(2) : String(v)
+                      const point = item?.payload as { complete?: boolean } | undefined
+                      return point?.complete === false ? `${text} (partial)` : text
+                    }}
+                  />
+                  {/* Months with an unpriced asset render a hollow amber dot —
+                      the value plotted there is a partial sum (#339). */}
+                  <Line
+                    type="monotone"
+                    dataKey="total"
+                    stroke="#6366F1"
+                    strokeWidth={2}
+                    dot={(props: { cx?: number; cy?: number; payload?: { complete?: boolean } }) =>
+                      props.payload?.complete === false && props.cx != null && props.cy != null ? (
+                        <circle
+                          key={`partial-${props.cx}-${props.cy}`}
+                          cx={props.cx}
+                          cy={props.cy}
+                          r={3.5}
+                          fill="#FFFBEB"
+                          stroke="#D97706"
+                          strokeWidth={1.5}
+                        />
+                      ) : (
+                        // recharts requires an element; render nothing visible.
+                        <circle key={`dot-${props.cx}-${props.cy}`} r={0} />
+                      )
+                    }
+                  />
+                </LineChart>
+              </ResponsiveContainer>
+              {hasPartialMonths && (
+                <div className="mt-1 text-[11px] text-amber-700">
+                  ◌ marked months include assets without prices — those totals are partial.
+                </div>
+              )}
+            </>
           )}
         </div>
       </div>
@@ -165,6 +209,7 @@ function NetWorthBand({ data }: { data: InsightsData }) {
 function AllocationBand({ data }: { data: InsightsData }) {
   const rows = data.allocation
   const total = rows.reduce((acc, r) => acc + num(r.value), 0)
+  const hasPartial = rows.some((r) => !r.complete)
   return (
     <section className="rounded-lg border border-gray-200 bg-white p-5">
       <div className="flex items-center gap-2">
@@ -173,35 +218,40 @@ function AllocationBand({ data }: { data: InsightsData }) {
           Asset allocation
         </h2>
       </div>
-      {rows.length === 0 || total === 0 ? (
+      {rows.length === 0 ? (
         <div className="mt-3 py-6 text-center text-sm text-gray-400">
           No investments yet — add a brokerage or crypto account to see allocation.
         </div>
       ) : (
         <div className="mt-3 grid grid-cols-1 gap-4 md:grid-cols-2">
-          <ResponsiveContainer width="100%" height={220}>
-            <PieChart>
-              <Pie
-                data={rows.map((r, i) => ({
-                  name: r.kind,
-                  value: num(r.value),
-                  color: FALLBACK_PIE_COLORS[i % FALLBACK_PIE_COLORS.length],
-                }))}
-                dataKey="value"
-                nameKey="name"
-                cx="50%"
-                cy="50%"
-                innerRadius={50}
-                outerRadius={85}
-                label={(p: { name?: string }) => p.name ?? ''}
-              >
-                {rows.map((_, i) => (
-                  <Cell key={i} fill={FALLBACK_PIE_COLORS[i % FALLBACK_PIE_COLORS.length]} />
-                ))}
-              </Pie>
-              <Tooltip formatter={(v) => (typeof v === 'number' ? v.toFixed(2) : String(v))} />
-            </PieChart>
-          </ResponsiveContainer>
+          {/* total === 0 with rows present means every position is unpriced —
+              skip the empty donut but keep the list, so holdings aren't
+              misreported as "no investments" (#339). */}
+          {total > 0 && (
+            <ResponsiveContainer width="100%" height={220}>
+              <PieChart>
+                <Pie
+                  data={rows.map((r, i) => ({
+                    name: r.kind,
+                    value: num(r.value),
+                    color: FALLBACK_PIE_COLORS[i % FALLBACK_PIE_COLORS.length],
+                  }))}
+                  dataKey="value"
+                  nameKey="name"
+                  cx="50%"
+                  cy="50%"
+                  innerRadius={50}
+                  outerRadius={85}
+                  label={(p: { name?: string }) => p.name ?? ''}
+                >
+                  {rows.map((_, i) => (
+                    <Cell key={i} fill={FALLBACK_PIE_COLORS[i % FALLBACK_PIE_COLORS.length]} />
+                  ))}
+                </Pie>
+                <Tooltip formatter={(v) => (typeof v === 'number' ? v.toFixed(2) : String(v))} />
+              </PieChart>
+            </ResponsiveContainer>
+          )}
           <ul className="flex flex-col justify-center gap-1.5 text-sm">
             {rows.map((r, i) => {
               const pct = total > 0 ? (num(r.value) / total) * 100 : 0
@@ -216,11 +266,20 @@ function AllocationBand({ data }: { data: InsightsData }) {
                   </span>
                   <span className="text-gray-500">
                     <AmountDisplay amount={r.value} /> · {pct.toFixed(1)}%
+                    {!r.complete && (
+                      <PartialBadge title="Some positions of this kind have no recent price — this value (and the percentages) understate the true allocation." />
+                    )}
                   </span>
                 </li>
               )
             })}
           </ul>
+        </div>
+      )}
+      {hasPartial && (
+        <div className="mt-2 text-[11px] text-amber-700">
+          Buckets marked “partial” hold assets without prices; the donut and percentages are
+          computed from the priced portion only.
         </div>
       )}
     </section>
@@ -388,6 +447,7 @@ function AccountsBand({ data }: { data: InsightsData }) {
               <span className="text-xs text-gray-400 capitalize">{a.source}</span>
               <span className="text-right">
                 <AmountDisplay amount={a.balance} currency={a.currency || 'USD'} />
+                {!a.balance_complete && <PartialBadge />}
               </span>
             </div>
           ))}

--- a/frontend/src/types/householdAggregator.ts
+++ b/frontend/src/types/householdAggregator.ts
@@ -76,6 +76,9 @@ export type HouseholdNetWorthPoint = {
 
 // AccountSummary mirrors service/household.AccountSummary — lightweight,
 // non-PII account projection used for the Insights account list band.
+// `complete` is false when a position in the account had no price observed
+// within the valuation stale window, so `balance` may rest on a stale rate
+// (#339).
 export type HouseholdAccountSummary = {
   account_id: number
   name: string
@@ -84,4 +87,5 @@ export type HouseholdAccountSummary = {
   balance: string
   owner_user_id: number
   visibility: 'balance_only' | 'balance_and_txns'
+  complete: boolean
 }


### PR DESCRIPTION
Closes #339. Third M12 (Trustworthy Overview) item — the UI half of the #282 "a missing price is surfaced as incomplete rather than silently counted as $0" contract.

## What

New shared `PartialBadge` component (amber "partial" chip with an explanatory tooltip) marks any monetary figure whose valuation is incomplete.

- **Net-worth trend band** (personal + household): months with `complete: false` render a hollow amber dot on the line, the tooltip appends "(partial)", and a footnote explains the marker. `InsightsTrendPoint` now carries `complete` from both loaders.
- **Allocation band** (personal + household): buckets with `complete: false` get a per-row badge + footnote. Edge case fixed: a portfolio whose positions are *all* unpriced previously rendered "No investments yet" — a wrong-but-confident empty state; it now lists the holdings (no donut) with partial badges.
- **Accounts list (`/accounts`) + Insights "Accounts feeding this" band**: balances that include unpriced/stale positions get the badge. Personal uses `balance_complete` from #291; household needed a backend addition (below).
- **Backend**: household `AccountBalances` now also reports per-account `Complete` — a windowed `EXISTS` against `prices`, with the cutoff derived from the valuation service's stale window via the aggregator's clock. Balance value semantics are unchanged; the flag rides along to `AccountSummary.complete` on the wire.

## Deliberately out of scope

The **headline** net-worth figures (personal `/dashboard/summary`, household dashboard) still coerce missing prices to $0 without a flag — that's a deeper derivation change filed as #344 rather than bloating this PR.

## Tests

- `TestAggregator_AccountSummaries_FlagsStalePricing`: primary-currency-only account → complete; freshly priced equity → complete; equity whose only price is 30 days old → incomplete.
- `make verify` green (vet, `-race -p 1` tests incl. all aggregator privacy suites, contract-check, frontend lint + build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
