### PR TITLE
feat #358: migration safety — round-trip test + expand→migrate→contract policy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,40 @@ jobs:
         # DATABASE_URL, so parallel packages step on each other's rows.
         run: go test -race -p 1 ./...
 
+  migration-roundtrip:
+    name: Migration round-trip (up→down→up)
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: offbook
+          POSTGRES_PASSWORD: offbook
+          POSTGRES_DB: offbook_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U offbook"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+    env:
+      APP_ENV: test
+      DATABASE_URL: postgres://offbook:offbook@localhost:5432/offbook_test?sslmode=disable
+    defaults:
+      run:
+        working-directory: backend
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: backend/go.mod
+          cache-dependency-path: backend/go.sum
+      # Asserts every migration reverses cleanly and seed data re-lands (#358).
+      # Runs against the throwaway offbook_test DB — the tool refuses any other.
+      - name: Migration round-trip
+        run: go run ./cmd/migrate-roundtrip
+
   schema-check:
     name: Schema report up-to-date
     runs-on: ubuntu-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,6 +58,13 @@ pacing so an autonomous session can resume the program across quota windows.
 - NEVER `git commit --amend`, `git reset --hard`, or `git push --force` (any variant). No exceptions.
 - Fix mistakes with new commits, not history rewrites.
 
