### PR TITLE
fix #350: acceptance fixtures vs M10+ schema drift

### DIFF
--- a/acceptance/fixtures/bootstrap.mjs
+++ b/acceptance/fixtures/bootstrap.mjs
@@ -35,8 +35,8 @@ async function upsertUser(client, persona) {
 
   const result = await client.query(
     `
-      INSERT INTO users (email, password_hash, is_admin, last_scope, default_scope, created_at, updated_at)
-      VALUES ($1, $2, $3, $4, $4, NOW(), NOW())
+      INSERT INTO users (email, password_hash, is_admin, last_scope, default_scope, primary_currency_asset_id, created_at, updated_at)
+      VALUES ($1, $2, $3, $4, $4, (SELECT id FROM assets WHERE symbol = 'USD' AND kind = 'fiat'), NOW(), NOW())
       RETURNING id
     `,
     [persona.email, hash, isAdmin, scope],
@@ -82,18 +82,23 @@ async function provisionPersonas() {
 
     const adminID = ids.get('admin')
     const existingHousehold = await client.query(
-      "SELECT id FROM households WHERE owner_id = $1 AND name = 'QA Household' AND deleted_at IS NULL ORDER BY id LIMIT 1",
+      `
+        SELECT h.id FROM households h
+        JOIN household_members m ON m.household_id = h.id
+          AND m.user_id = $1 AND m.role = 'owner' AND m.purged_at IS NULL
+        WHERE h.name = 'QA Household' AND h.deleted_at IS NULL
+        ORDER BY h.id LIMIT 1
+      `,
       [adminID],
     )
     let householdID = existingHousehold.rows[0]?.id
     if (!householdID) {
       const household = await client.query(
         `
-          INSERT INTO households (name, owner_id, grace_period_days, created_at, updated_at)
-          VALUES ('QA Household', $1, 30, NOW(), NOW())
+          INSERT INTO households (name, grace_period_days, created_at, updated_at)
+          VALUES ('QA Household', 30, NOW(), NOW())
           RETURNING id
         `,
-        [adminID],
       )
       householdID = household.rows[0]?.id
     }

--- a/acceptance/fixtures/state.mjs
+++ b/acceptance/fixtures/state.mjs
@@ -89,8 +89,8 @@ export async function createThrowawayUser({ suite, householdID, role = 'contribu
     try {
       const result = await client.query(
         `
-          INSERT INTO users (email, password_hash, is_admin, last_scope, default_scope, created_at, updated_at)
-          VALUES ($1, $2, FALSE, 'personal', 'personal', NOW(), NOW())
+          INSERT INTO users (email, password_hash, is_admin, last_scope, default_scope, primary_currency_asset_id, created_at, updated_at)
+          VALUES ($1, $2, FALSE, 'personal', 'personal', (SELECT id FROM assets WHERE symbol = 'USD' AND kind = 'fiat'), NOW(), NOW())
           RETURNING id, email
         `,
         [email, hash],
@@ -130,7 +130,10 @@ export async function deleteThrowawayUsers(suite) {
         const ids = users.rows.map((row) => row.id)
         const accounts = await client.query('SELECT id FROM accounts WHERE user_id = ANY($1::bigint[])', [ids])
         const accountIDs = accounts.rows.map((row) => row.id)
-        const households = await client.query('SELECT id FROM households WHERE owner_id = ANY($1::bigint[])', [ids])
+        const households = await client.query(
+          "SELECT household_id AS id FROM household_members WHERE user_id = ANY($1::bigint[]) AND role = 'owner'",
+          [ids],
+        )
         const householdIDs = households.rows.map((row) => row.id)
         await client.query('DELETE FROM sessions WHERE user_id = ANY($1::bigint[])', [ids])
         await client.query('DELETE FROM plaid_sync_errors WHERE user_id = ANY($1::bigint[])', [ids])
@@ -138,10 +141,12 @@ export async function deleteThrowawayUsers(suite) {
         await client.query('DELETE FROM ai_messages WHERE user_id = ANY($1::bigint[])', [ids])
         await client.query('DELETE FROM ai_messages WHERE thread_id IN (SELECT id FROM ai_threads WHERE user_id = ANY($1::bigint[]))', [ids])
         await client.query('DELETE FROM ai_threads WHERE user_id = ANY($1::bigint[])', [ids])
-        await client.query('DELETE FROM investments WHERE user_id = ANY($1::bigint[])', [ids])
         await client.query('DELETE FROM savings_goals WHERE user_id = ANY($1::bigint[])', [ids])
         await client.query('DELETE FROM budgets WHERE user_id = ANY($1::bigint[])', [ids])
         await client.query('DELETE FROM categorization_rules WHERE user_id = ANY($1::bigint[])', [ids])
+        await client.query('DELETE FROM positions WHERE user_id = ANY($1::bigint[])', [ids])
+        await client.query('DELETE FROM account_balance_observations WHERE user_id = ANY($1::bigint[])', [ids])
+        await client.query('DELETE FROM ingestion_jobs WHERE user_id = ANY($1::bigint[])', [ids])
         await client.query('UPDATE transactions SET transfer_pair_id = NULL WHERE user_id = ANY($1::bigint[])', [ids])
         await client.query('DELETE FROM transactions WHERE user_id = ANY($1::bigint[])', [ids])
         if (accountIDs.length > 0) {
@@ -154,8 +159,8 @@ export async function deleteThrowawayUsers(suite) {
           await client.query('DELETE FROM account_shares WHERE household_id = ANY($1::bigint[])', [householdIDs])
           await client.query('DELETE FROM ai_messages WHERE thread_id IN (SELECT id FROM ai_threads WHERE household_id = ANY($1::bigint[]))', [householdIDs])
           await client.query('DELETE FROM ai_threads WHERE household_id = ANY($1::bigint[])', [householdIDs])
-          await client.query('DELETE FROM shared_budgets WHERE household_id = ANY($1::bigint[])', [householdIDs])
-          await client.query('DELETE FROM shared_goals WHERE household_id = ANY($1::bigint[])', [householdIDs])
+          await client.query('DELETE FROM budgets WHERE household_id = ANY($1::bigint[])', [householdIDs])
+          await client.query('DELETE FROM savings_goals WHERE household_id = ANY($1::bigint[])', [householdIDs])
           await client.query('DELETE FROM household_invites WHERE household_id = ANY($1::bigint[])', [householdIDs])
           await client.query('DELETE FROM household_members WHERE household_id = ANY($1::bigint[])', [householdIDs])
           await client.query('DELETE FROM households WHERE id = ANY($1::bigint[])', [householdIDs])


### PR DESCRIPTION
Closes #350

The acceptance fixture loader crashed on a cold QA stack — it predates the M10 schema work:

- `users.primary_currency_asset_id` is NOT NULL since migration 000013 (the default-USD trigger was scaffolding deleted by 000014) → `upsertUser` and `createThrowawayUser` now set it to the seeded USD fiat asset.
- `households.owner_id` was dropped by #283 → QA Household lookup/creation goes through `household_members.role='owner'`.
- `deleteThrowawayUsers` cleaned tables that no longer exist (`investments`, `shared_budgets`, `shared_goals`) and missed new user-owned ones → now cleans `positions`, `account_balance_observations`, `ingestion_jobs`, and household-scoped `budgets`/`savings_goals` (ADR-0018) before deleting households.

Verified: `command make acceptance` green on a cold offbook-qa stack at `e80c3dd` — 40 passed, 4 skipped (Plaid suite, no QA sandbox creds). QA-infra only; no product code touched.

Found during the 2026-06-10 M12 QA run (ledger: Discussion #199).

🤖 Generated with [Claude Code](https://claude.com/claude-code)