### PR TITLE
fix #351: spending by-category leaks non-flow ledger rows

### DIFF
--- a/backend/internal/repository/dashboard_repo.go
+++ b/backend/internal/repository/dashboard_repo.go
@@ -155,6 +155,7 @@ func (r *dashboardRepo) Summarize(ctx context.Context, userID int64, from, to ti
 		LEFT JOIN categories c ON c.id = t.category_id
 		WHERE t.deleted_at IS NULL
 		  AND t.user_id = ?
+		  AND t.kind = 'flow'
 		  AND t.transaction_date >= ?
 		  AND t.transaction_date <  ?
 		GROUP BY t.category_id, c.name

--- a/backend/internal/service/dashboard_charts_test.go
+++ b/backend/internal/service/dashboard_charts_test.go
@@ -432,3 +432,38 @@ func TestDashboard_Summarize_NetWorthCompleteness(t *testing.T) {
 		t.Error("net_worth_complete = true, want false (BTC has no price chain)")
 	}
 }
+
+// TestDashboard_Summarize_ByCategoryExcludesNonFlowKinds: a user whose only
+// transactions are an opening balance and a paired trade (both non-'flow'
+// kinds) must see an EMPTY by-category breakdown and income=spending=0 —
+// not a bogus "Uncategorized" bucket summing the opening balance + trade
+// legs. Regression for #351: the by-category query was missing the
+// `kind = 'flow'` predicate that the income/spending query and
+// SpendByCategory already had.
+func TestDashboard_Summarize_ByCategoryExcludesNonFlowKinds(t *testing.T) {
+	svc, userID, accountID, g := newDashboardSvc(t)
+	ctx := context.Background()
+	usdID := testutil.LookupUSDAssetID(t, g)
+	btcID := testutil.LookupAssetID(t, g, "BTC", "crypto")
+
+	may := time.Date(2026, 5, 10, 0, 0, 0, 0, time.UTC)
+	// Opening balance: not spending activity.
+	seedNetWorthTxn(t, g, userID, accountID, usdID, model.KindOpeningBalance, may, "12000")
+	// Paired trade legs: buying BTC with USD. Neither leg is a flow.
+	seedNetWorthTxn(t, g, userID, accountID, usdID, model.KindTradeLeg, may, "-309.77")
+	seedNetWorthTxn(t, g, userID, accountID, btcID, model.KindTradeLeg, may, "0.01")
+
+	summary, err := svc.Summarize(ctx, userID, service.PeriodCurrentMonth)
+	if err != nil {
+		t.Fatalf("Summarize: %v", err)
+	}
+	if summary.Income != "0" {
+		t.Errorf("income = %s, want 0 (no flow transactions)", summary.Income)
+	}
+	if summary.Spending != "0" {
+		t.Errorf("spending = %s, want 0 (no flow transactions)", summary.Spending)
+	}
+	if len(summary.ByCategory) != 0 {
+		t.Errorf("by_category = %+v, want empty (opening_balance + trade_leg rows must not leak in as bogus spending)", summary.ByCategory)
+	}
+}


### PR DESCRIPTION
Closes #351

## Fix
`dashboard_repo.go`'s `Summarize` by-category query was missing `AND kind = 'flow'`. It summed every transaction kind (opening_balance, trade_leg, flow) grouped by category, so a user with manual opening balances + trades but zero flow transactions saw a bogus "Uncategorized" total in `by_category` even though `income`/`spending` correctly reported 0 — the response disagreed with itself.

Added the same `kind = 'flow'` predicate already used by:
- the income/spending query directly above it in `Summarize`
- standalone `SpendByCategory`
- household `CategoryAggregates` in `household_aggregator_repo.go` (household scope was never affected)

## TransactionCount decision
Left `TransactionCount` (personal `Summarize`) and household `PeriodTransactionCount` unfiltered by `kind`. Both feed a generic `transaction_count` field that represents overall ledger activity, not a spending-specific metric, and both scopes are already consistent with each other (both unfiltered). Filtering only the personal side would create a new personal/household inconsistency rather than fix one. Left as-is; noted here for visibility.

## Regression test
Added `TestDashboard_Summarize_ByCategoryExcludesNonFlowKinds` in `dashboard_charts_test.go`: seeds an opening-balance row + a paired trade (two trade_leg rows) with zero flow transactions, then asserts `Summarize` returns `income = 0`, `spending = 0`, and an **empty** `by_category` — mirroring the existing `seedNetWorthTxn` helper and the completeness-test style already in the file.

## Verification
`cd backend && command make verify` — contract-check, vet, lint, test (`-race -p 1`), schema-check, frontend lint + build all green. `schema-check` confirms no schema drift (this is a pure query fix, no migration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)