### PR TITLE
#338 Phase 1: ADR-0014 + price-provider seam + CoinGecko + manual refresh

### DIFF
--- a/backend/internal/handler/price_handler.go
+++ b/backend/internal/handler/price_handler.go
@@ -1,0 +1,36 @@
+package handler
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/gregwym/offbook/backend/internal/service/auth"
+	"github.com/gregwym/offbook/backend/internal/service/prices"
+)
+
+// PriceHandler exposes the manual price refresh (ADR-0014 Phase 1). The
+// refresh is user-initiated by design: clicking it is the egress consent —
+// only the user's held symbols leave the box, never quantities or PII.
+type PriceHandler struct {
+	svc *prices.Service
+}
+
+func NewPriceHandler(s *prices.Service) *PriceHandler {
+	return &PriceHandler{svc: s}
+}
+
+func (h *PriceHandler) Register(g *gin.RouterGroup) {
+	g.POST("/prices/refresh", h.Refresh)
+}
+
+func (h *PriceHandler) Refresh(c *gin.Context) {
+	result, err := h.svc.RefreshForUser(c.Request.Context(), auth.MustUserID(c.Request.Context()))
+	if err != nil {
+		// Upstream provider failures surface as 502: the request was fine,
+		// the price source wasn't. Valuations keep their stale flags.
+		c.JSON(http.StatusBadGateway, gin.H{"error": err.Error(), "code": "PRICE_PROVIDER_ERROR"})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"data": result})
+}

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -17,6 +17,7 @@ import (
 	"github.com/gregwym/offbook/backend/internal/service/household"
 	"github.com/gregwym/offbook/backend/internal/service/ingestion"
 	plaidsvc "github.com/gregwym/offbook/backend/internal/service/plaid"
+	"github.com/gregwym/offbook/backend/internal/service/prices"
 	"github.com/gregwym/offbook/backend/internal/service/valuation"
 )
 
