### PR TITLE
#338 Phase 2: Frankfurter/ECB FX provider

### DIFF
--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -75,9 +75,11 @@ func New(cfg config.Config, gormDB *gorm.DB) *gin.Engine {
 	dashboardRepo := repository.NewDashboardRepository(gormDB)
 	dashboardSvc := service.NewDashboardService(dashboardRepo, transactionRepo, userRepo, valuationSvc)
 
-	// Price refresh (ADR-0014 Phase 1): user-initiated, providers write
-	// into the prices time series the valuation layer already reads.
-	pricesSvc := prices.NewService(userRepo, positionRepo, assetRepo, priceRepo, prices.NewCoinGecko())
+	// Price refresh (ADR-0014): user-initiated, providers write into the
+	// prices time series the valuation layer already reads. CoinGecko
+	// covers crypto (Phase 1), Frankfurter/ECB covers fiat FX (Phase 2).
+	pricesSvc := prices.NewService(userRepo, positionRepo, assetRepo, priceRepo,
+		prices.NewCoinGecko(), prices.NewFrankfurter())
 	priceHandler := handler.NewPriceHandler(pricesSvc)
 
 	budgetRepo := repository.NewBudgetRepository(gormDB)

--- a/backend/internal/service/prices/frankfurter.go
+++ b/backend/internal/service/prices/frankfurter.go
@@ -1,0 +1,131 @@
+package prices
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/shopspring/decimal"
+
+	"github.com/gregwym/offbook/backend/internal/model"
+)
+
+// frankfurterBaseURL is the public, keyless API root. Frankfurter serves
+// the ECB daily reference rates as JSON. Overridable for tests.
+const frankfurterBaseURL = "https://api.frankfurter.app"
+
+// Frankfurter quotes fiat currencies into other fiat currencies using the
+// ECB daily reference rates (ADR-0014 Phase 2). One request per held
+// currency: GET /latest?from=EUR&to=USD returns the direct rate, so no
+// inverse division (and its precision loss) is needed. No API key — the
+// only egress is the currency-pair list.
+type Frankfurter struct {
+	baseURL string
+	client  *http.Client
+}
+
+// NewFrankfurter returns a provider hitting the public Frankfurter API.
+func NewFrankfurter() *Frankfurter {
+	return &Frankfurter{
+		baseURL: frankfurterBaseURL,
+		client:  &http.Client{Timeout: 15 * time.Second},
+	}
+}
+
+// WithBaseURL points the provider at a different API root (tests).
+func (f *Frankfurter) WithBaseURL(u string) *Frankfurter {
+	f.baseURL = u
+	return f
+}
+
+func (f *Frankfurter) Name() string { return "frankfurter" }
+
+// Supports: any fiat asset. Currencies outside the ECB reference set are
+// omitted at Fetch time (the upstream 404s) and surface as skipped.
+func (f *Frankfurter) Supports(a model.Asset) bool {
+	return a.Kind == model.AssetKindFiat
+}
+
+func (f *Frankfurter) Fetch(ctx context.Context, assets []model.Asset, quote model.Asset) ([]Quote, error) {
+	if len(assets) == 0 {
+		return nil, nil
+	}
+	if quote.Kind != model.AssetKindFiat {
+		return nil, nil // fiat→non-fiat is not an FX rate
+	}
+	to := strings.ToUpper(quote.Symbol)
+
+	out := make([]Quote, 0, len(assets))
+	for _, a := range assets {
+		from := strings.ToUpper(a.Symbol)
+		if from == to {
+			continue // same currency needs no rate
+		}
+		q, ok, err := f.fetchOne(ctx, from, to)
+		if err != nil {
+			return nil, err
+		}
+		if !ok {
+			continue // currency outside the ECB set → skipped
+		}
+		q.AssetID = a.ID
+		q.QuoteAssetID = quote.ID
+		out = append(out, q)
+	}
+	return out, nil
+}
+
+// fetchOne returns the latest reference rate for one currency pair.
+// ok=false means the upstream doesn't know the pair (→ skipped); err is
+// reserved for transport/protocol failures.
+func (f *Frankfurter) fetchOne(ctx context.Context, from, to string) (Quote, bool, error) {
+	u := fmt.Sprintf("%s/latest?from=%s&to=%s", f.baseURL, url.QueryEscape(from), url.QueryEscape(to))
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return Quote{}, false, fmt.Errorf("frankfurter: build request: %w", err)
+	}
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := f.client.Do(req)
+	if err != nil {
+		return Quote{}, false, fmt.Errorf("frankfurter: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	// Unknown currency → 404/422 from the API: a coverage gap, not a failure.
+	if resp.StatusCode == http.StatusNotFound || resp.StatusCode == http.StatusUnprocessableEntity {
+		return Quote{}, false, nil
+	}
+	if resp.StatusCode != http.StatusOK {
+		return Quote{}, false, fmt.Errorf("frankfurter: unexpected status %d for %s→%s", resp.StatusCode, from, to)
+	}
+
+	dec := json.NewDecoder(resp.Body)
+	dec.UseNumber()
+	var body struct {
+		Date  string                 `json:"date"`
+		Rates map[string]json.Number `json:"rates"`
+	}
+	if err := dec.Decode(&body); err != nil {
+		return Quote{}, false, fmt.Errorf("frankfurter: decode response: %w", err)
+	}
+	raw, ok := body.Rates[to]
+	if !ok {
+		return Quote{}, false, nil
+	}
+	price, err := decimal.NewFromString(raw.String())
+	if err != nil {
+		return Quote{}, false, fmt.Errorf("frankfurter: bad rate %q for %s→%s: %w", raw.String(), from, to, err)
+	}
+	// The ECB publishes one reference rate per business day; use that date
+	// as the observation instant so re-refreshing the same day upserts in
+	// place rather than stacking near-duplicate rows.
+	asOf, err := time.Parse("2006-01-02", body.Date)
+	if err != nil {
+		return Quote{}, false, fmt.Errorf("frankfurter: bad date %q: %w", body.Date, err)
+	}
+	return Quote{Price: price, AsOf: asOf.UTC()}, true, nil
+}

--- a/backend/internal/service/prices/frankfurter_test.go
+++ b/backend/internal/service/prices/frankfurter_test.go
@@ -1,0 +1,109 @@
+package prices
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gregwym/offbook/backend/internal/model"
+)
+
+func TestFrankfurter_Supports(t *testing.T) {
+	f := NewFrankfurter()
+	cases := []struct {
+		name  string
+		asset model.Asset
+		want  bool
+	}{
+		{"fiat", fiatAsset(1, "EUR"), true},
+		{"exotic fiat (coverage decided at fetch)", fiatAsset(1, "XXX"), true},
+		{"crypto", cryptoAsset(1, "BTC"), false},
+		{"equity", model.Asset{ID: 1, Symbol: "AAPL", Kind: model.AssetKindEquity}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := f.Supports(tc.asset); got != tc.want {
+				t.Errorf("Supports(%s/%s) = %v, want %v", tc.asset.Symbol, tc.asset.Kind, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestFrankfurter_Fetch_DirectRatePerPair: each held currency gets one
+// /latest?from=X&to=Y call; the returned rate lands as a decimal string
+// with the ECB publication date as the observation instant. Unknown
+// currencies (upstream 404) are omitted, not errors. Same-currency pairs
+// are skipped without a call.
+func TestFrankfurter_Fetch_DirectRatePerPair(t *testing.T) {
+	calls := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		from := r.URL.Query().Get("from")
+		switch from {
+		case "EUR":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = fmt.Fprint(w, `{"date":"2026-06-09","rates":{"USD":1.078642}}`)
+		case "XXX":
+			w.WriteHeader(http.StatusNotFound)
+		default:
+			t.Errorf("unexpected from=%s", from)
+			w.WriteHeader(http.StatusBadRequest)
+		}
+	}))
+	defer srv.Close()
+
+	f := NewFrankfurter().WithBaseURL(srv.URL)
+	eur := fiatAsset(21, "EUR")
+	xxx := fiatAsset(22, "XXX")
+	usdDupe := fiatAsset(23, "USD") // same as quote → no call, no quote
+	usd := fiatAsset(1, "USD")
+
+	quotes, err := f.Fetch(context.Background(), []model.Asset{eur, xxx, usdDupe}, usd)
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if calls != 2 {
+		t.Errorf("upstream calls = %d, want 2 (EUR + XXX; USD→USD skipped)", calls)
+	}
+	if len(quotes) != 1 {
+		t.Fatalf("got %d quotes, want 1 (XXX unknown upstream); got %+v", len(quotes), quotes)
+	}
+	q := quotes[0]
+	if q.AssetID != eur.ID || q.QuoteAssetID != usd.ID {
+		t.Errorf("quote ids = (%d→%d), want (%d→%d)", q.AssetID, q.QuoteAssetID, eur.ID, usd.ID)
+	}
+	if q.Price.String() != "1.078642" {
+		t.Errorf("price = %s, want 1.078642", q.Price)
+	}
+	wantAsOf := time.Date(2026, 6, 9, 0, 0, 0, 0, time.UTC)
+	if !q.AsOf.Equal(wantAsOf) {
+		t.Errorf("asOf = %v, want %v (ECB publication date)", q.AsOf, wantAsOf)
+	}
+}
+
+func TestFrankfurter_Fetch_NonFiatQuoteReturnsNothing(t *testing.T) {
+	f := NewFrankfurter().WithBaseURL("http://invalid.invalid") // must not be called
+	quotes, err := f.Fetch(context.Background(), []model.Asset{fiatAsset(1, "EUR")}, cryptoAsset(2, "BTC"))
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(quotes) != 0 {
+		t.Errorf("got %d quotes, want 0 (fiat→crypto is not an FX rate)", len(quotes))
+	}
+}
+
+func TestFrankfurter_Fetch_ServerErrorPropagates(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	f := NewFrankfurter().WithBaseURL(srv.URL)
+	_, err := f.Fetch(context.Background(), []model.Asset{fiatAsset(1, "EUR")}, fiatAsset(2, "USD"))
+	if err == nil {
+		t.Fatal("Fetch: expected error on 500, got nil")
+	}
+}

--- a/backend/internal/service/prices/service_test.go
+++ b/backend/internal/service/prices/service_test.go
@@ -226,3 +226,64 @@ func TestRefreshForUser_TenantScoped(t *testing.T) {
 		t.Errorf("provider was asked for %+v — user B's holdings leaked into user A's refresh", fake.requested)
 	}
 }
+
+// fiatFakeProvider quotes fiat assets — paired with fakeProvider (crypto)
+// to prove the service partitions held assets across providers (Phase 2).
+type fiatFakeProvider struct {
+	requested []model.Asset
+	asOf      time.Time
+}
+
+func (f *fiatFakeProvider) Name() string                { return "fiat-fake" }
+func (f *fiatFakeProvider) Supports(a model.Asset) bool { return a.Kind == model.AssetKindFiat }
+func (f *fiatFakeProvider) Fetch(_ context.Context, assets []model.Asset, quote model.Asset) ([]prices.Quote, error) {
+	f.requested = append(f.requested, assets...)
+	out := make([]prices.Quote, 0, len(assets))
+	for _, a := range assets {
+		out = append(out, prices.Quote{AssetID: a.ID, QuoteAssetID: quote.ID, Price: decimal.RequireFromString("1.1"), AsOf: f.asOf})
+	}
+	return out, nil
+}
+
+// TestRefreshForUser_PartitionsAcrossProviders: crypto goes to the crypto
+// provider, fiat to the FX provider, nothing is skipped, and each provider
+// sees only the assets it supports.
+func TestRefreshForUser_PartitionsAcrossProviders(t *testing.T) {
+	g := openTestDB(t)
+	ctx := context.Background()
+	userID := seedUser(t, g)
+	acct := seedAccount(t, g, userID)
+
+	eur := testutil.LookupAssetID(t, g, "EUR", "fiat")
+	btc := testutil.LookupAssetID(t, g, "BTC", "crypto")
+	seedPosition(t, g, userID, acct.ID, eur, "100")
+	seedPosition(t, g, userID, acct.ID, btc, "0.5")
+
+	asOf := time.Date(2026, 6, 10, 13, 0, 0, 0, time.UTC)
+	crypto := &fakeProvider{price: decimal.New(1, 0), asOf: asOf}
+	fx := &fiatFakeProvider{asOf: asOf}
+	svc := prices.NewService(
+		repository.NewUserRepository(g),
+		repository.NewPositionRepository(g),
+		repository.NewAssetRepository(g),
+		repository.NewPriceRepository(g),
+		crypto, fx,
+	)
+	t.Cleanup(func() {
+		g.Unscoped().Where("source IN ? AND as_of = ?", []string{"fake", "fiat-fake"}, asOf).Delete(&model.Price{})
+	})
+
+	result, err := svc.RefreshForUser(ctx, userID)
+	if err != nil {
+		t.Fatalf("RefreshForUser: %v", err)
+	}
+	if result.Refreshed != 2 || len(result.Skipped) != 0 {
+		t.Errorf("result = %+v, want 2 refreshed / 0 skipped", result)
+	}
+	if len(crypto.requested) != 1 || crypto.requested[0].ID != btc {
+		t.Errorf("crypto provider asked for %+v, want exactly BTC", crypto.requested)
+	}
+	if len(fx.requested) != 1 || fx.requested[0].ID != eur {
+		t.Errorf("fx provider asked for %+v, want exactly EUR", fx.requested)
+	}
+}


### PR DESCRIPTION
Part of #338 (Phase 2 of 3 — Phase 3, scheduled refresh, remains). Builds on the Phase-1 seam (#346).

## What

**Frankfurter/ECB FX provider** — held cash in a non-primary currency now prices into the user's primary currency on "Refresh prices":

- `Supports`: any fiat asset; actual coverage decided at fetch (ECB reference set).
- One keyless `GET /latest?from=X&to=Y` per held currency — the *direct* rate, so no inverse division and no precision loss. Prices decode via `json.Number` → `decimal`.
- The ECB publication date is used as the observation `as_of`, so re-refreshing the same day upserts in place on the existing `(asset, quote, as_of, source)` key instead of stacking near-duplicate rows.
- Unknown currency → upstream 404/422 → omitted and reported as `skipped` (a coverage gap, not a failure); 5xx/transport errors propagate as `PRICE_PROVIDER_ERROR`.
- Same-currency pairs short-circuit without a network call (the service already excludes the primary currency; this guards the provider itself).

Registered after CoinGecko in the router — no other wiring changes; the Phase-1 endpoint, button, and consent model carry over unchanged.

## Tests

- Frankfurter: `Supports` matrix, direct-rate parse + ECB-date `as_of`, unknown-currency 404 → omitted (with call-count assertion that same-currency pairs skip the network), fiat→crypto quote short-circuits, 500 propagates.
- Service: new `TestRefreshForUser_PartitionsAcrossProviders` — crypto routes to the crypto provider, fiat to the FX provider, each provider sees only its assets, nothing skipped.
- `make verify` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
