### PR TITLE
docs: durable delivery loop via cloud cron routine

### DIFF
--- a/docs/dev/autonomous-delivery.md
+++ b/docs/dev/autonomous-delivery.md
@@ -33,7 +33,8 @@ it is Sonnet or Opus, never Fable.
 
 ## The loop (one iteration = one shipped PR)
 
-Driven by the `/loop` skill in self-paced (no-interval) mode. Each iteration:
+The durable driver is a cloud cron routine (see **Durability** below), not the
+local `/loop` skill — but each firing runs the same iteration. Each iteration:
 
 1. **Pick** the next unchecked issue from the active epic in dependency order
    (below). Skip issues whose prerequisites are unmerged.
@@ -50,6 +51,51 @@ Driven by the `/loop` skill in self-paced (no-interval) mode. Each iteration:
 
 Pacing: the loop is quota-bound, not time-bound. Use a long fallback wake
 (1200s+) only as a heartbeat; the real signal is subagent completion.
+
+## Durability — the engine is a cloud cron routine, not the local session
+
+**The failure this section fixes:** an interactive Claude session driving the
+loop dies when the 5-hour quota cap is hit (or the laptop sleeps, or the REPL is
+closed). `ScheduleWakeup` and `CronCreate` both re-invoke *this* session and only
+fire while the local REPL is alive — so neither survives quota exhaustion. If the
+loop depends on them alone, it silently stops and never resumes.
+
+**The fix:** the durable driver is a **claude.ai cloud routine** (managed via the
+`RemoteTrigger` tool / the `/schedule` skill), created on the **bridge
+environment** so it executes against this repo's working tree with the local git
++ `gh` credentials and the local Docker/Colima Postgres that `make verify` needs.
+The cloud scheduler fires it on a wall-clock cron **independently of any local
+session**. When quota is exhausted a firing no-ops (or fails cheaply) and the
+*next* scheduled firing — after the window resets — picks up exactly where the
+last left off. That is the self-healing property the local loop lacked.
+
+Routine invariants (encoded in the routine's prompt):
+
+- **One iteration per firing.** Each firing ships *at most one* PR, then exits.
+  This bounds per-firing cost and lets quota back-pressure throttle naturally —
+  do not loop inside a single firing.
+- **Idempotent pick.** Before starting an issue, `gh pr list --state open` and
+  `git branch -a`: if a branch/PR already exists for the next issue, continue or
+  merge it rather than duplicating; if that PR is green + mergeable, merge and
+  advance; if open but red, fix forward; only then start a fresh issue. This is
+  what keeps two overlapping firings from colliding.
+- **State lives in GitHub, not the session.** The epic checklists (#383/#384/#385)
+  plus merged PRs are the source of truth for "what's done." A cold firing
+  reconstructs position from them + this file — never from prior session memory.
+- **Cadence** ≈ every 2h so each rolling 5-hour window gets ≥2 attempts; a capped
+  firing simply retries next window. Recurring routines auto-expire after 7 days —
+  re-arm (or bump the schedule) to continue a multi-week run.
+- **Model:** the routine runs as Sonnet (the workhorse tier). Issues flagged
+  Opus-design in the delivery order get their ADR/design slice written first, then
+  implemented; money/valuation correctness is never downgraded to Fable.
+- **Human-gated stops** (#362 and any owner-secret step) are done to their
+  agent-completable slice, then the routine comments on the issue and advances —
+  never blocks the loop.
+
+An interactive session may still hand-drive iterations (e.g. to burn a live quota
+window faster), but it must not run concurrently with the routine on the *same*
+issue — the idempotency guard above is the tie-breaker. The routine is the thing
+that guarantees the plan keeps moving when no one is watching.
 
 ## Delivery scope — everything up to Milestone B
 


### PR DESCRIPTION
## Why
The autonomous delivery loop stopped after the 5-hour quota cap and never resumed — because the documented driver (`/loop` + `ScheduleWakeup`/`CronCreate`) only fires while the local Claude session/REPL is alive. Quota death = silent stop.

## What
Adds a **Durability** section to `docs/dev/autonomous-delivery.md`: the durable driver is a **claude.ai cloud routine** on the bridge environment, fired on a wall-clock cron by Anthropic's scheduler independent of any local session. A capped firing no-ops; the next scheduled firing (after the window resets) resumes.

Invariants encoded in the routine prompt:
- one iteration (≤1 PR) per firing — quota back-pressure throttles naturally
- idempotent pick — guard against colliding firings via `gh pr list` / `git branch -a`
- state reconstructed from GitHub epics + merged PRs, never session memory
- ~2h cadence, Sonnet workhorse tier, human-gated issues advance rather than block

The routine itself is created out-of-band via the `/schedule` skill; this PR documents the design so it's reproducible and reviewable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)