+## Migration Safety
+The pre-prod "wipe dev DBs and rebuild" era ends at M13 (#358). Once an instance holds real financial data, every schema change must be safe to take without risking that data.
+- **Expand → migrate → contract.** Never rename or drop a column/table in the same migration that stops writing to it. Split any breaking change into stages that each work against the *currently deployed* code: (1) **expand** — add the new column/table/index, backfill, and start writing both old and new (deploy); (2) **migrate** — move reads to the new shape (deploy); (3) **contract** — drop the old column/table once nothing reads it (deploy). Each stage is independently deployable and independently reversible.
+- **Destructive migrations need an explicit PR callout.** Any migration that drops or rewrites a column/table, or is otherwise not a pure additive expand, must say so in the PR description (a `**Destructive migration:**` line naming what it drops and why it's safe now). Reviewers gate on it.
+- **Down-migrations are a dev/rollback tool, not a data-recovery tool.** A `down` reverses schema for local iteration and staged rollback; it does **not** restore data a contract step deleted. **Backups** are the recovery path (`make backup`/`make restore`, #357). `make deploy` takes an automatic backup *before* migrations run for exactly this reason.
+- **Every migration ships a working `down`.** `make verify` (and CI) runs `make migrate-roundtrip` — a fresh `offbook_test` DB taken up → down → up, asserting clean completion and seed integrity. A missing or broken down file, or a seed that doesn't re-land, fails the build. Do not disable this to land a migration; fix the down file.
+
 ## Dev Dependencies
 - Run all dev infrastructure (Postgres, Redis, queues, etc.) via Docker / `docker compose`, never native installs.
 - Native installs only for language toolchains (Go, Node, etc.) — universal tooling, not project state.

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .DEFAULT_GOAL := help
 
-.PHONY: help verify acceptance qa-smoke qa-suite require-env ensure-env deploy deployed-sha down teardown auto-deploy-install auto-deploy-uninstall
+.PHONY: help verify acceptance qa-smoke qa-suite require-env ensure-env pre-deploy-backup deploy deployed-sha down teardown auto-deploy-install auto-deploy-uninstall
 
 # ─── Deploy configuration (ADR-0016) ─────────────────────────────────────────
 # Near-zero config by convention. The common case — one instance, behind
@@ -112,7 +112,23 @@ ensure-env:
 #   command make deploy                                          # dev
 #   command make deploy FLAVOR=prod                              # prod
 #   command make deploy TS_AUTHKEY=tskey-... TS_HOSTNAME=offbook # first boot
-deploy: ensure-env
+# pre-deploy-backup: migration-safety hook (#358). Every deploy that could run a
+# migration on a data-bearing instance takes a backup FIRST — down-migrations are
+# a dev/rollback tool, not a data-recovery tool; backups are the recovery path.
+# The backup implementation is the M13 `backup` target (#357). Until that target
+# exists this is a loud no-op so deploy still works, but a data-bearing instance
+# MUST NOT run migrations without it once #357 lands. First-boot instances have
+# no data yet, so a warning there is harmless.
+pre-deploy-backup:
+	@if $(MAKE) -n backup >/dev/null 2>&1; then \
+		echo "Taking pre-migration backup (migration safety, #358)…"; \
+		FLAVOR="$(FLAVOR)" ENV_FILE="$(ENV_FILE)" $(MAKE) backup; \
+	else \
+		echo "⚠️  No 'backup' target yet (#357) — skipping pre-migration backup." >&2; \
+		echo "   Do not run migrations on an instance holding real data until #357 lands." >&2; \
+	fi
+
+deploy: ensure-env pre-deploy-backup
 	@SHA="$$(git rev-parse --short HEAD)"; \
 	if [ -n "$$($(COMPOSE) ps -q tailscale 2>/dev/null)" ]; then \
 		echo "Deploying $(OFFBOOK_PROJECT) @ $$SHA from $(ENV_FILE) (app update; sidecar up)…"; \

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -19,7 +19,7 @@ HEALTH_URL  = http://localhost:$(PORT)/api/v1/health
 # DATABASE_URL on either if you need to point at a non-local Postgres.
 TEST_DATABASE_URL ?= postgres://offbook:offbook@localhost:5432/offbook_test?sslmode=disable
 
-.PHONY: help dev stop restart smoke test test-v test-fast lint vet build verify contract-check schema schema-check clean routes logs
+.PHONY: help dev stop restart smoke test test-v test-fast lint vet build verify contract-check schema schema-check migrate-roundtrip clean routes logs
 
 # Checked-in schema report (#304). Regenerated from the migrated DB by
 # cmd/schema-report; CI enforces it via schema-check.
@@ -40,6 +40,7 @@ help:
 	@echo "make contract-check - assert every frontend apiClient URL maps to a registered backend route (#273)"
 	@echo "make schema     - regenerate $(SCHEMA_FILE) from the migrated DB (#304)"
 	@echo "make schema-check - fail if $(SCHEMA_FILE) is stale vs the migrations (CI mirror)"
+	@echo "make migrate-roundtrip - assert every migration reverses cleanly: up->down->up + seed integrity (#358)"
 	@echo "make routes     - print routes from the last server log"
 	@echo "make logs       - tail $(LOGFILE)"
 
@@ -111,6 +112,8 @@ verify:
 	@$(MAKE) test
 	@echo "== schema check =="
 	@$(MAKE) schema-check
+	@echo "== migration round-trip =="
+	@$(MAKE) migrate-roundtrip
 	@if [ -d ../frontend ] && [ -f ../frontend/package.json ]; then \
 		echo "== frontend lint =="; \
 		(cd ../frontend && pnpm lint) || exit 1; \
@@ -144,6 +147,14 @@ schema:
 schema-check:
 	@APP_ENV=test DATABASE_URL='$(TEST_DATABASE_URL)' go run ./cmd/migrate up >/dev/null
 	@APP_ENV=test DATABASE_URL='$(TEST_DATABASE_URL)' go run ./cmd/schema-report --check --out $(SCHEMA_FILE)
+
+# Migration reversibility gate (#358). Runs against offbook_test only (the tool
+# refuses any other DB — it drops every table): reset → up → down → up, asserting
+# clean completion and that seed data (system categories, plaid_category_map)
+# re-lands. This is what makes down-migrations a trustworthy rollback tool and
+# ends the pre-prod "wipe and rebuild" era. It leaves the DB at head.
+migrate-roundtrip:
+	@APP_ENV=test DATABASE_URL='$(TEST_DATABASE_URL)' go run ./cmd/migrate-roundtrip
 
 logs:
 	@tail -f $(LOGFILE)

--- a/backend/cmd/migrate-roundtrip/main.go
+++ b/backend/cmd/migrate-roundtrip/main.go
@@ -1,0 +1,168 @@
+// migrate-roundtrip exercises the full migration set for reversibility (#358).
+//
+// It runs, against the test DB only:
+//
+//	reset (down-all) → up → assert seed → down-all → assert empty → up → assert seed
+//
+// This is the mechanical enforcement of the expand→migrate→contract policy:
+// every migration must ship a working down file, and a fresh up must leave the
+// schema at head with seed data intact. A missing or broken down migration, or
+// a seed that doesn't re-apply cleanly, fails the build.
+//
+// The sequence is DESTRUCTIVE (down-all drops every table), so it refuses to run
+// against anything but the test DB. CI runs it against the same offbook_test
+// Postgres the backend tests use; `make verify` runs it locally before the
+// suite. It ends with the DB fully migrated, so subsequent steps see head.
+package main
+
+import (
+	"database/sql"
+	"errors"
+	"flag"
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/golang-migrate/migrate/v4"
+	migratepg "github.com/golang-migrate/migrate/v4/database/postgres"
+	_ "github.com/golang-migrate/migrate/v4/source/file"
+	_ "github.com/lib/pq"
+
+	"github.com/gregwym/offbook/backend/internal/config"
+)
+
+// systemCategoryCount is the number of seeded system categories (migration
+// 000002). The round-trip asserts every one re-appears after a fresh up.
+const systemCategoryCount = 20
+
+func main() {
+	path := flag.String("path", "migrations", "migrations directory")
+	flag.Parse()
+
+	cfg := config.MustLoad()
+	if cfg.DatabaseURL == "" {
+		log.Fatal("DATABASE_URL is empty")
+	}
+	// Hard guard: down-all wipes the entire schema. Only ever run this against
+	// the test DB. Both signals must agree with "test" so a stray APP_ENV or a
+	// mislabeled URL can't nuke a dev/prod database.
+	if cfg.AppEnv != config.AppEnvTest {
+		log.Fatalf("migrate-roundtrip refuses to run with APP_ENV=%q — it drops every table; run with APP_ENV=test", cfg.AppEnv)
+	}
+	if !strings.Contains(cfg.DatabaseURL, "_test") {
+		log.Fatalf("migrate-roundtrip refuses to run: DATABASE_URL does not target a *_test database")
+	}
+
+	db, err := sql.Open("postgres", cfg.DatabaseURL)
+	if err != nil {
+		log.Fatalf("sql.Open: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	// 1. Fresh slate, BEFORE building the migrator. The test DB persists across
+	//    runs and may carry rows from a prior suite (or a half-migrated state),
+	//    so hard-drop the schema rather than migrate-down to it. This measures
+	//    migration reversibility on the canonical empty→up→down→up path the AC
+	//    asks for — not "can we reverse whatever fixtures happen to be lying
+	//    around", which depends on residual data and would flake. The reset also
+	//    removes golang-migrate's schema_migrations table, so the migrator must
+	//    be constructed afterward (WithInstance ensures that table at build time).
+	reset(db)
+
+	m, err := newMigrator(db, *path)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// 2. All up, from empty. Asserts every up migration applies and seeds land.
+	step("apply all migrations (up)", m.Up)
+	assertAtHead(m)
+	assertSeedIntact(db)
+
+	// 3. All down. Asserts every migration has a working, complete down file.
+	step("roll back all migrations (down-all)", m.Down)
+	assertEmpty(db)
+
+	// 4. All up again. Asserts re-migration from empty is clean and idempotent.
+	step("re-apply all migrations (up)", m.Up)
+	assertAtHead(m)
+	assertSeedIntact(db)
+
+	log.Println("migrate-roundtrip: OK — up→down→up clean, seed integrity verified")
+}
+
+// reset drops the entire public schema for a genuinely empty starting point,
+// including golang-migrate's schema_migrations table. Safe here because the
+// caller already proved this is the *_test DB.
+func reset(db *sql.DB) {
+	log.Print("→ reset to a fresh, empty schema (DROP SCHEMA public CASCADE)")
+	if _, err := db.Exec(`DROP SCHEMA public CASCADE; CREATE SCHEMA public;`); err != nil {
+		log.Fatalf("reset schema: %v", err)
+	}
+}
+
+// step runs one migrate action and fails loudly on any error except
+// ErrNoChange (a legitimate no-op).
+func step(label string, action func() error) {
+	log.Printf("→ %s", label)
+	if err := action(); err != nil && !errors.Is(err, migrate.ErrNoChange) {
+		log.Fatalf("%s: %v", label, err)
+	}
+}
+
+// assertAtHead confirms the migrator reports the head version, not dirty.
+func assertAtHead(m *migrate.Migrate) {
+	v, dirty, err := m.Version()
+	if err != nil {
+		log.Fatalf("version after up: %v", err)
+	}
+	if dirty {
+		log.Fatalf("schema is dirty at version %d after up — a migration failed partway", v)
+	}
+	log.Printf("  at version %d (clean)", v)
+}
+
+// assertSeedIntact confirms the seed migrations re-populated after a fresh up.
+func assertSeedIntact(db *sql.DB) {
+	var cats int
+	if err := db.QueryRow(`SELECT count(*) FROM categories WHERE is_system AND deleted_at IS NULL`).Scan(&cats); err != nil {
+		log.Fatalf("count system categories: %v", err)
+	}
+	if cats != systemCategoryCount {
+		log.Fatalf("seed integrity: expected %d system categories, found %d", systemCategoryCount, cats)
+	}
+
+	var mappings int
+	if err := db.QueryRow(`SELECT count(*) FROM plaid_category_map`).Scan(&mappings); err != nil {
+		log.Fatalf("count plaid_category_map: %v", err)
+	}
+	if mappings == 0 {
+		log.Fatal("seed integrity: plaid_category_map is empty after up")
+	}
+	log.Printf("  seed intact: %d system categories, %d plaid category mappings", cats, mappings)
+}
+
+// assertEmpty confirms down-all left no schema behind — the version is nil and
+// a representative domain table is gone.
+func assertEmpty(db *sql.DB) {
+	var reg sql.NullString
+	if err := db.QueryRow(`SELECT to_regclass('public.categories')`).Scan(&reg); err != nil {
+		log.Fatalf("to_regclass after down-all: %v", err)
+	}
+	if reg.Valid {
+		log.Fatalf("down-all left table %q behind — a down migration is incomplete", reg.String)
+	}
+	log.Print("  schema empty after down-all")
+}
+
+func newMigrator(db *sql.DB, path string) (*migrate.Migrate, error) {
+	driver, err := migratepg.WithInstance(db, &migratepg.Config{})
+	if err != nil {
+		return nil, fmt.Errorf("migrate driver: %w", err)
+	}
+	m, err := migrate.NewWithDatabaseInstance("file://"+path, "postgres", driver)
+	if err != nil {
+		return nil, fmt.Errorf("migrate.New: %w", err)
+	}
+	return m, nil
+}


### PR DESCRIPTION
Closes #358

## What
End the pre-prod "wipe dev DBs and rebuild" era (M13 / epic #383). Make every schema change safe to take on an instance holding real financial data.

- **Migration round-trip test** (`backend/cmd/migrate-roundtrip`): against `offbook_test` only, hard-resets the schema then runs **up → down → up**, asserting clean completion, head version (not dirty), and **seed integrity** (20 system categories + non-empty `plaid_category_map`) after each up. It refuses to run against any non-`*_test` DB because it drops every table. This mechanically enforces that every migration ships a *working, complete* down file — a missing/broken down or a seed that doesn't re-land fails the build.
- Wired into `make verify` (new `migrate-roundtrip` target) and a new **CI job** `migration-roundtrip` on the same `offbook_test` Postgres service the backend tests use.
- **`make deploy` takes an automatic backup before migrations** via a guarded `pre-deploy-backup` hook. The backup implementation is #357's `make backup`; until that lands the hook is a loud no-op, and once `backup` exists the hook invokes it automatically (this PR wires the seam #357 completes — honoring the M13 delivery order where #358 precedes #357).
- **AGENTS.md → Migration Safety**: expand→migrate→contract policy; destructive migrations require an explicit PR callout; down-migrations are a dev/rollback tool, **not** a data-recovery tool (backups are the recovery path).

## Acceptance criteria
- [x] AGENTS.md policy: expand→migrate→contract; destructive migrations flagged in PR.
- [x] `make deploy` takes an automatic backup before running migrations (reuses the #357 backup target via a forward-compatible hook).
- [x] `make verify` + CI gain a fresh-DB up→down→up round-trip asserting clean completion and seed integrity.
- [x] Docs note down-migrations are a dev/rollback tool, not data recovery.

## Verification
`command make verify` green locally (includes the new round-trip step, backend `-race -p 1` tests, lint, schema-check, frontend lint+build). The round-trip also surfaced that all 26 existing down migrations reverse cleanly on a fresh DB.

## Note
No new migration in this PR, so `docs/db/schema.md` is unchanged (schema-check green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)