@@ -73,6 +74,11 @@ func New(cfg config.Config, gormDB *gorm.DB) *gin.Engine {
 
 	dashboardRepo := repository.NewDashboardRepository(gormDB)
 	dashboardSvc := service.NewDashboardService(dashboardRepo, transactionRepo, userRepo, valuationSvc)
+
+	// Price refresh (ADR-0014 Phase 1): user-initiated, providers write
+	// into the prices time series the valuation layer already reads.
+	pricesSvc := prices.NewService(userRepo, positionRepo, assetRepo, priceRepo, prices.NewCoinGecko())
+	priceHandler := handler.NewPriceHandler(pricesSvc)
 
 	budgetRepo := repository.NewBudgetRepository(gormDB)
 	budgetSvc := service.NewBudgetService(budgetRepo, categoryRepo)
@@ -171,6 +177,7 @@ func New(cfg config.Config, gormDB *gorm.DB) *gin.Engine {
 		categoryHandler.Register(secured)
 		ruleHandler.Register(secured)
 		dashboardHandler.Register(secured)
+		priceHandler.Register(secured)
 		budgetHandler.Register(secured)
 		savingsGoalHandler.Register(secured)
 		householdHandler.Register(secured)

--- a/backend/internal/router/routes.golden
+++ b/backend/internal/router/routes.golden
@@ -94,6 +94,7 @@ POST /api/v1/plaid/items/:item_id/sync-investment-transactions
 POST /api/v1/plaid/items/:item_id/sync-transactions
 POST /api/v1/plaid/link/exchange
 POST /api/v1/plaid/link/token
+POST /api/v1/prices/refresh
 POST /api/v1/savings-goals
 POST /api/v1/savings-goals/:id/contributions
 POST /api/v1/setup/admin

--- a/backend/internal/service/prices/coingecko.go
+++ b/backend/internal/service/prices/coingecko.go
@@ -1,0 +1,149 @@
+package prices
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/shopspring/decimal"
+
+	"github.com/gregwym/offbook/backend/internal/model"
+)
+
+// coingeckoBaseURL is the public, keyless API root. Overridable for tests.
+const coingeckoBaseURL = "https://api.coingecko.com/api/v3"
+
+// coingeckoIDBySymbol maps asset symbols to CoinGecko coin IDs. Static and
+// code-reviewed by design (ADR-0014 §5): runtime resolution via /coins/list
+// is ambiguous (ticker collisions) and unreviewable. A held symbol missing
+// here surfaces as "skipped" in the refresh result — extend with a PR.
+var coingeckoIDBySymbol = map[string]string{
+	"BTC":   "bitcoin",
+	"ETH":   "ethereum",
+	"USDT":  "tether",
+	"USDC":  "usd-coin",
+	"BNB":   "binancecoin",
+	"XRP":   "ripple",
+	"SOL":   "solana",
+	"ADA":   "cardano",
+	"DOGE":  "dogecoin",
+	"DOT":   "polkadot",
+	"MATIC": "matic-network",
+	"LTC":   "litecoin",
+	"AVAX":  "avalanche-2",
+	"LINK":  "chainlink",
+	"UNI":   "uniswap",
+	"BCH":   "bitcoin-cash",
+	"XLM":   "stellar",
+	"ATOM":  "cosmos",
+	"ETC":   "ethereum-classic",
+	"FIL":   "filecoin",
+}
+
+// CoinGecko quotes crypto assets via the free /simple/price endpoint. No
+// API key: the only egress is the coin-ID list and quote currency.
+type CoinGecko struct {
+	baseURL string
+	client  *http.Client
+	now     func() time.Time
+}
+
+// NewCoinGecko returns a provider hitting the public CoinGecko API.
+func NewCoinGecko() *CoinGecko {
+	return &CoinGecko{
+		baseURL: coingeckoBaseURL,
+		client:  &http.Client{Timeout: 15 * time.Second},
+		now:     time.Now,
+	}
+}
+
+// WithBaseURL points the provider at a different API root (tests).
+func (c *CoinGecko) WithBaseURL(u string) *CoinGecko {
+	c.baseURL = u
+	return c
+}
+
+func (c *CoinGecko) Name() string { return "coingecko" }
+
+// Supports: crypto assets whose symbol is in the static map.
+func (c *CoinGecko) Supports(a model.Asset) bool {
+	if a.Kind != model.AssetKindCrypto {
+		return false
+	}
+	_, ok := coingeckoIDBySymbol[strings.ToUpper(a.Symbol)]
+	return ok
+}
+
+func (c *CoinGecko) Fetch(ctx context.Context, assets []model.Asset, quote model.Asset) ([]Quote, error) {
+	if len(assets) == 0 {
+		return nil, nil
+	}
+	// CoinGecko quotes against fiat tickers (usd, eur, …). A non-fiat
+	// quote asset can't be served — omit everything (reported as skipped).
+	if quote.Kind != model.AssetKindFiat {
+		return nil, nil
+	}
+	vs := strings.ToLower(quote.Symbol)
+
+	ids := make([]string, 0, len(assets))
+	assetByID := make(map[string]model.Asset, len(assets))
+	for _, a := range assets {
+		id, ok := coingeckoIDBySymbol[strings.ToUpper(a.Symbol)]
+		if !ok {
+			continue // Supports-filtered callers shouldn't hit this; stay safe
+		}
+		ids = append(ids, id)
+		assetByID[id] = a
+	}
+	if len(ids) == 0 {
+		return nil, nil
+	}
+
+	u := fmt.Sprintf("%s/simple/price?ids=%s&vs_currencies=%s",
+		c.baseURL, url.QueryEscape(strings.Join(ids, ",")), url.QueryEscape(vs))
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return nil, fmt.Errorf("coingecko: build request: %w", err)
+	}
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("coingecko: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("coingecko: unexpected status %d", resp.StatusCode)
+	}
+
+	// Decode with UseNumber so prices reach decimal without a float64 hop.
+	dec := json.NewDecoder(resp.Body)
+	dec.UseNumber()
+	var body map[string]map[string]json.Number
+	if err := dec.Decode(&body); err != nil {
+		return nil, fmt.Errorf("coingecko: decode response: %w", err)
+	}
+
+	asOf := c.now().UTC()
+	out := make([]Quote, 0, len(body))
+	for id, byCurrency := range body {
+		a, ok := assetByID[id]
+		if !ok {
+			continue
+		}
+		raw, ok := byCurrency[vs]
+		if !ok {
+			continue // upstream couldn't quote in this currency → skipped
+		}
+		p, err := decimal.NewFromString(raw.String())
+		if err != nil {
+			return nil, fmt.Errorf("coingecko: bad price %q for %s: %w", raw.String(), a.Symbol, err)
+		}
+		out = append(out, Quote{AssetID: a.ID, QuoteAssetID: quote.ID, Price: p, AsOf: asOf})
+	}
+	return out, nil
+}

