### PR TITLE
#344: headline net-worth completeness flags (personal + household)

### DIFF
--- a/backend/internal/repository/dashboard_repo.go
+++ b/backend/internal/repository/dashboard_repo.go
@@ -8,37 +8,13 @@ import (
 	"gorm.io/gorm"
 )
 
-// netWorthQuery sums positions × latest prices in the user's primary
-// currency. Per ADR-0013, balance is derived from (positions, prices) —
-// the legacy accounts.balance column is gone. For positions denominated
-// in the user's primary currency the price is implicit (1); for others
-// we look up the most-recent price into that currency. Missing-price
-// fallback is 0 — calling code can surface a "stale price" warning.
-const netWorthQuery = `
-	SELECT COALESCE(SUM(
-		CASE
-			WHEN p.asset_id = u.primary_currency_asset_id THEN p.quantity
-			ELSE COALESCE(
-				p.quantity * (
-					SELECT pr.price FROM prices pr
-					WHERE pr.asset_id = p.asset_id
-					  AND pr.quote_asset_id = u.primary_currency_asset_id
-					ORDER BY pr.as_of DESC
-					LIMIT 1
-				), 0)
-		END
-	), 0)::text
-	FROM positions p
-	JOIN accounts a ON a.id = p.account_id AND a.deleted_at IS NULL
-	JOIN users    u ON u.id = p.user_id
-	WHERE p.deleted_at IS NULL AND p.user_id = ?`
-
 // DashboardSummaryAggregates is the raw aggregate output from a single
 // /dashboard/summary call. All monetary values are computed in Postgres
 // (NUMERIC arithmetic) and arrive in Go as shopspring/decimal so we never
-// touch them as floats.
+// touch them as floats. Net worth is NOT here: it's derived in the
+// service through the single valuation derivation (#282/#344), so a
+// missing price surfaces as incomplete instead of a silent $0.
 type DashboardSummaryAggregates struct {
-	NetWorth         decimal.Decimal
 	Income           decimal.Decimal // SUM(amount) WHERE amount > 0
 	Spending         decimal.Decimal // SUM(-amount) WHERE amount < 0 — returned positive
 	AccountCount     int64
@@ -122,10 +98,6 @@ func NewDashboardRepository(db *gorm.DB) DashboardRepository {
 // income/spending/transaction count + by-category ARE period-scoped.
 func (r *dashboardRepo) Summarize(ctx context.Context, userID int64, from, to time.Time) (*DashboardSummaryAggregates, error) {
 	out := &DashboardSummaryAggregates{}
-
-	if err := r.db.WithContext(ctx).Raw(netWorthQuery, userID).Scan(&out.NetWorth).Error; err != nil {
-		return nil, err
-	}
 
 	if err := r.db.WithContext(ctx).Raw(`
 		SELECT COUNT(*)

--- a/backend/internal/repository/household_aggregator_repo.go
+++ b/backend/internal/repository/household_aggregator_repo.go
@@ -35,9 +35,12 @@ type HouseholdAggregatorRepository interface {
 	// household (active + left-within-grace). Callers split by left_at.
 	ListMembersIncludingLeft(ctx context.Context, householdID int64) ([]model.HouseholdMember, error)
 
-	// SumBalances returns sum(balance) across the given account IDs.
-	// Returns decimal.Zero on empty input — no SQL is issued in that case.
-	SumBalances(ctx context.Context, accountIDs []int64) (decimal.Decimal, error)
+	// SumBalances returns sum(balance) across the given account IDs, plus
+	// a completeness flag: false when any position in the set had no price
+	// row at-or-after freshAfter (and isn't denominated in its owner's
+	// primary currency), i.e. the sum may rest on stale rates (#344).
+	// Returns (decimal.Zero, true) on empty input — no SQL is issued.
+	SumBalances(ctx context.Context, accountIDs []int64, freshAfter time.Time) (decimal.Decimal, bool, error)
 
 	// PeriodIncomeSpending returns (income, spending) over [from, to)
 	// across the given account IDs. Spending is returned as a positive value.
@@ -169,15 +172,21 @@ func (r *householdAggregatorRepo) ListMembersIncludingLeft(ctx context.Context, 
 	return out, err
 }
 
-func (r *householdAggregatorRepo) SumBalances(ctx context.Context, accountIDs []int64) (decimal.Decimal, error) {
+func (r *householdAggregatorRepo) SumBalances(ctx context.Context, accountIDs []int64, freshAfter time.Time) (decimal.Decimal, bool, error) {
 	if len(accountIDs) == 0 {
-		return decimal.Zero, nil
+		return decimal.Zero, true, nil
 	}
 	// Per ADR-0013, balance is derived from positions × latest prices —
 	// the legacy accounts.balance column is gone. For positions denominated
 	// in the position owner's primary currency the price is implicit (1);
-	// for others we look up the most-recent price into that currency.
-	var s string
+	// for others we look up the most-recent price into that currency. The
+	// complete flag mirrors AccountBalances (#339/#344): any position whose
+	// freshest price predates freshAfter marks the sum partial.
+	type rawRow struct {
+		Balance  string
+		Complete bool
+	}
+	var row rawRow
 	err := r.db.WithContext(ctx).Raw(`
 		SELECT COALESCE(SUM(
 			CASE
@@ -191,17 +200,26 @@ func (r *householdAggregatorRepo) SumBalances(ctx context.Context, accountIDs []
 						LIMIT 1
 					), 0)
 			END
-		), 0)::text
+		), 0)::text AS balance,
+		COALESCE(BOOL_AND(
+			p.asset_id = u.primary_currency_asset_id
+			OR EXISTS (
+				SELECT 1 FROM prices pr
+				WHERE pr.asset_id = p.asset_id
+				  AND pr.quote_asset_id = u.primary_currency_asset_id
+				  AND pr.as_of >= ?
+			)
+		), TRUE) AS complete
 		FROM positions p
 		JOIN accounts a ON a.id = p.account_id AND a.deleted_at IS NULL
 		JOIN users    u ON u.id = p.user_id
 		WHERE p.deleted_at IS NULL AND p.account_id IN ?
-	`, accountIDs).Scan(&s).Error
+	`, freshAfter, accountIDs).Scan(&row).Error
 	if err != nil {
-		return decimal.Zero, err
+		return decimal.Zero, false, err
 	}
