### PR TITLE
fix #352: write manual trade prices as Tier-1 prices rows (source='trade')

### DIFF
--- a/backend/internal/service/trade_service.go
+++ b/backend/internal/service/trade_service.go
@@ -28,6 +28,12 @@ var (
 	ErrSecurityEqualsQuote = errors.New("trade asset must differ from the account's cash asset")
 )
 
+// priceSourceTrade tags price observations derived from a user-entered
+// trade (Tier-1 manual price entry, ADR-0013 §5). Distinct from provider
+// sources ('coingecko', 'frankfurter') and 'manual' (the standalone
+// set-price surface, #373) so provenance stays inspectable.
+const priceSourceTrade = "trade"
+
 // Brokerage-style accounts are the only ones that accept trades. The
 // list mirrors the position-model intent: bank-style accounts hold a
 // single cash position and don't need trade pairing.
@@ -209,9 +215,30 @@ func (s *TradeService) Record(ctx context.Context, userID, accountID int64, in R
 	err = s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		txRepo := repository.NewTransactionRepository(tx)
 		posRepo := repository.NewPositionRepository(tx)
+		priceRepo := repository.NewPriceRepository(tx)
 
 		if err := txRepo.CreateTradePair(ctx, secLeg, cashLeg); err != nil {
 			return fmt.Errorf("create trade pair: %w", err)
+		}
+
+		// Persist the user-supplied trade price as a Tier-1 price
+		// observation (source='trade') so the security position values at
+		// last-trade price with the existing staleness flagging (#352).
+		// Without this, a manually tracked equity is permanently unpriceable
+		// — there is no equity price provider (ADR-0014 ships crypto+FX only)
+		// — and its position would value at $0-but-partial forever. The price
+		// is quoted in the account's cash sleeve (in.Price is per-unit in the
+		// account's primary quote asset), which is exactly the direct hop
+		// valuation.Value tries first (asset → account quote → user currency).
+		tradePrice := &model.Price{
+			AssetID:      in.AssetID,
+			QuoteAssetID: acct.PrimaryQuoteAssetID,
+			AsOf:         in.TradeDate,
+			Price:        in.Price,
+			Source:       priceSourceTrade,
+		}
+		if err := priceRepo.Insert(ctx, tradePrice); err != nil {
+			return fmt.Errorf("insert trade price: %w", err)
 		}
 
 		// Recompute the security position from history (quantity + cost

--- a/backend/internal/service/trade_service_test.go
+++ b/backend/internal/service/trade_service_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gregwym/offbook/backend/internal/model"
 	"github.com/gregwym/offbook/backend/internal/repository"
 	"github.com/gregwym/offbook/backend/internal/service"
+	"github.com/gregwym/offbook/backend/internal/service/valuation"
 	"github.com/gregwym/offbook/backend/internal/testutil"
 )
 
@@ -105,6 +106,57 @@ func TestTradeService_Record_Buy_WritesPairAndPositions(t *testing.T) {
 		Where("user_id = ? AND account_id = ?", userID, accountID).Count(&n)
 	if n != 2 {
 		t.Errorf("got %d transactions, want 2", n)
+	}
+}
+
+// TestTradeService_Record_WritesTradePriceForValuation is the #352
+// regression: a manually recorded equity trade must write its user-entered
+// price as a Tier-1 `prices` row (source='trade') so the position values at
+// last-trade price instead of being permanently $0/partial (there is no
+// equity price provider — ADR-0014 ships only crypto + FX).
+func TestTradeService_Record_WritesTradePriceForValuation(t *testing.T) {
+	svc, userID, accountID, aapl, g := seedTradeFixture(t)
+	ctx := context.Background()
+	usdID := testutil.LookupUSDAssetID(t, g)
+	tradeDate := time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)
+
+	rec, err := svc.Record(ctx, userID, accountID, service.RecordTradeInput{
+		Kind: "buy", AssetID: aapl,
+		Quantity: decimal.NewFromInt(10), Price: decimal.NewFromInt(150),
+		TradeDate: tradeDate,
+	})
+	if err != nil {
+		t.Fatalf("record: %v", err)
+	}
+
+	// A Tier-1 price observation is written for the security quoted in the
+	// account's cash sleeve.
+	var p model.Price
+	if err := g.Where("asset_id = ? AND quote_asset_id = ? AND source = ?", aapl, usdID, "trade").
+		First(&p).Error; err != nil {
+		t.Fatalf("expected a source='trade' price row: %v", err)
+	}
+	if !p.Price.Equal(decimal.NewFromInt(150)) {
+		t.Errorf("trade price = %s, want 150", p.Price)
+	}
+	if !p.AsOf.Equal(tradeDate) {
+		t.Errorf("trade price as_of = %s, want %s", p.AsOf, tradeDate)
+	}
+
+	// Valuation now prices the equity position fresh at the trade price —
+	// never silently $0 for a fully-described manual holding.
+	val := valuation.NewService(
+		repository.NewPositionRepository(g),
+		repository.NewPriceRepository(g),
+		repository.NewAssetRepository(g),
+		repository.NewAccountRepository(g),
+	)
+	got, err := val.Value(ctx, *rec.SecurityPosition, tradeDate, usdID)
+	if err != nil {
+		t.Fatalf("value security position: %v", err)
+	}
+	if !got.Equal(decimal.NewFromInt(1500)) {
+		t.Errorf("security value = %s, want 1500", got)
 	}
 }
 


### PR DESCRIPTION
Closes #352

## What

A manually recorded equity trade now persists the user-entered per-unit price as a `prices` observation, inside the same DB transaction as the paired trade legs:

- `asset_id` = the security, `quote_asset_id` = the account's cash sleeve (`primary_quote_asset_id`)
- `as_of` = the trade date, `price` = the user-entered per-unit price
- `source` = `'trade'` (distinct from provider sources and the `'manual'` set-price surface #373)

## Why

Before this, a manually tracked equity was **permanently unpriceable**: ADR-0014 ships only crypto (CoinGecko) + FX (Frankfurter) providers, and no price route accepts equity prices. The position valued at `$0`-but-`[partial]` forever even though the user fully described the holding (repro in #352). The completeness flags (#282/#339/#344) made that honest but useless.

Valuation's direct hop (`asset → account quote → user currency`) now picks the row up with the existing staleness flagging — a last-trade price is used, flagged stale once it ages past the window, never silently coerced to `$0`.

This is the **M13 P2 minimum slice** (roadmap §M13, epic #383). The standalone Tier-1 "set price" endpoint + UI lands in M15 as #373. Plaid brokerage users already get prices from holdings sync (`source='plaid'`); the gap this closes is non-Plaid / manual users.

## Scope notes

- No schema change — `prices.source` is `TEXT NOT NULL` with no CHECK constraint; `make schema-check` clean.
- Idempotent: the price insert upserts on `(asset, quote, as_of, source)`, so re-recording the same trade updates in place.

## Tests

- `TestTradeService_Record_WritesTradePriceForValuation` — records a buy, asserts a `source='trade'` price row at the trade price/date, and asserts `valuation.Value` prices the position at `1500` (not `$0`).
- `make verify` green (contract-check, vet, lint, `-race -p 1` test suite, frontend lint + build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)