--- a/backend/internal/service/prices/coingecko_test.go
+++ b/backend/internal/service/prices/coingecko_test.go
@@ -1,0 +1,113 @@
+package prices
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gregwym/offbook/backend/internal/model"
+)
+
+func cryptoAsset(id int64, symbol string) model.Asset {
+	return model.Asset{ID: id, Symbol: symbol, Kind: model.AssetKindCrypto}
+}
+
+func fiatAsset(id int64, symbol string) model.Asset {
+	return model.Asset{ID: id, Symbol: symbol, Kind: model.AssetKindFiat}
+}
+
+func TestCoinGecko_Supports(t *testing.T) {
+	c := NewCoinGecko()
+	cases := []struct {
+		name  string
+		asset model.Asset
+		want  bool
+	}{
+		{"mapped crypto", cryptoAsset(1, "BTC"), true},
+		{"mapped crypto lowercase", cryptoAsset(1, "eth"), true},
+		{"unmapped crypto", cryptoAsset(1, "OBSCURECOIN"), false},
+		{"equity with crypto-like symbol", model.Asset{ID: 1, Symbol: "BTC", Kind: model.AssetKindEquity}, false},
+		{"fiat", fiatAsset(1, "USD"), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := c.Supports(tc.asset); got != tc.want {
+				t.Errorf("Supports(%s/%s) = %v, want %v", tc.asset.Symbol, tc.asset.Kind, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestCoinGecko_Fetch_ParsesWithoutFloat64: prices arrive as decimal strings
+// straight from the JSON number token — a high-precision quote must survive
+// the trip exactly.
+func TestCoinGecko_Fetch_ParsesWithoutFloat64(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/simple/price" {
+			t.Errorf("path = %s, want /simple/price", r.URL.Path)
+		}
+		q := r.URL.Query()
+		if q.Get("vs_currencies") != "usd" {
+			t.Errorf("vs_currencies = %q, want usd", q.Get("vs_currencies"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		// "unknowncoin" is unrequested noise; "ethereum" omits the usd quote.
+		_, _ = w.Write([]byte(`{
+			"bitcoin": {"usd": 67123.456789012345678},
+			"ethereum": {"eur": 3000.5},
+			"unknowncoin": {"usd": 1}
+		}`))
+	}))
+	defer srv.Close()
+
+	c := NewCoinGecko().WithBaseURL(srv.URL)
+	fixed := time.Date(2026, 6, 10, 12, 0, 0, 0, time.UTC)
+	c.now = func() time.Time { return fixed }
+
+	btc := cryptoAsset(11, "BTC")
+	eth := cryptoAsset(12, "ETH")
+	usd := fiatAsset(1, "USD")
+	quotes, err := c.Fetch(context.Background(), []model.Asset{btc, eth}, usd)
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(quotes) != 1 {
+		t.Fatalf("got %d quotes, want 1 (ETH had no usd quote, unknowncoin unrequested); got %+v", len(quotes), quotes)
+	}
+	q := quotes[0]
+	if q.AssetID != btc.ID || q.QuoteAssetID != usd.ID {
+		t.Errorf("quote ids = (%d→%d), want (%d→%d)", q.AssetID, q.QuoteAssetID, btc.ID, usd.ID)
+	}
+	if q.Price.String() != "67123.456789012345678" {
+		t.Errorf("price = %s, want 67123.456789012345678 (no float64 precision loss)", q.Price)
+	}
+	if !q.AsOf.Equal(fixed) {
+		t.Errorf("asOf = %v, want %v", q.AsOf, fixed)
+	}
+}
+
+func TestCoinGecko_Fetch_NonFiatQuoteReturnsNothing(t *testing.T) {
+	c := NewCoinGecko().WithBaseURL("http://invalid.invalid") // must not be called
+	quotes, err := c.Fetch(context.Background(), []model.Asset{cryptoAsset(1, "BTC")}, cryptoAsset(2, "ETH"))
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(quotes) != 0 {
+		t.Errorf("got %d quotes, want 0 (crypto quote currency unsupported)", len(quotes))
+	}
+}
+
+func TestCoinGecko_Fetch_UpstreamErrorPropagates(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer srv.Close()
+
+	c := NewCoinGecko().WithBaseURL(srv.URL)
+	_, err := c.Fetch(context.Background(), []model.Asset{cryptoAsset(1, "BTC")}, fiatAsset(2, "USD"))
+	if err == nil {
+		t.Fatal("Fetch: expected error on 429, got nil")
+	}
+}

--- a/backend/internal/service/prices/provider.go
+++ b/backend/internal/service/prices/provider.go
@@ -1,0 +1,41 @@
+// Package prices implements ADR-0014: pluggable price & FX providers that
+// keep the `prices` time series current between imports. Providers only
+// produce price observations — they never touch positions or transactions
+// (quantity is ledger-derived per ADR-0017), and the only thing sent
+// upstream is the symbol list, never quantities, amounts, or PII.
+package prices
+
+import (
+	"context"
+	"time"
+
+	"github.com/shopspring/decimal"
+
+	"github.com/gregwym/offbook/backend/internal/model"
+)
+
+// Quote is one observed price: AssetID priced in QuoteAssetID at AsOf.
+type Quote struct {
+	AssetID      int64
+	QuoteAssetID int64
+	Price        decimal.Decimal
+	AsOf         time.Time
+}
+
+// Provider fetches current prices from one upstream source. Implementations
+// mirror the service/ai provider pattern: small, per-source, registered with
+// the orchestrating Service.
+type Provider interface {
+	// Name identifies the provider and doubles as the prices.source value
+	// ('coingecko', 'ecb', …) so every observation stays attributable.
+	Name() string
+	// Supports reports whether this provider can quote the asset at all.
+	// The service uses it to partition held assets across providers.
+	Supports(a model.Asset) bool
+	// Fetch returns observations for the given (already Supports-filtered)
+	// assets, priced in the quote asset. Assets the upstream can't quote —
+	// unknown symbol, unsupported quote currency — are silently omitted
+	// from the result; the caller reports them as skipped. An error means
+	// the upstream call itself failed.
+	Fetch(ctx context.Context, assets []model.Asset, quote model.Asset) ([]Quote, error)
+}

--- a/backend/internal/service/prices/service.go
+++ b/backend/internal/service/prices/service.go
@@ -1,0 +1,147 @@
+package prices
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/gregwym/offbook/backend/internal/model"
+	"github.com/gregwym/offbook/backend/internal/repository"
+)
+
+// RefreshResult is the wire response of a manual refresh. Skipped lists the
+// held symbols no provider could quote — surfaced, not silent (#282 spirit):
+// those assets will keep reporting stale/unpriced in valuations.
+type RefreshResult struct {
+	Refreshed int       `json:"refreshed"`
+	Skipped   []string  `json:"skipped"`
+	AsOf      time.Time `json:"as_of"`
+}
+
+// Service orchestrates providers: it derives the asset set from the user's
+// current holdings, partitions it across registered providers, and appends
+// the returned observations to the prices time series. It never reads or
+// writes positions/transactions beyond listing held assets.
+type Service struct {
+	users     repository.UserRepository
+	positions repository.PositionRepository
+	assets    repository.AssetRepository
+	prices    repository.PriceRepository
+	providers []Provider
+	now       func() time.Time
+}
+
+func NewService(
+	users repository.UserRepository,
+	positions repository.PositionRepository,
+	assets repository.AssetRepository,
+	prices repository.PriceRepository,
+	providers ...Provider,
+) *Service {
+	return &Service{
+		users:     users,
+		positions: positions,
+		assets:    assets,
+		prices:    prices,
+		providers: providers,
+		now:       time.Now,
+	}
+}
+
+// SetClock overrides the time source (tests).
+func (s *Service) SetClock(fn func() time.Time) { s.now = fn }
+
+// RefreshForUser fetches current prices for every asset the user holds
+// (positions ≠ 0), quoted in the user's primary currency, and appends the
+// observations to `prices`. The egress is the symbol list only, and only
+// for this user's holdings — never another tenant's (the position read is
+// user-scoped). Held assets no provider can quote are returned in Skipped.
+func (s *Service) RefreshForUser(ctx context.Context, userID int64) (*RefreshResult, error) {
+	user, err := s.users.GetByID(ctx, userID)
+	if err != nil {
+		return nil, fmt.Errorf("prices: load user: %w", err)
+	}
+
+	allAssets, err := s.assets.List(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("prices: list assets: %w", err)
+	}
+	assetByID := make(map[int64]model.Asset, len(allAssets))
+	for _, a := range allAssets {
+		assetByID[a.ID] = a
+	}
+	quote, ok := assetByID[user.PrimaryCurrencyAssetID]
+	if !ok {
+		return nil, fmt.Errorf("prices: primary currency asset %d not found", user.PrimaryCurrencyAssetID)
+	}
+
+	positions, err := s.positions.ListByUserID(ctx, userID)
+	if err != nil {
+		return nil, fmt.Errorf("prices: list positions: %w", err)
+	}
+	seen := map[int64]bool{}
+	held := make([]model.Asset, 0, len(positions))
+	for _, p := range positions {
+		if p.Quantity.IsZero() || p.AssetID == quote.ID || seen[p.AssetID] {
+			continue
+		}
+		seen[p.AssetID] = true
+		a, ok := assetByID[p.AssetID]
+		if !ok {
+			continue
+		}
+		held = append(held, a)
+	}
+
+	result := &RefreshResult{Skipped: []string{}, AsOf: s.now().UTC()}
+	remaining := held
+	for _, provider := range s.providers {
+		supported := make([]model.Asset, 0, len(remaining))
+		next := make([]model.Asset, 0, len(remaining))
+		for _, a := range remaining {
+			if provider.Supports(a) {
+				supported = append(supported, a)
+			} else {
+				next = append(next, a)
+			}
+		}
+		remaining = next
+		if len(supported) == 0 {
+			continue
+		}
+		quotes, err := provider.Fetch(ctx, supported, quote)
+		if err != nil {
+			return nil, fmt.Errorf("prices: provider %s: %w", provider.Name(), err)
+		}
+		quoted := map[int64]bool{}
+		for _, q := range quotes {
+			if err := s.prices.Insert(ctx, &model.Price{
+				AssetID:      q.AssetID,
+				QuoteAssetID: q.QuoteAssetID,
+				AsOf:         q.AsOf,
+				Price:        q.Price,
+				Source:       provider.Name(),
+			}); err != nil {
+				return nil, fmt.Errorf("prices: insert %s observation: %w", provider.Name(), err)
+			}
+			quoted[q.AssetID] = true
+			result.Refreshed++
+		}
+		// Supported but not returned (unknown to upstream, unquotable
+		// currency) → back into the pool so a later provider may cover it,
+		// or it lands in Skipped.
+		for _, a := range supported {
+			if !quoted[a.ID] {
+				remaining = append(remaining, a)
+			}
+		}
+	}
+
+	for _, a := range remaining {
+		result.Skipped = append(result.Skipped, strings.ToUpper(a.Symbol))
+	}
+	sort.Strings(result.Skipped)
+	return result, nil
+}

--- a/backend/internal/service/prices/service_test.go
+++ b/backend/internal/service/prices/service_test.go
@@ -1,0 +1,228 @@
+package prices_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/joho/godotenv"
+	"github.com/shopspring/decimal"
+	"gorm.io/gorm"
+
+	"github.com/gregwym/offbook/backend/internal/db"
+	"github.com/gregwym/offbook/backend/internal/model"
+	"github.com/gregwym/offbook/backend/internal/repository"
+	"github.com/gregwym/offbook/backend/internal/service/prices"
+	"github.com/gregwym/offbook/backend/internal/testutil"
+)
+
+func loadRepoDotenv() {
+	dir, err := os.Getwd()
+	if err != nil {
+		return
+	}
+	for i := 0; i < 8; i++ {
+		envPath := filepath.Join(dir, ".env")
+		if _, err := os.Stat(envPath); err == nil {
+			_ = godotenv.Load(envPath)
+			return
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return
+		}
+		dir = parent
+	}
+}
+
+func openTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	loadRepoDotenv()
+	url := os.Getenv("TEST_DATABASE_URL")
+	if url == "" {
+		url = os.Getenv("DATABASE_URL")
+	}
+	if url == "" {
+		t.Skip("no DATABASE_URL set; skipping integration test")
+	}
+	g, err := db.Open(url)
+	if err != nil {
+		t.Fatalf("db.Open: %v", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := db.Ping(ctx, g); err != nil {
+		t.Skipf("db.Ping: %v; skipping integration test", err)
+	}
+	return g
+}
+
+func seedUser(t *testing.T, g *gorm.DB) int64 {
+	t.Helper()
+	u := &model.User{
+		Email:                  fmt.Sprintf("prices-test-%d-%d@example.test", time.Now().UnixNano(), len(t.Name())),
+		PasswordHash:           "x",
+		LastScope:              model.ScopePersonal,
+		DefaultScope:           model.ScopePersonal,
+		PrimaryCurrencyAssetID: testutil.LookupUSDAssetID(t, g),
+	}
+	if err := g.Create(u).Error; err != nil {
+		t.Fatalf("seed user: %v", err)
+	}
+	t.Cleanup(func() {
+		g.Unscoped().Where("user_id = ?", u.ID).Delete(&model.Position{})
+		g.Unscoped().Where("user_id = ?", u.ID).Delete(&model.Account{})
+		g.Unscoped().Delete(&model.User{}, u.ID)
+	})
+	return u.ID
+}
+
+func seedAccount(t *testing.T, g *gorm.DB, userID int64) *model.Account {
+	t.Helper()
+	a := &model.Account{
+		UserID: userID, Name: "Prices-" + time.Now().Format("150405.000000"),
+		InstitutionSlug: "fixture", AccountType: "crypto", Currency: "USD",
+		PrimaryQuoteAssetID: testutil.LookupUSDAssetID(t, g), IsActive: true,
+	}
+	if err := g.Create(a).Error; err != nil {
+		t.Fatalf("seed account: %v", err)
+	}
+	return a
+}
+
+func seedPosition(t *testing.T, g *gorm.DB, userID, accountID, assetID int64, qty string) {
+	t.Helper()
+	p := &model.Position{
+		UserID: userID, AccountID: accountID, AssetID: assetID,
+		Quantity: decimal.RequireFromString(qty),
+	}
+	if err := g.Create(p).Error; err != nil {
+		t.Fatalf("seed position: %v", err)
+	}
+}
+
+// fakeProvider quotes every crypto asset at a fixed price and records what
+// it was asked for, so tests can assert the egress set.
+type fakeProvider struct {
+	requested []model.Asset
+	price     decimal.Decimal
+	asOf      time.Time
+}
+
+func (f *fakeProvider) Name() string { return "fake" }
+
+func (f *fakeProvider) Supports(a model.Asset) bool { return a.Kind == model.AssetKindCrypto }
+
+func (f *fakeProvider) Fetch(_ context.Context, assets []model.Asset, quote model.Asset) ([]prices.Quote, error) {
+	f.requested = append(f.requested, assets...)
+	out := make([]prices.Quote, 0, len(assets))
+	for _, a := range assets {
+		out = append(out, prices.Quote{AssetID: a.ID, QuoteAssetID: quote.ID, Price: f.price, AsOf: f.asOf})
+	}
+	return out, nil
+}
+
+// TestRefreshForUser_WritesHeldCryptoOnly: refresh prices exactly the
+// crypto the user holds — fiat lands in Skipped (FX is Phase 2), the
+// primary currency is excluded entirely, and the observation lands in
+// `prices` with the provider as source.
+func TestRefreshForUser_WritesHeldCryptoOnly(t *testing.T) {
+	g := openTestDB(t)
+	ctx := context.Background()
+	userID := seedUser(t, g)
+	acct := seedAccount(t, g, userID)
+
+	usd := testutil.LookupUSDAssetID(t, g)
+	eur := testutil.LookupAssetID(t, g, "EUR", "fiat")
+	btc := testutil.LookupAssetID(t, g, "BTC", "crypto")
+
+	seedPosition(t, g, userID, acct.ID, usd, "1000") // primary currency → not refreshed, not skipped
+	seedPosition(t, g, userID, acct.ID, eur, "100")  // fiat → skipped (Phase 2)
+	seedPosition(t, g, userID, acct.ID, btc, "0.5")  // crypto → refreshed
+
+	asOf := time.Date(2026, 6, 10, 12, 0, 0, 0, time.UTC)
+	fake := &fakeProvider{price: decimal.RequireFromString("67000.5"), asOf: asOf}
+	svc := prices.NewService(
+		repository.NewUserRepository(g),
+		repository.NewPositionRepository(g),
+		repository.NewAssetRepository(g),
+		repository.NewPriceRepository(g),
+		fake,
+	)
+	t.Cleanup(func() {
+		g.Unscoped().Where("source = ? AND as_of = ?", "fake", asOf).Delete(&model.Price{})
+	})
+
+	result, err := svc.RefreshForUser(ctx, userID)
+	if err != nil {
+		t.Fatalf("RefreshForUser: %v", err)
+	}
+	if result.Refreshed != 1 {
+		t.Errorf("Refreshed = %d, want 1 (BTC only)", result.Refreshed)
+	}
+	if len(result.Skipped) != 1 || result.Skipped[0] != "EUR" {
+		t.Errorf("Skipped = %v, want [EUR]", result.Skipped)
+	}
+	if len(fake.requested) != 1 || fake.requested[0].ID != btc {
+		t.Errorf("provider asked for %+v, want exactly the held BTC (egress = held symbols only)", fake.requested)
+	}
+
+	var row model.Price
+	if err := g.Where("asset_id = ? AND quote_asset_id = ? AND source = ?", btc, usd, "fake").
+		Order("as_of DESC").First(&row).Error; err != nil {
+		t.Fatalf("price row not written: %v", err)
+	}
+	if row.Price.String() != "67000.5" {
+		t.Errorf("stored price = %s, want 67000.5", row.Price)
+	}
+
+	// Idempotency: refreshing again with the same as_of upserts in place,
+	// not a duplicate row.
+	if _, err := svc.RefreshForUser(ctx, userID); err != nil {
+		t.Fatalf("second RefreshForUser: %v", err)
+	}
+	var n int64
+	if err := g.Model(&model.Price{}).
+		Where("asset_id = ? AND quote_asset_id = ? AND source = ? AND as_of = ?", btc, usd, "fake", asOf).
+		Count(&n).Error; err != nil {
+		t.Fatalf("count price rows: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("price rows = %d, want 1 (same observation upserts, not duplicates)", n)
+	}
+}
+
+// TestRefreshForUser_TenantScoped: another user's holdings never leave the
+// box — the provider sees only the requesting user's assets.
+func TestRefreshForUser_TenantScoped(t *testing.T) {
+	g := openTestDB(t)
+	ctx := context.Background()
+	userA := seedUser(t, g)
+	userB := seedUser(t, g)
+	acctB := seedAccount(t, g, userB)
+	btc := testutil.LookupAssetID(t, g, "BTC", "crypto")
+	seedPosition(t, g, userB, acctB.ID, btc, "1") // user B holds crypto; A holds nothing
+
+	fake := &fakeProvider{price: decimal.New(1, 0), asOf: time.Now().UTC()}
+	svc := prices.NewService(
+		repository.NewUserRepository(g),
+		repository.NewPositionRepository(g),
+		repository.NewAssetRepository(g),
+		repository.NewPriceRepository(g),
+		fake,
+	)
+
+	result, err := svc.RefreshForUser(ctx, userA)
+	if err != nil {
+		t.Fatalf("RefreshForUser: %v", err)
+	}
+	if result.Refreshed != 0 || len(result.Skipped) != 0 {
+		t.Errorf("result = %+v, want nothing refreshed or skipped (user A holds nothing)", result)
+	}
+	if len(fake.requested) != 0 {
+		t.Errorf("provider was asked for %+v — user B's holdings leaked into user A's refresh", fake.requested)
+	}
+}

--- a/docs/ADR/0014-pluggable-price-providers.md
+++ b/docs/ADR/0014-pluggable-price-providers.md
@@ -1,0 +1,114 @@
+# ADR-0014: Pluggable Price & FX Providers
+
+**Status:** Accepted
+
+**Context date:** 2026-06-10
+
+## Context
+
+ADR-0013/ADR-0017 made every valuation a pure function of stored facts:
+`value(t) = quantity_asof(t) × price_asof(t)`. Quantities flow from the
+transaction ledger; prices flow from the `prices` time series. But the only
+writers of `prices` are Plaid sync and statement import — so any asset not
+covered by those (manually tracked equities and crypto, foreign-currency
+cash needing FX) freezes at its last imported price. The valuation layer
+correctly reports those positions stale/unpriced (#282, #339), which makes
+the gap *visible* — this ADR is about making it *rare*.
+
+The deferral note in M10 reserved this ADR for "Pluggable Tier-3 price
+provider (Yahoo, Polygon, ECB, CoinGecko)."
+
+## Decision
+
+### 1. Providers are a new seam: `internal/service/prices`
+
+Mirror the `service/ai` provider pattern: a small interface, concrete
+implementations per upstream source, a service that orchestrates them.
+
+```go
+type Provider interface {
+    // Name doubles as the prices.source value ('coingecko', 'ecb', …).
+    Name() string
+    // Supports reports whether this provider can quote the asset at all.
+    Supports(a model.Asset) bool
+    // Fetch returns current observations for the supported assets, priced
+    // in the quote asset. Unquotable assets are silently omitted from the
+    // result — the caller treats them as skipped.
+    Fetch(ctx context.Context, assets []model.Asset, quote model.Asset) ([]Quote, error)
+}
+```
+
+Providers **only write `prices` rows** (via the orchestrating service).
+They never touch `positions` or `transactions` — quantity remains
+ledger-derived per ADR-0017. A provider failure or gap degrades to the
+existing stale/unpriced signal; it never coerces to $0 and never blocks
+the request beyond reporting the error.
+
+### 2. Refresh is user-initiated first, scheduled later
+
+Phases (tracked in #338):
+
+1. **Phase 1 — seam + CoinGecko + manual refresh.** `POST /prices/refresh`
+   refreshes prices for the assets the *requesting user currently holds*
+   (positions ≠ 0), in the user's primary currency. A "Refresh prices"
+   button on Insights drives it. Crypto only (CoinGecko's free, keyless
+   `/simple/price` endpoint).
+2. **Phase 2 — FX.** Daily fiat reference rates (ECB or equivalent) so
+   non-primary-currency cash prices into the user's primary currency.
+3. **Phase 3 — scheduled refresh.** Periodic refresh for all held assets
+   across users, respecting provider rate limits.
+
+### 3. Egress and privacy
+
+What leaves the box is **the symbol list only** — never quantities, never
+amounts, never account metadata, never PII. In Phase 1 the egress is
+strictly user-initiated: clicking "Refresh prices" *is* the consent, the
+same model as choosing a cloud AI provider (ADR-0019's "locality is the
+user's provider choice"). Phase 3's background refresh will require a
+persistent opt-in setting before it ships.
+
+A symbol list is still a fingerprint of the user's portfolio composition.
+Providers requiring an API key (Polygon, etc.) tie that fingerprint to an
+account and will be opt-in per provider with the key stored encrypted,
+like the Claude API key. Keyless providers (CoinGecko, ECB) carry only
+IP-level exposure.
+
+### 4. Idempotency and provenance
+
+`prices` is append-only with upsert-in-place on
+`(asset_id, quote_asset_id, as_of, source)` — re-refreshing within the
+same observation instant updates rather than duplicates, and provider
+observations never collide with `plaid`/`manual`/import-sourced rows for
+the same instant. `source` = `Provider.Name()` keeps every observation
+attributable.
+
+### 5. Symbol mapping is static and reviewable
+
+CoinGecko keys quotes by its own coin IDs (`bitcoin`, not `BTC`). The
+mapping ships as a small, code-reviewed table of major assets rather than
+a runtime call to the (huge, ambiguous) `/coins/list` endpoint. A held
+symbol outside the table is reported as *skipped* in the refresh result —
+visible, not silent — and extending the table is a one-line PR.
+
+## Alternatives considered
+
+- **Price lookup at valuation time** (no stored series): breaks
+  `price_asof(t)` history, couples every page load to third parties,
+  and silently re-fingerprints the portfolio on every render. Rejected.
+- **One mega-provider with internal routing:** the registry already *is*
+  the router; per-source implementations keep failures, rate limits, and
+  consent per provider.
+- **Runtime symbol resolution via provider search APIs:** ambiguous
+  (ticker collisions across exchanges/chains) and unreviewable. The
+  static map trades coverage for correctness; skipped symbols are
+  surfaced to the user.
+
+## Consequences
+
+- Net worth, allocation, and account balances stay current between
+  imports for covered assets; gaps surface through the existing
+  stale/unpriced signals (#339) instead of silent staleness.
+- Each new source is a small `Provider` implementation plus registry
+  wiring — no changes to valuation or storage.
+- The static symbol map is a maintenance surface; acceptable because
+  misses are visible in the refresh result.

--- a/frontend/src/api/prices.ts
+++ b/frontend/src/api/prices.ts
@@ -1,0 +1,17 @@
+import { apiClient, type ApiItem } from './client'
+
+// RefreshResult mirrors backend prices.RefreshResult (ADR-0014 Phase 1).
+// `skipped` lists held symbols no provider could quote — those assets keep
+// their stale/partial flags until a covering provider lands.
+export type PriceRefreshResult = {
+  refreshed: number
+  skipped: string[]
+  as_of: string
+}
+
+// refreshPrices is user-initiated by design: the click is the egress
+// consent. Only the user's held symbols are sent upstream.
+export async function refreshPrices(): Promise<PriceRefreshResult> {
+  const res = await apiClient.post<ApiItem<PriceRefreshResult>>('/prices/refresh')
+  return res.data.data
+}

--- a/frontend/src/hooks/useScopedInsights.ts
+++ b/frontend/src/hooks/useScopedInsights.ts
@@ -6,7 +6,7 @@
 // aggregator is the only path for cross-user reads; this hook must never
 // call household repos directly. Personal scope hits the existing per-user
 // dashboard/portfolio/budget/goal/account endpoints.
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { listAccounts } from '../api/accounts'
 import { getBudgetSpend, listBudgets } from '../api/budgets'
 import { listCategories } from '../api/categories'
@@ -103,9 +103,13 @@ type Result =
   | { state: 'error'; error: string }
   | { state: 'ready'; data: InsightsData }
 
-export function useScopedInsights(): Result {
+// reload refetches the active scope's data in place (used after actions
+// that change what the bands should show, e.g. a price refresh).
+export function useScopedInsights(): Result & { reload: () => void } {
   const { active, hydrated, householdId } = useScopeStore()
   const [result, setResult] = useState<Result>({ state: 'loading' })
+  const [nonce, setNonce] = useState(0)
+  const reload = useCallback(() => setNonce((n) => n + 1), [])
 
   useEffect(() => {
     if (!hydrated) return
@@ -126,9 +130,9 @@ export function useScopedInsights(): Result {
     return () => {
       cancelled = true
     }
-  }, [active, hydrated, householdId])
+  }, [active, hydrated, householdId, nonce])
 
-  return result
+  return { ...result, reload }
 }
 
 async function loadPersonal(): Promise<InsightsData> {

--- a/frontend/src/pages/InsightsPage.tsx
+++ b/frontend/src/pages/InsightsPage.tsx
@@ -9,11 +9,13 @@
 //   3) Spending by category (current period)
 //   4) Budgets + Goals at-a-glance
 //   5) Account list summary
+import { useState } from 'react'
 import { Link } from 'react-router-dom'
 import {
   LineChart as LineChartIcon,
   PieChart as PieChartIcon,
   PiggyBank,
+  RefreshCw,
   Target,
   TrendingUp,
   Wallet,
@@ -29,6 +31,7 @@ import {
   XAxis,
   YAxis,
 } from 'recharts'
+import { refreshPrices } from '../api/prices'
 import { AmountDisplay } from '../components/AmountDisplay'
 import { FALLBACK_PIE_COLORS } from '../components/chartColors'
 import { PartialBadge } from '../components/PartialBadge'
@@ -56,13 +59,16 @@ export function InsightsPage() {
 
   return (
     <div className="space-y-6">
-      <div>
-        <h1 className="text-2xl font-semibold text-gray-900">Insights</h1>
-        <p className="mt-1 text-sm text-gray-500">
-          {active === SCOPE_HOUSEHOLD
-            ? 'Household aggregates over shared accounts. PII never leaves each member’s book.'
-            : 'Net worth · allocation · spending · budgets · goals — at a glance.'}
-        </p>
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-semibold text-gray-900">Insights</h1>
+          <p className="mt-1 text-sm text-gray-500">
+            {active === SCOPE_HOUSEHOLD
+              ? 'Household aggregates over shared accounts. PII never leaves each member’s book.'
+              : 'Net worth · allocation · spending · budgets · goals — at a glance.'}
+          </p>
+        </div>
+        <RefreshPricesButton onRefreshed={result.reload} />
       </div>
 
       {result.state === 'loading' && (
@@ -101,6 +107,50 @@ function InsightsBody({ data }: { data: InsightsData }) {
         {data.period.from.slice(0, 10)} → {data.period.to.slice(0, 10)}
       </p>
     </>
+  )
+}
+
+// RefreshPricesButton triggers the user-initiated price refresh (ADR-0014
+// Phase 1). Clicking is the egress consent: only the user's held symbols
+// go upstream. On success the page data reloads so valuations pick up the
+// fresh observations; skipped symbols are surfaced, not hidden.
+function RefreshPricesButton({ onRefreshed }: { onRefreshed: () => void }) {
+  const [busy, setBusy] = useState(false)
+  const [note, setNote] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  const run = async () => {
+    setBusy(true)
+    setNote(null)
+    setError(null)
+    try {
+      const r = await refreshPrices()
+      const parts = [`${r.refreshed} price${r.refreshed === 1 ? '' : 's'} refreshed`]
+      if (r.skipped.length > 0) parts.push(`no source for ${r.skipped.join(', ')}`)
+      setNote(parts.join(' · '))
+      onRefreshed()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'refresh failed')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <div className="flex shrink-0 flex-col items-end gap-1">
+      <button
+        type="button"
+        onClick={() => void run()}
+        disabled={busy}
+        title="Fetch current market prices for the assets you hold. Sends only the symbol list to the price provider."
+        className="inline-flex items-center gap-1.5 rounded-md border border-gray-300 bg-white px-3 py-1.5 text-sm text-gray-700 hover:bg-gray-50 disabled:opacity-50"
+      >
+        <RefreshCw size={14} className={busy ? 'animate-spin' : undefined} />
+        {busy ? 'Refreshing…' : 'Refresh prices'}
+      </button>
+      {note && <span className="text-[11px] text-gray-500">{note}</span>}
+      {error && <span className="text-[11px] text-red-600">{error}</span>}
+    </div>
   )
 }
 


### PR DESCRIPTION
Part of #338 (Phase 1 of 3 — epic stays open for FX and scheduled refresh). Fourth M12 (Trustworthy Overview) item.

## What

**[ADR-0014](docs/ADR/0014-pluggable-price-providers.md)** written and accepted: pluggable price providers as a new seam mirroring `service/ai`. Providers only append to the `prices` time series the valuation layer already reads — never touch `positions`/`transactions` (quantity stays ledger-derived per ADR-0017) — and the only egress is the held-symbol list, never quantities, amounts, or PII.

### Backend

- **`internal/service/prices`** — `Provider` interface (`Name`/`Supports`/`Fetch`) + orchestrating `Service.RefreshForUser`: derives the asset set from the user's *current holdings* (user-scoped position read, nonzero quantities, primary currency excluded), partitions across registered providers, appends observations with `source = provider.Name()`. The existing unique key `(asset, quote, as_of, source)` makes re-refresh upsert in place. Held assets no provider can quote come back in `skipped` — visible, not silent (so non-primary fiat surfaces the Phase-2 FX gap honestly).
- **CoinGecko provider** — free, keyless `/simple/price`; static symbol→coin-id map for 20 major assets (ADR-0014 §5: reviewable over runtime resolution); `json.Number` decoding so prices reach `decimal` without a float64 hop.
- **`POST /prices/refresh`** — upstream failure maps to 502 `PRICE_PROVIDER_ERROR`; valuations keep their stale flags either way. Route golden updated.

### Frontend

- **"Refresh prices" button** on the Insights header (both scopes — each member refreshes their own holdings). The click *is* the egress consent in Phase 1; no background fetching. Shows `N prices refreshed · no source for X, Y`, then reloads the page data via a new `reload()` exposed by `useScopedInsights`.

## Tests

- CoinGecko: `Supports` matrix (mapped/unmapped crypto, equity with crypto-like ticker, fiat), high-precision parse with no float64 loss, non-fiat quote short-circuits without a network call, 429 propagates.
- Service (real test DB): refreshes exactly the held crypto, skips fiat, excludes primary currency, idempotent re-refresh (1 row), and **tenant scoping** — another user's holdings never reach the provider.
- `make verify` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