-	d, _ := decimal.NewFromString(s)
-	return d, nil
+	d, _ := decimal.NewFromString(row.Balance)
+	return d, row.Complete, nil
 }
 
 func (r *householdAggregatorRepo) PeriodIncomeSpending(ctx context.Context, accountIDs []int64, from, to time.Time) (decimal.Decimal, decimal.Decimal, error) {

--- a/backend/internal/service/account_service_test.go
+++ b/backend/internal/service/account_service_test.go
@@ -311,16 +311,31 @@ func TestAccountService_Create_OpeningBalanceIsLedgerFact(t *testing.T) {
 	}
 
 	// Counts toward net worth (positions × price) but NOT income/spending.
-	dash := repository.NewDashboardRepository(g)
-	agg, err := dash.Summarize(ctx, userID, time.Now().AddDate(0, -1, 0), time.Now().AddDate(0, 0, 1))
+	// Net worth comes from the service since #344 (single valuation
+	// derivation; the repo no longer computes it).
+	dashSvc := service.NewDashboardService(
+		repository.NewDashboardRepository(g),
+		repository.NewTransactionRepository(g),
+		repository.NewUserRepository(g),
+		valuation.NewService(
+			repository.NewPositionRepository(g),
+			repository.NewPriceRepository(g),
+			repository.NewAssetRepository(g),
+			repository.NewAccountRepository(g),
+		),
+	)
+	summary, err := dashSvc.Summarize(ctx, userID, service.PeriodCurrentMonth)
 	if err != nil {
 		t.Fatalf("summarize: %v", err)
 	}
-	if !agg.NetWorth.Equal(decimal.NewFromInt(1000)) {
-		t.Errorf("net worth = %s, want 1000 (opening balance counts)", agg.NetWorth)
+	if summary.NetWorth != "1000" {
+		t.Errorf("net worth = %s, want 1000 (opening balance counts)", summary.NetWorth)
 	}
-	if !agg.Income.IsZero() || !agg.Spending.IsZero() {
-		t.Errorf("income=%s spending=%s, want 0/0 (opening_balance excluded from flow)", agg.Income, agg.Spending)
+	if !summary.NetWorthComplete {
+		t.Error("net_worth_complete = false, want true (primary-currency cash needs no price)")
+	}
+	if summary.Income != "0" || summary.Spending != "0" {
+		t.Errorf("income=%s spending=%s, want 0/0 (opening_balance excluded from flow)", summary.Income, summary.Spending)
 	}
 }
 

--- a/backend/internal/service/dashboard_charts_test.go
+++ b/backend/internal/service/dashboard_charts_test.go
@@ -396,3 +396,39 @@ func TestDashboard_Allocation_TenantIsolation(t *testing.T) {
 		t.Errorf("user A allocation has %d rows, want 0 (user B's positions must not leak)", len(rows))
 	}
 }
+
+// TestDashboard_Summarize_NetWorthCompleteness: the headline net worth goes
+// through the valuation derivation (#344) — a fresh-priced portfolio reports
+// complete; adding an unpriced asset flips the flag and the unpriced value
+// is excluded, never coerced to $0-and-counted-as-fine.
+func TestDashboard_Summarize_NetWorthCompleteness(t *testing.T) {
+	svc, userID, accountID, g := newDashboardSvc(t)
+	ctx := context.Background()
+	usdID := testutil.LookupUSDAssetID(t, g)
+
+	seedAllocationPosition(t, g, userID, accountID, usdID, "1000")
+
+	summary, err := svc.Summarize(ctx, userID, service.PeriodCurrentMonth)
+	if err != nil {
+		t.Fatalf("Summarize: %v", err)
+	}
+	if summary.NetWorth != "1000" || !summary.NetWorthComplete {
+		t.Errorf("summary = {net_worth:%s complete:%v}, want {1000 true}", summary.NetWorth, summary.NetWorthComplete)
+	}
+
+	// An unpriced asset joins the book → headline flips to partial and the
+	// priced portion still sums.
+	btcID := testutil.LookupAssetID(t, g, "BTC", "crypto")
+	seedAllocationPosition(t, g, userID, accountID, btcID, "0.5")
+
+	summary, err = svc.Summarize(ctx, userID, service.PeriodCurrentMonth)
+	if err != nil {
+		t.Fatalf("Summarize (with unpriced): %v", err)
+	}
+	if summary.NetWorth != "1000" {
+		t.Errorf("net_worth = %s, want 1000 (unpriced BTC excluded from the sum)", summary.NetWorth)
+	}
+	if summary.NetWorthComplete {
+		t.Error("net_worth_complete = true, want false (BTC has no price chain)")
+	}
+}

--- a/backend/internal/service/dashboard_service.go
+++ b/backend/internal/service/dashboard_service.go
@@ -27,10 +27,13 @@ const (
 var ErrInvalidPeriod = errors.New("invalid period")
 
 // DashboardSummary mirrors the API response shape exactly. The handler can
-// json-encode this directly.
+// json-encode this directly. NetWorthComplete is false when a held position
+// had no fresh price, so NetWorth is a partial sum (#282/#344) — the UI
+// flags it instead of presenting a confident-but-understated figure.
 type DashboardSummary struct {
 	Period           PeriodWindow                    `json:"period"`
 	NetWorth         string                          `json:"net_worth"`
+	NetWorthComplete bool                            `json:"net_worth_complete"`
 	Income           string                          `json:"income"`
 	Spending         string                          `json:"spending"`
 	AccountCount     int64                           `json:"account_count"`
@@ -116,6 +119,27 @@ func (s *DashboardService) Summarize(ctx context.Context, userID int64, period s
 		return nil, err
 	}
 
+	// Headline net worth goes through the single valuation derivation
+	// (#282/#344) with the same stale window as the per-account balances,
+	// so the headline and the accounts list never disagree silently. An
+	// unpriced or stale position drops out of the sum and flips the flag.
+	user, err := s.users.GetByID(ctx, userID)
+	if err != nil {
+		return nil, err
+	}
+	allocPositions, err := s.repo.ListPositionsForAllocation(ctx, userID)
+	if err != nil {
+		return nil, err
+	}
+	positions := make([]model.Position, 0, len(allocPositions))
+	for _, p := range allocPositions {
+		positions = append(positions, model.Position{AssetID: p.AssetID, Quantity: p.Quantity})
+	}
+	netWorth, err := s.val.ValuePositions(ctx, positions, s.now().UTC(), user.PrimaryCurrencyAssetID)
+	if err != nil {
+		return nil, err
+	}
+
 	items := make([]DashboardCategorySpendingItem, 0, len(agg.ByCategory))
 	for _, row := range agg.ByCategory {
 		items = append(items, DashboardCategorySpendingItem{
@@ -127,7 +151,8 @@ func (s *DashboardService) Summarize(ctx context.Context, userID int64, period s
 
 	return &DashboardSummary{
 		Period:           PeriodWindow{Key: period, From: from, To: to},
-		NetWorth:         agg.NetWorth.String(),
+		NetWorth:         netWorth.Value.String(),
+		NetWorthComplete: netWorth.Complete(),
 		Income:           agg.Income.String(),
 		Spending:         agg.Spending.String(),
 		AccountCount:     agg.AccountCount,

--- a/backend/internal/service/household/aggregator.go
+++ b/backend/internal/service/household/aggregator.go
@@ -55,8 +55,11 @@ func (a *Aggregator) SetClock(fn func() time.Time) { a.now = fn }
 // household + aggregates only across opt-in shared accounts. All money fields
 // are strings to preserve precision across the wire.
 type HouseholdDashboard struct {
-	Period           PeriodWindow                  `json:"period"`
-	NetWorth         string                        `json:"net_worth"`         // sum across balance_only + balance_and_txns shares
+	Period   PeriodWindow `json:"period"`
+	NetWorth string       `json:"net_worth"` // sum across balance_only + balance_and_txns shares
+	// NetWorthComplete is false when a shared position had no price within
+	// the valuation stale window — NetWorth may rest on stale rates (#344).
+	NetWorthComplete bool                          `json:"net_worth_complete"`
 	Income           string                        `json:"income"`            // period; balance_and_txns only
 	Spending         string                        `json:"spending"`          // period; balance_and_txns only
 	AccountCount     int                           `json:"account_count"`     // shared accounts count (any visibility)
@@ -219,7 +222,7 @@ func (a *Aggregator) Dashboard(ctx context.Context, householdID int64, period st
 	}
 	txAccounts := filterAccountsByUsers(txShares, liveUserIDs)
 
-	netWorth, err := a.repo.SumBalances(ctx, netWorthAccounts)
+	netWorth, netWorthComplete, err := a.repo.SumBalances(ctx, netWorthAccounts, a.now().Add(-a.val.StaleWindow()))
 	if err != nil {
 		return nil, fmt.Errorf("sum balances: %w", err)
 	}
@@ -252,6 +255,7 @@ func (a *Aggregator) Dashboard(ctx context.Context, householdID int64, period st
 	return &HouseholdDashboard{
 		Period:           PeriodWindow{Key: period, From: from, To: to},
 		NetWorth:         netWorth.String(),
+		NetWorthComplete: netWorthComplete,
 		Income:           income.String(),
 		Spending:         spending.String(),
 		AccountCount:     len(netWorthAccounts),
@@ -296,7 +300,9 @@ func (a *Aggregator) perMemberContributions(
 		if len(nwIDs) == 0 && len(txIDs) == 0 {
 			continue
 		}
-		nw, err := a.repo.SumBalances(ctx, nwIDs)
+		// Per-member completeness isn't surfaced on the tile strip yet —
+		// the headline flag (above) covers the same account set.
+		nw, _, err := a.repo.SumBalances(ctx, nwIDs, a.now().Add(-a.val.StaleWindow()))
 		if err != nil {
 			return nil, fmt.Errorf("sum balances for user %d: %w", m.UserID, err)
 		}
@@ -422,7 +428,9 @@ func (a *Aggregator) AIContext(ctx context.Context, householdID, requesterUserID
 	}
 	txAccounts := filterAccountsByUsers(txShares, liveUserIDs)
 
-	netWorth, err := a.repo.SumBalances(ctx, nwAccounts)
+	// Completeness is not part of the AI context — the model gets the
+	// partial sum either way; flagging is a UI concern.
+	netWorth, _, err := a.repo.SumBalances(ctx, nwAccounts, a.now().Add(-a.val.StaleWindow()))
 	if err != nil {
 		return nil, err
 	}

--- a/backend/internal/service/household/aggregator_insights_test.go
+++ b/backend/internal/service/household/aggregator_insights_test.go
@@ -394,3 +394,42 @@ func TestAggregator_AccountSummaries_FlagsStalePricing(t *testing.T) {
 		t.Errorf("stale-priced account Complete = true, want false (only price is 30d old)")
 	}
 }
+
+// TestAggregator_Dashboard_NetWorthCompleteness: the household headline
+// reports complete for fresh/primary-currency positions and partial when a
+// shared position's only price predates the stale window (#344).
+func TestAggregator_Dashboard_NetWorthCompleteness(t *testing.T) {
+	agg, g := newAggregator(t)
+	ctx := context.Background()
+	usd := testutil.LookupUSDAssetID(t, g)
+	ownerID := seedUser(t, g, "dash-nwc-owner")
+	hh := seedHouseholdRow(t, g, ownerID, "DashNWC", 30)
+	addMember(t, g, hh.ID, ownerID, model.RoleOwner, nil)
+
+	cashAcct := seedAccount(t, g, ownerID, "cash")
+	upsertPosition(t, g, ownerID, cashAcct.ID, usd, "500")
+	setShare(t, g, cashAcct.ID, hh.ID, model.VisibilityBalanceOnly)
+
+	dash, err := agg.Dashboard(ctx, hh.ID, household.PeriodCurrentMonth)
+	if err != nil {
+		t.Fatalf("Dashboard: %v", err)
+	}
+	if dash.NetWorth != "500" || !dash.NetWorthComplete {
+		t.Errorf("dashboard = {net_worth:%s complete:%v}, want {500 true}", dash.NetWorth, dash.NetWorthComplete)
+	}
+
+	// A stale-priced shared equity flips the headline to partial.
+	stale := seedAsset(t, g, "DNWC-"+fmt.Sprintf("%d", time.Now().UnixNano()), model.AssetKindEquity, usd)
+	insertPrice(t, g, stale, usd, "10", time.Now().Add(-30*24*time.Hour))
+	brkAcct := seedAccount(t, g, ownerID, "brk")
+	upsertPosition(t, g, ownerID, brkAcct.ID, stale, "5")
+	setShare(t, g, brkAcct.ID, hh.ID, model.VisibilityBalanceOnly)
+
+	dash, err = agg.Dashboard(ctx, hh.ID, household.PeriodCurrentMonth)
+	if err != nil {
+		t.Fatalf("Dashboard (stale): %v", err)
+	}
+	if dash.NetWorthComplete {
+		t.Error("net_worth_complete = true, want false (shared equity priced 30d ago)")
+	}
+}

--- a/frontend/src/hooks/useScopedInsights.ts
+++ b/frontend/src/hooks/useScopedInsights.ts
@@ -83,6 +83,9 @@ export type InsightsData = {
   scope: 'personal' | 'household'
   period: { from: string; to: string }
   net_worth: string
+  // false when a held/shared position had no fresh price — the headline
+  // is a partial sum (#344).
+  net_worth_complete: boolean
   income: string
   spending: string
   by_category: InsightsCategoryRow[]
@@ -176,6 +179,7 @@ async function loadPersonal(): Promise<InsightsData> {
     scope: 'personal',
     period: { from: summary.period.from, to: summary.period.to },
     net_worth: summary.net_worth,
+    net_worth_complete: summary.net_worth_complete,
     income: summary.income,
     spending: summary.spending,
     by_category: summary.by_category,
@@ -236,6 +240,7 @@ async function loadHousehold(): Promise<InsightsData> {
     scope: 'household',
     period: { from: dashboard.period.from, to: dashboard.period.to },
     net_worth: dashboard.net_worth,
+    net_worth_complete: dashboard.net_worth_complete,
     income: dashboard.income,
     spending: dashboard.spending,
     by_category: dashboard.by_category,

--- a/frontend/src/pages/InsightsPage.tsx
+++ b/frontend/src/pages/InsightsPage.tsx
@@ -186,6 +186,9 @@ function NetWorthBand({ data }: { data: InsightsData }) {
           </div>
           <div className="mt-1 text-3xl font-semibold text-gray-900">
             <AmountDisplay amount={data.net_worth} />
+            {!data.net_worth_complete && (
+              <PartialBadge title="Some assets have no recent price — this net worth is a partial sum. Try Refresh prices." />
+            )}
           </div>
           <div className="mt-1 text-xs text-gray-400">
             Income (period): <AmountDisplay amount={data.income} /> · Spending:{' '}

--- a/frontend/src/types/dashboard.ts
+++ b/frontend/src/types/dashboard.ts
@@ -3,6 +3,9 @@
 export type DashboardSummary = {
   period: { key: string; from: string; to: string }
   net_worth: string
+  // false when a held position had no fresh price — net_worth is a
+  // partial sum (#344).
+  net_worth_complete: boolean
   income: string
   spending: string
   account_count: number

--- a/frontend/src/types/householdAggregator.ts
+++ b/frontend/src/types/householdAggregator.ts
@@ -45,6 +45,9 @@ export type GoalProgressItem = {
 export type HouseholdDashboard = {
   period: HouseholdPeriod
   net_worth: string
+  // false when a shared position had no price within the valuation stale
+  // window — net_worth may rest on stale rates (#344).
+  net_worth_complete: boolean
   income: string
   spending: string
   account_count: number


### PR DESCRIPTION
Closes #344. Last correctness item of M12 (Trustworthy Overview) — with this, every monetary figure on the overview carries the #282 "no wrong-but-confident totals" contract: headline, trend, allocation, and per-account balances, in both scopes.

## What

- **Personal headline** — `/dashboard/summary` net worth no longer comes from the repo's `COALESCE(..., 0)` SQL (the `netWorthQuery` is deleted). The service derives it via `valuation.ValuePositions` over the user's positions in their primary currency — the same derivation and **same stale window** as the per-account balances (#291), so the headline and the accounts list can never silently disagree. `DashboardSummary` gains `net_worth_complete`.
- **Household headline** — `SumBalances` now also returns a completeness flag (the same windowed-`EXISTS` pattern `AccountBalances` gained in #339), with the cutoff derived from the aggregator's clock minus the valuation stale window. `HouseholdDashboard` gains `net_worth_complete`. Per-member contributions and the AI context discard the flag — the model receives the partial sum either way; flagging is a UI concern.
- **Frontend** — the Insights net-worth headline renders the `PartialBadge` in both scopes, with a tooltip pointing the user at "Refresh prices" (#338).

## Behavior change (intentional)

The personal headline previously counted **any-age** prices and silently coerced missing ones to $0. It now values through the stale-window gate: a stale/unpriced position drops out of the sum *and* the figure is flagged partial. This matches the account balances exactly, and #338's refresh makes the partial state transient.

## Tests

- Personal: `TestDashboard_Summarize_NetWorthCompleteness` — complete with priced cash; adding an unpriced asset flips the flag and the priced portion still sums.
- Household: `TestAggregator_Dashboard_NetWorthCompleteness` — complete with shared cash; a shared equity whose only price is 30 days old flips the flag.
- The opening-balance ledger-fact test now asserts net worth through the service (the repo no longer computes it).
- `make verify` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
