### PR TITLE
feat #357: backups & restore — nightly pg_dump, retention, restore-verify

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,6 +37,23 @@ MIGRATIONS_PATH=migrations
 # unset when your auth key already auto-applies a tag.
 # TS_EXTRA_ARGS=
 
+# ─── Backups (#357) — see docs/ops/backup-restore.md ─────────────────────────
+# Nightly pg_dump backups. Sensible defaults; all optional. `command make backup`
+# runs on demand, `command make backup-install` schedules it nightly.
+#
+# Retention — keep the newest N dailies + one dump per week for M weeks:
+# BACKUP_KEEP_DAILY=7
+# BACKUP_KEEP_WEEKLY=4
+#
+# Off-host copy (OPT-IN; owner provides the target + credentials). Unset ⇒
+# on-host only. rclone reads its own config; restic reads RESTIC_PASSWORD etc.
+# BACKUP_REMOTE=rclone:myremote:offbook-backups
+# BACKUP_REMOTE=restic:/srv/restic-repo
+#
+# Failure-notification seam (for the M13 notifier, #360). A command that takes
+# the failure message as $1; fired when a backup or its verification fails.
+# BACKUP_NOTIFY_CMD=
+
 # Auth (required from M2.5+). `make deploy` generates this for you on first
 # boot; set it by hand only for non-deploy runs. Generate with: openssl rand -hex 32
 #

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,9 @@ frontend/dist/
 # Database
 data/
 
+# Backups — pg_dump archives (#357). Never commit real data dumps.
+backups/
+
 # IDE
 .idea/
 .vscode/

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .DEFAULT_GOAL := help
 
-.PHONY: help verify acceptance qa-smoke qa-suite require-env ensure-env pre-deploy-backup deploy deployed-sha down teardown auto-deploy-install auto-deploy-uninstall
+.PHONY: help verify acceptance qa-smoke qa-suite require-env ensure-env pre-deploy-backup deploy deployed-sha down teardown auto-deploy-install auto-deploy-uninstall backup restore backup-verify backup-list backup-install backup-uninstall
 
 # ─── Deploy configuration (ADR-0016) ─────────────────────────────────────────
 # Near-zero config by convention. The common case — one instance, behind
@@ -43,6 +43,19 @@ OFFBOOK_FILES := $(or $(shell sed -n 's/^OFFBOOK_COMPOSE_FILES=//p' $(ENV_FILE) 
 # with the env file as the interpolation/secret source.
 COMPOSE := docker compose --env-file $(ENV_FILE) -p $(OFFBOOK_PROJECT) $(foreach f,$(OFFBOOK_FILES),-f $(f))
 
+# ─── Backup configuration (#357) ─────────────────────────────────────────────
+# Dumps land here, deliberately OUTSIDE the postgres data volume (so losing the
+# volume never loses the backups). Per-project so dev and prod don't mix.
+# Retention: keep the newest N dailies + one dump per week for M weeks.
+BACKUP_DIR ?= backups/$(OFFBOOK_PROJECT)
+BACKUP_KEEP_DAILY ?= 7
+BACKUP_KEEP_WEEKLY ?= 4
+# Exported to the infra/backup scripts so they can reach THIS instance's
+# postgres container without re-deriving the compose invocation.
+BACKUP_ENV = OFFBOOK_COMPOSE='$(COMPOSE)' OFFBOOK_PROJECT='$(OFFBOOK_PROJECT)' \
+	BACKUP_DIR='$(BACKUP_DIR)' BACKUP_KEEP_DAILY='$(BACKUP_KEEP_DAILY)' \
+	BACKUP_KEEP_WEEKLY='$(BACKUP_KEEP_WEEKLY)'
+
 ACCEPTANCE_DIR := acceptance
 ACCEPTANCE_BASE_URL ?= http://localhost:15173
 ACCEPTANCE_API_URL ?= http://localhost:18000/api/v1
@@ -61,6 +74,12 @@ help:
 	@printf '%s\n' '  command make teardown [FLAVOR=prod]      Destroy an instance: containers + volumes (DB + tailnet identity).'
 	@printf '%s\n' '  command make auto-deploy-install         Install the user-level systemd poll-and-redeploy timer.'
 	@printf '%s\n' '  command make auto-deploy-uninstall       Remove the auto-deploy timer.'
+	@printf '%s\n' '  command make backup [FLAVOR=prod]        Dump the DB now (+ prune, + off-host if configured).'
+	@printf '%s\n' '  command make backup-verify               Prove the latest dump restores (into a scratch DB).'
+	@printf '%s\n' '  command make restore BACKUP=<file>       Recover the DB from a dump (destructive; typed confirm).'
+	@printf '%s\n' '  command make backup-list                 List the dumps on hand for this instance.'
+	@printf '%s\n' '  command make backup-install              Install the user-level nightly backup timer.'
+	@printf '%s\n' '  command make backup-uninstall            Remove the nightly backup timer.'
 	@printf '%s\n' ''
 	@printf '%s\n' 'Backend-only targets live in backend/Makefile; run them from backend/ with command make <target>.'
 
@@ -112,20 +131,18 @@ ensure-env:
 #   command make deploy                                          # dev
 #   command make deploy FLAVOR=prod                              # prod
 #   command make deploy TS_AUTHKEY=tskey-... TS_HOSTNAME=offbook # first boot
-# pre-deploy-backup: migration-safety hook (#358). Every deploy that could run a
-# migration on a data-bearing instance takes a backup FIRST — down-migrations are
-# a dev/rollback tool, not a data-recovery tool; backups are the recovery path.
-# The backup implementation is the M13 `backup` target (#357). Until that target
-# exists this is a loud no-op so deploy still works, but a data-bearing instance
-# MUST NOT run migrations without it once #357 lands. First-boot instances have
-# no data yet, so a warning there is harmless.
+# pre-deploy-backup: migration-safety hook (#358), backed by the #357 backup
+# target. Every deploy of a data-bearing instance takes a backup FIRST — a deploy
+# can run a migration, and down-migrations are a dev/rollback tool, not a
+# data-recovery tool; backups are the recovery path. On FIRST boot the postgres
+# service isn't up yet (nothing to back up), so this skips cleanly; on an update
+# it backs up and a failure aborts the deploy (don't migrate what you can't restore).
 pre-deploy-backup:
-	@if $(MAKE) -n backup >/dev/null 2>&1; then \
-		echo "Taking pre-migration backup (migration safety, #358)…"; \
+	@if [ -n "$$($(COMPOSE) ps -q postgres 2>/dev/null)" ]; then \
+		echo "Taking pre-migration backup (migration safety, #357/#358)…"; \
 		FLAVOR="$(FLAVOR)" ENV_FILE="$(ENV_FILE)" $(MAKE) backup; \
 	else \
-		echo "⚠️  No 'backup' target yet (#357) — skipping pre-migration backup." >&2; \
-		echo "   Do not run migrations on an instance holding real data until #357 lands." >&2; \
+		echo "First boot / postgres not running — nothing to back up before deploy."; \
 	fi
 
 deploy: ensure-env pre-deploy-backup
@@ -187,6 +204,43 @@ auto-deploy-install:
 
 auto-deploy-uninstall:
 	@OFFBOOK_FLAVOR="$(FLAVOR)" infra/auto-deploy/uninstall.sh
+
+# ─── Backups & restore (#357) ────────────────────────────────────────────────
+# backup: dump this instance's DB (pg_dump -Fc) to $(BACKUP_DIR), prune old
+# dumps, and (if BACKUP_REMOTE is set) copy off-host. Runs nightly via the
+# offbook-backup@<flavor>.timer; run it by hand any time before risky changes.
+backup: require-env
+	@$(BACKUP_ENV) infra/backup/backup.sh
+
+# restore: recover the DB from a dump. DESTRUCTIVE — drops & recreates the live
+# database. Guarded by a typed confirmation (skip with FORCE=1).
+#   command make restore BACKUP=backups/offbook/offbook-YYYYmmdd-HHMMSS.dump
+restore: require-env
+	@test -n "$(BACKUP)" || { echo "Set BACKUP=<file>. List them: command make backup-list" >&2; exit 2; }
+	@test -f "$(BACKUP)" || { echo "Backup file '$(BACKUP)' not found." >&2; exit 2; }
+	@if [ -z "$(FORCE)" ]; then \
+		printf '⚠️  This REPLACES the %s database with %s (all current data is lost).\n' "$(OFFBOOK_PROJECT)" "$(BACKUP)"; \
+		printf 'Type the project name (%s) to confirm: ' "$(OFFBOOK_PROJECT)"; \
+		read ans; [ "$$ans" = "$(OFFBOOK_PROJECT)" ] || { echo "Aborted."; exit 1; }; \
+	fi
+	@$(BACKUP_ENV) infra/backup/restore.sh "$(BACKUP)"
+
+# backup-verify: prove the LATEST dump restores — into a throwaway scratch DB,
+# never the live one. An unrestored backup is not a backup. Part of the nightly run.
+backup-verify: require-env
+	@$(BACKUP_ENV) infra/backup/verify.sh $(BACKUP)
+
+# backup-list: show the dumps on hand for this instance, newest last.
+backup-list:
+	@ls -lh "$(BACKUP_DIR)"/$(OFFBOOK_PROJECT)-*.dump 2>/dev/null || echo "No backups yet in $(BACKUP_DIR)."
+
+# backup-install / -uninstall: manage the user-level nightly backup timer for
+# this FLAVOR (mirrors auto-deploy). No file editing, no sudo. See infra/backup/README.md.
+backup-install:
+	@OFFBOOK_FLAVOR="$(FLAVOR)" infra/backup/install.sh
+
+backup-uninstall:
+	@OFFBOOK_FLAVOR="$(FLAVOR)" infra/backup/uninstall.sh
 
 acceptance:
 	@./scripts/qa-assert-role.sh

--- a/docs/ops/backup-restore.md
+++ b/docs/ops/backup-restore.md
@@ -1,0 +1,177 @@
+# Backup & Restore Runbook
+
+Offbook keeps every account, transaction, budget, and household in a single
+Postgres database. Losing that volume — disk failure, a bad migration, a
+fat-fingered `make teardown` — loses everything unless there's a backup. This
+runbook is the recovery path: **you should be able to restore last night's state
+by following these steps alone, no improvisation.**
+
+Scope: nightly logical backups (`pg_dump`) with retention and automated
+restore-verification. Out of scope (future options, see bottom): WAL archiving /
+point-in-time recovery, multi-host HA.
+
+## What the backup is
+
+- A per-instance `pg_dump -Fc` (custom format: compressed, restorable with
+  `pg_restore`) of the instance's database.
+- Written to `backups/<project>/` on the **host**, deliberately **outside** the
+  Postgres data volume — so losing the volume never loses the backups with it.
+- File name: `<project>-YYYYmmdd-HHMMSS.dump` (e.g. `offbook-prod-20260710-023012.dump`).
+- `<project>` is the compose project for the flavor: `offbook` (dev) or
+  `offbook-prod` (prod). Dev and prod back up to separate directories.
+
+## Taking a backup
+
+```sh
+command make backup                # dev instance (project offbook)
+command make backup FLAVOR=prod    # prod instance (project offbook-prod)
+```
+
+This dumps the DB, prunes old dumps per the retention policy, and — if an
+off-host target is configured — copies the new dump off-host. It requires the
+instance's Postgres to be running (`command make deploy` first).
+
+`command make deploy` also takes a backup **automatically before it runs**, so
+every update of a data-bearing instance is preceded by a fresh dump (migration
+safety, [AGENTS.md § Migration Safety](../../AGENTS.md)). First boot has no data
+yet, so that pre-deploy backup is skipped cleanly.
+
+List what's on hand:
+
+```sh
+command make backup-list                 # dev
+command make backup-list FLAVOR=prod     # prod
+```
+
+## Nightly schedule
+
+Install a user-level systemd timer (mirrors the auto-deploy timer — no sudo, no
+editing checked-in files):
+
+```sh
+command make backup-install              # dev,  offbook-backup@dev.timer
+command make backup-install FLAVOR=prod  # prod, offbook-backup@prod.timer
+```
+
+It fires nightly at ~02:30 (randomized delay so multiple instances don't dump at
+once), runs `make backup` then `make backup-verify`, and is `Persistent=true`
+(a missed run catches up after the host wakes). Inspect it:
+
+```sh
+systemctl --user list-timers 'offbook-backup@*'
+journalctl --user -u offbook-backup@prod -f
+systemctl --user start offbook-backup@prod.service   # run now
+```
+
+Remove it with `command make backup-uninstall [FLAVOR=prod]`.
+
+On a host without systemd, run `command make backup` from cron instead.
+
+## Retention
+
+Grandfather-father-son: keep the newest **N dailies** plus one dump per ISO week
+for the most-recent **M weeks**. Defaults: `BACKUP_KEEP_DAILY=7`,
+`BACKUP_KEEP_WEEKLY=4` (≈ a month of history in ~11 dumps). Override in the
+instance env file (`.env` / `.env.prod`) or on the command line:
+
+```sh
+command make backup BACKUP_KEEP_DAILY=14 BACKUP_KEEP_WEEKLY=8
+```
+
+## Restore-verification (an unrestored backup is not a backup)
+
+```sh
+command make backup-verify               # verifies the latest dev dump
+command make backup-verify FLAVOR=prod   # verifies the latest prod dump
+```
+
+This restores the **latest** dump into a throwaway scratch database
+(`<db>_restore_check`), asserts the schema and seed data survived (a
+`schema_migrations` version exists and isn't dirty; ≥ 20 system categories), then
+drops the scratch DB. It **never touches the live database**, so it is safe to
+run on a schedule — the nightly timer runs it after every backup.
+
+## Restoring (disaster recovery)
+
+**This is destructive**: it drops and recreates the live database, replacing all
+current data with the dump's contents. Do it deliberately.
+
+1. Pick the dump to restore:
+
+   ```sh
+   command make backup-list FLAVOR=prod
+   ```
+
+2. (Recommended) stop the app so nothing races the restore — Postgres can stay
+   up; the restore terminates stray connections itself:
+
+   ```sh
+   command make down FLAVOR=prod     # or leave the stack up; see note below
+   ```
+
+   If you `down` the whole stack, bring **only Postgres** back up before
+   restoring, or skip `down` and restore against the running stack (the backend
+   will error until you redeploy in step 4 — that's fine).
+
+3. Restore. You'll be asked to type the project name to confirm (skip with
+   `FORCE=1` in automation):
+
+   ```sh
+   command make restore FLAVOR=prod BACKUP=backups/offbook-prod/offbook-prod-20260710-023012.dump
+   ```
+
+4. Restart the backend so it reconnects to the fresh database:
+
+   ```sh
+   command make deploy FLAVOR=prod
+   ```
+
+5. Sanity-check: open the app, confirm accounts / transactions / balances look
+   like last night. `GET /api/v1/health` should be `ok`.
+
+### Recovering from a *lost volume*
+
+If the Postgres volume itself is gone (disk failure, `make teardown`):
+
+1. Recreate the stack — `command make deploy FLAVOR=prod` brings up a fresh,
+   empty, migrated database.
+2. Run the restore (steps 3–4 above) with your latest dump.
+3. If you keep off-host copies and the local `backups/` dir was on the lost
+   disk, pull the dump back from the off-host target first (see below).
+
+## Off-host copies (optional, opt-in)
+
+An on-host backup survives a lost volume but **not** total host loss. To close
+that gap, set `BACKUP_REMOTE` in the instance env file to an rclone or restic
+target; each `make backup` then copies the new dump off-host. Unset ⇒ on-host
+only (the default).
+
+```sh
+# .env.prod
+BACKUP_REMOTE=rclone:myremote:offbook-backups   # rclone remote:path
+# or
+BACKUP_REMOTE=restic:/srv/restic-repo           # restic repository
+```
+
+The remote and its credentials are yours to provision — Offbook never invents a
+target. `rclone` reads its own config; `restic` reads `RESTIC_PASSWORD` etc. from
+the environment. Restore from off-host by pulling the `.dump` back into
+`backups/<project>/` (`rclone copy` / `restic restore`) and running
+`command make restore BACKUP=<file>` as usual.
+
+## Failure notifications
+
+`make backup` / the nightly runner exit non-zero on any failure, so systemd
+records the failure in the journal. Backup/verify failure is also wired to the
+M13 notifier via a seam: set `BACKUP_NOTIFY_CMD` to a command that takes the
+message as `$1` and it fires on failure. When the notifier (#360) lands, point
+`BACKUP_NOTIFY_CMD` at it (or replace the seam body in
+`infra/backup/run.sh`) — no other change needed.
+
+## Future options (not implemented)
+
+- **Point-in-time recovery (WAL archiving):** continuous WAL shipping +
+  base backups for recovery to an arbitrary second, not just the last nightly
+  dump. Warranted once RPO needs to drop below ~24h.
+- **Multi-host HA / streaming replication:** a warm standby for failover.
+  Out of scope for the single-host Tailscale deployment model (ADR-0016).

--- a/infra/backup/README.md
+++ b/infra/backup/README.md
@@ -1,0 +1,38 @@
+# infra/backup
+
+Nightly `pg_dump` backups with retention and automated restore-verification for
+each Offbook instance. User-facing docs — how to back up, restore, schedule, and
+recover — live in **[docs/ops/backup-restore.md](../../docs/ops/backup-restore.md)**.
+This file is the implementation map.
+
+## Pieces
+
+| File | Role |
+|---|---|
+| `lib.sh` | Sourced helpers. Parses `$OFFBOOK_COMPOSE` into the compose invocation and runs commands inside the `postgres` container (`pg_sh`, `db_name`, `db_user`, `ensure_postgres_up`). |
+| `backup.sh` | Dump the live DB to `$BACKUP_DIR` (`pg_dump -Fc`), then prune + optional off-host copy. `command make backup`. |
+| `prune.sh` | Retention only (pure filesystem; no DB). Keeps N dailies + one dump per week for M weeks. Independently testable. |
+| `offhost.sh` | Opt-in off-host copy seam (rclone/restic via `$BACKUP_REMOTE`). No-op when unset. |
+| `restore.sh` | Drop + recreate the live DB and `pg_restore` a chosen dump. `command make restore BACKUP=…` (the Makefile adds the confirm prompt). |
+| `verify.sh` | Restore the latest dump into a throwaway scratch DB and sanity-check it, then drop it. Never touches the live DB. `command make backup-verify`. |
+| `run.sh` | Nightly entrypoint the timer fires: `make backup` then `make backup-verify`, with a notifier-on-failure seam (`$BACKUP_NOTIFY_CMD`, for #360). |
+| `offbook-backup@.{service,timer}` | User-level templated systemd units (instance name = FLAVOR). Rendered/installed by `install.sh`. |
+| `install.sh` / `uninstall.sh` | Manage the per-FLAVOR timer. `command make backup-install [FLAVOR=prod]`. |
+
+## Design notes
+
+- **Convention-agnostic:** the scripts never re-derive the compose invocation.
+  The Makefile owns it (it varies by `FLAVOR`) and passes it in as
+  `$OFFBOOK_COMPOSE`; the scripts word-split it into a command array. Point
+  `OFFBOOK_COMPOSE` at any compose project with a `postgres` service and the
+  scripts work — which is exactly how they're tested against a throwaway stack.
+- **Container-side DB ops:** dumps/restores run inside the `postgres` container
+  via `docker compose exec`, so they always use the container's own
+  `$POSTGRES_USER`/`$POSTGRES_DB` and a client binary matching the server — no
+  host `psql` install, no hard-coded DB name.
+- **Portable bash:** no `mapfile` / associative arrays, so the scripts run on the
+  Linux deployment hosts *and* a macOS (bash 3.2) dev box. `prune.sh`'s ISO-week
+  bucketing uses GNU `date -d` and degrades to "keep newest N+M" without it.
+- **Mirrors `infra/auto-deploy`:** same templated-unit + install-script pattern,
+  same single-flight `flock`, same "call back into `make`" approach — so the two
+  timers are operated identically.

--- a/infra/backup/backup.sh
+++ b/infra/backup/backup.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Dump one Offbook instance's database to a compressed, restorable archive,
+# then apply retention and (optionally) copy off-host. This is the primitive
+# `command make backup` runs; the nightly timer runs it via run.sh.
+#
+# The dump is taken inside the postgres container with pg_dump -Fc (custom
+# format — compressed, restorable by pg_restore, forward-compatible across minor
+# server versions). It is written to BACKUP_DIR on the HOST, deliberately OUTSIDE
+# the postgres data volume, so losing that volume never loses the backups too.
+#
+# Env (all provided by the Makefile, with defaults):
+#   OFFBOOK_COMPOSE     compose invocation for this instance (required)
+#   OFFBOOK_PROJECT     compose project name, used in the filename (required)
+#   BACKUP_DIR          where dumps land (default: backups/<project>)
+#   BACKUP_KEEP_DAILY   most-recent dumps kept unconditionally (default: 7)
+#   BACKUP_KEEP_WEEKLY  additional ISO-weeks kept, one dump each (default: 4)
+set -euo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=infra/backup/lib.sh
+. "$HERE/lib.sh"
+_init_compose
+
+PROJECT="${OFFBOOK_PROJECT:?OFFBOOK_PROJECT required}"
+BACKUP_DIR="${BACKUP_DIR:-backups/$PROJECT}"
+KEEP_DAILY="${BACKUP_KEEP_DAILY:-7}"
+KEEP_WEEKLY="${BACKUP_KEEP_WEEKLY:-4}"
+
+ensure_postgres_up
+mkdir -p "$BACKUP_DIR"
+
+ts="$(date +%Y%m%d-%H%M%S)"
+out="$BACKUP_DIR/${PROJECT}-${ts}.dump"
+tmp="$out.partial"
+
+echo "Backing up '$(db_name)' (project $PROJECT) → $out"
+# Write to a .partial first so an interrupted dump never masquerades as a good
+# backup (retention and restore only ever see complete .dump files).
+if ! pg_sh 'pg_dump -U "$POSTGRES_USER" -Fc "$POSTGRES_DB"' > "$tmp"; then
+	rm -f "$tmp"
+	echo "error: pg_dump failed" >&2
+	exit 1
+fi
+if [ ! -s "$tmp" ]; then
+	rm -f "$tmp"
+	echo "error: pg_dump produced an empty file" >&2
+	exit 1
+fi
+mv "$tmp" "$out"
+echo "Wrote $(du -h "$out" | cut -f1) → $out"
+
+"$HERE/prune.sh" "$BACKUP_DIR" "$PROJECT" "$KEEP_DAILY" "$KEEP_WEEKLY"
+
+# Off-host copy is an opt-in seam (owner supplies the remote + credentials).
+# No-op with a note when unconfigured — never invents a target.
+"$HERE/offhost.sh" "$out" || {
+	echo "warning: off-host copy step reported a failure (backup itself is intact)." >&2
+}
+
+echo "backup OK"

--- a/infra/backup/install.sh
+++ b/infra/backup/install.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Install the user-level nightly backup timer for one FLAVOR.
+# No sudo, no editing checked-in files. Re-runnable (idempotent).
+#
+#   command make backup-install              # dev
+#   command make backup-install FLAVOR=prod  # prod
+set -euo pipefail
+
+FLAVOR="${OFFBOOK_FLAVOR:-${FLAVOR:-dev}}"
+REPO="$(git -C "$(dirname "$0")" rev-parse --show-toplevel)"
+UNIT_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/systemd/user"
+
+if ! command -v systemctl >/dev/null 2>&1; then
+	echo "error: systemctl not found. The backup timer needs systemd (Linux host)." >&2
+	echo "       On a non-systemd host, run 'command make backup' from cron instead." >&2
+	exit 1
+fi
+
+mkdir -p "$UNIT_DIR"
+
+# Render the templated service with THIS checkout's absolute path, copy the
+# timer verbatim. Shared by every flavor (the instance name carries the flavor).
+sed "s|__OFFBOOK_REPO__|$REPO|g" \
+	"$REPO/infra/backup/offbook-backup@.service" \
+	> "$UNIT_DIR/offbook-backup@.service"
+cp "$REPO/infra/backup/offbook-backup@.timer" "$UNIT_DIR/offbook-backup@.timer"
+
+systemctl --user daemon-reload
+systemctl --user enable --now "offbook-backup@${FLAVOR}.timer"
+
+# Keep the timer firing when no user session is active (headless Pi/server).
+if command -v loginctl >/dev/null 2>&1; then
+	if ! loginctl enable-linger "$USER" 2>/dev/null; then
+		echo "note: could not enable lingering automatically — the timer will only run while you're logged in." >&2
+		echo "      For a headless host, run once:  sudo loginctl enable-linger $USER" >&2
+	fi
+fi
+
+echo "Installed offbook-backup@${FLAVOR}.timer (user service, repo: $REPO)."
+echo "  Watch:        journalctl --user -u offbook-backup@${FLAVOR} -f"
+echo "  Run now:      systemctl --user start offbook-backup@${FLAVOR}.service"
+echo "  Next firing:  systemctl --user list-timers offbook-backup@${FLAVOR}.timer"

--- a/infra/backup/lib.sh
+++ b/infra/backup/lib.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Shared helpers for the Offbook backup/restore scripts. Sourced, not executed.
+#
+# The one piece of host-specific state every script needs is HOW to reach the
+# Postgres container for this instance — i.e. the `docker compose … -p <project>
+# -f …` invocation. The Makefile owns that (it varies by FLAVOR) and hands it in
+# as the OFFBOOK_COMPOSE env string, which we word-split into the COMPOSE array.
+# This keeps the scripts convention-agnostic and independently testable: point
+# OFFBOOK_COMPOSE at any compose project with a `postgres` service and they work.
+
+# Parse OFFBOOK_COMPOSE into the COMPOSE array used by every db call.
+_init_compose() {
+	if [ -z "${OFFBOOK_COMPOSE:-}" ]; then
+		echo "error: OFFBOOK_COMPOSE is not set (run via 'command make backup' etc.)." >&2
+		exit 2
+	fi
+	# Intentional word-split of a controlled, script-internal value.
+	# shellcheck disable=SC2206
+	COMPOSE=( ${OFFBOOK_COMPOSE} )
+}
+
+# pg_sh runs a shell snippet INSIDE the postgres container, so it always uses the
+# container's own $POSTGRES_USER/$POSTGRES_DB and the matching client binaries —
+# no host-side knowledge of the DB name or a local psql install required.
+pg_sh() {
+	"${COMPOSE[@]}" exec -T postgres sh -c "$1"
+}
+
+# db_name / db_user echo the live values from the container environment.
+db_name() { pg_sh 'printf %s "$POSTGRES_DB"'; }
+db_user() { pg_sh 'printf %s "$POSTGRES_USER"'; }
+
+# ensure_postgres_up fails fast with a clear message if the stack isn't running.
+ensure_postgres_up() {
+	if ! "${COMPOSE[@]}" ps --status running postgres 2>/dev/null | grep -q postgres; then
+		echo "error: the postgres service for this instance is not running. Start it with 'command make deploy' first." >&2
+		exit 1
+	fi
+}

--- a/infra/backup/offbook-backup@.service
+++ b/infra/backup/offbook-backup@.service
@@ -1,0 +1,18 @@
+# User-level templated unit. The instance name (%i) is the FLAVOR, e.g.
+#   offbook-backup@dev    offbook-backup@prod
+#
+# Installed (not run) from the repo by infra/backup/install.sh, which
+# substitutes __OFFBOOK_REPO__ with this checkout's absolute path. Don't edit by
+# hand — re-run `command make backup-install` to regenerate.
+[Unit]
+Description=Offbook nightly backup (%i): pg_dump + restore-verify
+After=docker.service network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+Environment=OFFBOOK_FLAVOR=%i
+WorkingDirectory=__OFFBOOK_REPO__
+ExecStart=__OFFBOOK_REPO__/infra/backup/run.sh
+# A dump + scratch restore can take a while on a large DB; don't kill it early.
+TimeoutStartSec=3600

--- a/infra/backup/offbook-backup@.timer
+++ b/infra/backup/offbook-backup@.timer
@@ -1,0 +1,16 @@
+# User-level templated timer. Enabled per FLAVOR by install.sh, e.g.
+#   systemctl --user enable --now offbook-backup@dev.timer
+[Unit]
+Description=Nightly offbook backup + restore-verify (%i)
+
+[Timer]
+# Nightly at 02:30, with jitter so multiple instances don't all dump at once.
+OnCalendar=*-*-* 02:30:00
+RandomizedDelaySec=15min
+AccuracySec=1min
+# Catch up with a single run if the host was asleep/off across the scheduled time.
+Persistent=true
+Unit=offbook-backup@%i.service
+
+[Install]
+WantedBy=timers.target

--- a/infra/backup/offhost.sh
+++ b/infra/backup/offhost.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Optional off-host copy of a freshly-written backup. OPT-IN and no-op by
+# default: an on-host backup still protects against a lost postgres volume or a
+# bad migration, but not against total host loss. Copying off-host closes that
+# gap — and needs a remote target + credentials that only the instance owner can
+# supply, so this script never fabricates one.
+#
+#   offhost.sh <backup_file>
+#
+# Configure by setting, in the instance env file (.env / .env.prod):
+#   BACKUP_REMOTE=rclone:myremote:offbook-backups   # rclone remote+path
+#   BACKUP_REMOTE=restic:/srv/restic-repo           # restic repository
+# rclone reads its own config/credentials; restic reads RESTIC_PASSWORD etc.
+# When BACKUP_REMOTE is unset this exits 0 after a one-line note.
+set -euo pipefail
+
+file="${1:?backup file required}"
+remote="${BACKUP_REMOTE:-}"
+
+if [ -z "$remote" ]; then
+	echo "off-host: BACKUP_REMOTE unset — keeping backups on-host only (see docs/ops/backup-restore.md)."
+	exit 0
+fi
+
+kind="${remote%%:*}"
+target="${remote#*:}"
+
+case "$kind" in
+rclone)
+	command -v rclone >/dev/null 2>&1 || { echo "off-host: BACKUP_REMOTE requests rclone but it isn't installed." >&2; exit 1; }
+	echo "off-host: rclone copy $file → $target"
+	rclone copy "$file" "$target"
+	;;
+restic)
+	command -v restic >/dev/null 2>&1 || { echo "off-host: BACKUP_REMOTE requests restic but it isn't installed." >&2; exit 1; }
+	echo "off-host: restic backup $file → repo $target"
+	restic -r "$target" backup "$file"
+	;;
+*)
+	echo "off-host: unknown BACKUP_REMOTE scheme '$kind' (expected rclone:… or restic:…)." >&2
+	exit 1
+	;;
+esac
+echo "off-host: copy OK"

--- a/infra/backup/prune.sh
+++ b/infra/backup/prune.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# Retention for Offbook backups: grandfather-father-son.
+#
+#   prune.sh <backup_dir> <project> <keep_daily> <keep_weekly>
+#
+# Keeps the <keep_daily> most-recent dumps unconditionally, PLUS the newest dump
+# of each of the <keep_weekly> most-recent ISO weeks (older than the daily
+# window). Everything else is deleted. This bounds disk use while preserving a
+# longer weekly tail than a flat "keep N" would.
+#
+# Pure filesystem logic — no DB, no compose — so it is trivially testable in
+# isolation. Deliberately avoids bash-4-only features (mapfile, associative
+# arrays) so it runs on the Linux hosts AND on a macOS dev box (bash 3.2). ISO-
+# week bucketing needs GNU `date -d`; without it, it degrades safely to keeping
+# the newest (keep_daily + keep_weekly) dumps and warns.
+set -euo pipefail
+
+dir="${1:?backup dir required}"
+project="${2:?project required}"
+keep_daily="${3:?keep_daily required}"
+keep_weekly="${4:?keep_weekly required}"
+
+cd "$dir" 2>/dev/null || { echo "prune: $dir does not exist, nothing to do"; exit 0; }
+
+# Newest first. Filenames embed a lexicographically-sortable timestamp
+# (<project>-YYYYmmdd-HHMMSS.dump), so a reverse name sort is newest-first.
+all=()
+while IFS= read -r line; do
+	[ -n "$line" ] && all+=("$line")
+done < <(ls -1 "${project}"-*.dump 2>/dev/null | sort -r)
+
+if [ "${#all[@]}" -eq 0 ]; then
+	echo "prune: no dumps in $dir yet"
+	exit 0
+fi
+
+# GNU date probe (BSD/macOS date lacks -d).
+gnu_date=1
+date -d '2020-01-01' +%G >/dev/null 2>&1 || gnu_date=0
+
+# keep_list is a newline-delimited set of filenames to retain; membership is
+# tested with grep -qxF (exact whole-line match — portable, no associative
+# arrays). The daily and weekly passes cover disjoint files, so appending
+# unconditionally never duplicates in a way that matters.
+keep_list=""
+mark_keep() { keep_list="${keep_list}${1}"$'\n'; }
+is_kept()   { printf '%s' "$keep_list" | grep -qxF -- "$1"; }
+
+# 1. Daily window: newest keep_daily unconditionally.
+i=0
+for f in "${all[@]}"; do
+	[ "$i" -ge "$keep_daily" ] && break
+	mark_keep "$f"
+	i=$((i + 1))
+done
+
+if [ "$gnu_date" -eq 1 ]; then
+	# 2. Weekly tail: among the OLDER dumps, keep the newest per ISO week for the
+	#    most-recent keep_weekly distinct weeks.
+	weeks_seen=0
+	last_week=""
+	idx=0
+	for f in "${all[@]}"; do
+		idx=$((idx + 1))
+		[ "$idx" -le "$keep_daily" ] && continue
+		[ "$weeks_seen" -ge "$keep_weekly" ] && break
+		# Extract YYYYmmdd from <project>-YYYYmmdd-HHMMSS.dump, format as
+		# YYYY-MM-DD so GNU date parses it unambiguously.
+		stamp="${f#"${project}"-}"; day="${stamp%%-*}"
+		iso="$(date -d "${day:0:4}-${day:4:2}-${day:6:2}" +%G-%V 2>/dev/null || true)"
+		[ -z "$iso" ] && continue
+		if [ "$iso" != "$last_week" ]; then
+			mark_keep "$f"
+			weeks_seen=$((weeks_seen + 1))
+			last_week="$iso"
+		fi
+	done
+else
+	# Fallback: keep an extra keep_weekly newest dumps instead of week buckets.
+	echo "prune: GNU 'date -d' unavailable; falling back to keep newest $((keep_daily + keep_weekly))" >&2
+	i=0
+	for f in "${all[@]}"; do
+		[ "$i" -ge "$((keep_daily + keep_weekly))" ] && break
+		mark_keep "$f"
+		i=$((i + 1))
+	done
+fi
+
+# 3. Delete anything not marked keep.
+kept=0
+deleted=0
+for f in "${all[@]}"; do
+	if is_kept "$f"; then
+		kept=$((kept + 1))
+	else
+		rm -f "$f"
+		echo "prune: removed $f"
+		deleted=$((deleted + 1))
+	fi
+done
+echo "prune: kept $kept, removed $deleted (daily=$keep_daily, weekly=$keep_weekly)"

--- a/infra/backup/restore.sh
+++ b/infra/backup/restore.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Restore an Offbook instance's database from a pg_dump archive. This is the
+# recovery path for a lost postgres volume, a bad migration, or a fat-fingered
+# teardown — the counterpart to backup.sh.
+#
+#   restore.sh <backup_file>
+#
+# DESTRUCTIVE: it drops and recreates the live database, then restores the dump
+# into it. The Makefile front door (`command make restore BACKUP=…`) gates this
+# with a typed-confirmation prompt (skip with FORCE=1). Stop the backend first
+# in a real recovery so nothing races the restore; this script also terminates
+# stray connections before the drop.
+#
+# Env: OFFBOOK_COMPOSE (required, provided by the Makefile).
+set -euo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=infra/backup/lib.sh
+. "$HERE/lib.sh"
+_init_compose
+
+file="${1:?backup file required}"
+[ -f "$file" ] || { echo "error: backup file '$file' not found." >&2; exit 2; }
+
+ensure_postgres_up
+
+db="$(db_name)"
+echo "Restoring $file into database '$db'…"
+
+# Drop + recreate the target DB from the maintenance 'postgres' DB. $POSTGRES_DB
+# / $POSTGRES_USER expand inside the container; the \"…\" keep the identifiers
+# quoted for psql. ON_ERROR_STOP makes any failure fatal.
+pg_sh '
+set -e
+psql -U "$POSTGRES_USER" -d postgres -v ON_ERROR_STOP=1 \
+  -c "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = '"'"'$POSTGRES_DB'"'"' AND pid <> pg_backend_pid();" \
+  -c "DROP DATABASE IF EXISTS \"$POSTGRES_DB\";" \
+  -c "CREATE DATABASE \"$POSTGRES_DB\" OWNER \"$POSTGRES_USER\";"
+'
+
+# Stream the archive into pg_restore running inside the container. --no-owner so
+# the restore doesn't fail on role mismatches; the single app role owns it.
+if ! "${COMPOSE[@]}" exec -T postgres sh -c 'pg_restore -U "$POSTGRES_USER" -d "$POSTGRES_DB" --no-owner --exit-on-error' < "$file"; then
+	echo "error: pg_restore failed — the database was recreated but may be incomplete. Investigate before serving traffic." >&2
+	exit 1
+fi
+
+echo "restore OK — '$db' restored from $file"
+echo "Restart the backend so it reconnects cleanly:  command make deploy"

--- a/infra/backup/run.sh
+++ b/infra/backup/run.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Nightly backup entrypoint for one FLAVOR: take a backup, then verify the
+# latest dump restores. This is what the offbook-backup@<flavor>.timer fires;
+# it calls back into `make` so it always uses the same COMPOSE/config plumbing
+# as an interactive `command make backup` (mirrors infra/auto-deploy/auto-deploy.sh).
+#
+# Env overrides:
+#   OFFBOOK_REPO      repo checkout path (default: this script's repo root)
+#   OFFBOOK_FLAVOR    flavor -> make …  (default: dev)
+#
+# Failure handling is a SEAM for the M13 notifier (#360): on any failure we call
+# notify_failure, which today logs and, if BACKUP_NOTIFY_CMD is set, shells out
+# to it with a message. Exiting non-zero also lets systemd's OnFailure= (or the
+# journal) surface the problem. When #360 lands, point BACKUP_NOTIFY_CMD at the
+# notifier (or replace the body here) — no other change needed.
+set -euo pipefail
+
+REPO="${OFFBOOK_REPO:-$(cd "$(dirname "$0")/../.." && pwd)}"
+FLAVOR="${OFFBOOK_FLAVOR:-dev}"
+
+# Single-flight per flavor: a slow verify shouldn't overlap the next timer tick.
+exec 9>"${TMPDIR:-/tmp}/offbook-backup-${FLAVOR}.lock"
+if ! flock -n 9; then
+	echo "backup[$FLAVOR]: a run is already in progress, skipping"
+	exit 0
+fi
+
+cd "$REPO"
+
+notify_failure() {
+	local msg="offbook backup[$FLAVOR] FAILED: $1"
+	echo "$msg" >&2
+	if [ -n "${BACKUP_NOTIFY_CMD:-}" ]; then
+		# Seam for #360. BACKUP_NOTIFY_CMD receives the message as $1.
+		sh -c "$BACKUP_NOTIFY_CMD" _ "$msg" || echo "backup[$FLAVOR]: notifier command failed" >&2
+	fi
+}
+
+if ! make backup FLAVOR="$FLAVOR"; then
+	notify_failure "pg_dump/backup step failed"
+	exit 1
+fi
+
+if ! make backup-verify FLAVOR="$FLAVOR"; then
+	notify_failure "restore-verification failed (the latest dump did not restore)"
+	exit 1
+fi
+
+echo "backup[$FLAVOR]: backup + verify OK"

--- a/infra/backup/uninstall.sh
+++ b/infra/backup/uninstall.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Remove the user-level nightly backup timer for one FLAVOR.
+#
+#   command make backup-uninstall              # dev
+#   command make backup-uninstall FLAVOR=prod  # prod
+set -euo pipefail
+
+FLAVOR="${OFFBOOK_FLAVOR:-${FLAVOR:-dev}}"
+UNIT_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/systemd/user"
+
+if ! command -v systemctl >/dev/null 2>&1; then
+	echo "error: systemctl not found." >&2
+	exit 1
+fi
+
+systemctl --user disable --now "offbook-backup@${FLAVOR}.timer" 2>/dev/null || true
+
+# Drop the shared template files only when no other flavor's timer is still
+# enabled.
+if ! systemctl --user list-unit-files 'offbook-backup@*.timer' 2>/dev/null | grep -q '\benabled\b'; then
+	rm -f "$UNIT_DIR/offbook-backup@.service" "$UNIT_DIR/offbook-backup@.timer"
+	echo "Removed shared offbook-backup@ unit files (no flavors remain enabled)."
+fi
+
+systemctl --user daemon-reload
+echo "Uninstalled offbook-backup@${FLAVOR}.timer."

--- a/infra/backup/verify.sh
+++ b/infra/backup/verify.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Prove the latest backup actually restores — an unrestored backup is not a
+# backup. Restores the newest dump into a THROWAWAY scratch database (never the
+# live one), sanity-checks it, then drops the scratch DB. Safe to run on a
+# schedule against a live instance: it only reads the live DB's name/user and
+# writes to a scratch DB it owns.
+#
+#   verify.sh [backup_file]   # default: newest dump in BACKUP_DIR
+#
+# Sanity checks after restore:
+#   • schema_migrations has a row (schema present) and is not dirty
+#   • the 20 seeded system categories are present (seed/data integrity)
+#
+# Env: OFFBOOK_COMPOSE (required), OFFBOOK_PROJECT, BACKUP_DIR (to find latest).
+set -euo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=infra/backup/lib.sh
+. "$HERE/lib.sh"
+_init_compose
+
+PROJECT="${OFFBOOK_PROJECT:?OFFBOOK_PROJECT required}"
+BACKUP_DIR="${BACKUP_DIR:-backups/$PROJECT}"
+
+file="${1:-}"
+if [ -z "$file" ]; then
+	file="$(ls -1 "$BACKUP_DIR/${PROJECT}"-*.dump 2>/dev/null | sort | tail -1 || true)"
+fi
+[ -n "$file" ] && [ -f "$file" ] || { echo "error: no backup to verify (looked in $BACKUP_DIR)." >&2; exit 2; }
+
+ensure_postgres_up
+
+live_db="$(db_name)"
+scratch="${live_db}_restore_check"
+echo "Verifying $file by restoring into scratch DB '$scratch'…"
+
+cleanup() {
+	pg_sh "psql -U \"\$POSTGRES_USER\" -d postgres -v ON_ERROR_STOP=1 \
+	  -c \"DROP DATABASE IF EXISTS \\\"$scratch\\\";\"" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+# Fresh scratch DB.
+pg_sh "psql -U \"\$POSTGRES_USER\" -d postgres -v ON_ERROR_STOP=1 \
+  -c \"DROP DATABASE IF EXISTS \\\"$scratch\\\";\" \
+  -c \"CREATE DATABASE \\\"$scratch\\\" OWNER \\\"\$POSTGRES_USER\\\";\""
+
+# Restore into it.
+if ! "${COMPOSE[@]}" exec -T postgres sh -c "pg_restore -U \"\$POSTGRES_USER\" -d \"$scratch\" --no-owner --exit-on-error" < "$file"; then
+	echo "VERIFY FAILED: pg_restore could not restore $file" >&2
+	exit 1
+fi
+
+# Check 1: schema present (a migration version row exists).
+ver="$(pg_sh "psql -U \"\$POSTGRES_USER\" -d \"$scratch\" -tAc 'SELECT version FROM schema_migrations LIMIT 1;'" | tr -d '[:space:]')"
+if [ -z "$ver" ]; then
+	echo "VERIFY FAILED: restored DB has no schema_migrations version" >&2
+	exit 1
+fi
+
+# Check 2: not left dirty.
+dirty="$(pg_sh "psql -U \"\$POSTGRES_USER\" -d \"$scratch\" -tAc 'SELECT dirty FROM schema_migrations LIMIT 1;'" | tr -d '[:space:]')"
+if [ "$dirty" = "t" ]; then
+	echo "VERIFY FAILED: restored schema_migrations is dirty at version $ver" >&2
+	exit 1
+fi
+
+# Check 3: seed/data integrity — the 20 system categories survived the round-trip.
+cats="$(pg_sh "psql -U \"\$POSTGRES_USER\" -d \"$scratch\" -tAc 'SELECT count(*) FROM categories WHERE is_system;'" | tr -d '[:space:]')"
+if [ -z "$cats" ] || [ "$cats" -lt 20 ]; then
+	echo "VERIFY FAILED: expected >=20 system categories in restored DB, found '${cats:-0}'" >&2
+	exit 1
+fi
+
+echo "verify OK — $file restores cleanly (schema version $ver, $cats system categories)"


### PR DESCRIPTION
Closes #357

## What
There was **no backup story at all** — the top production-readiness blocker (gap O1). This adds the full recovery path: **lose the Postgres volume and restore last night's state by following [the runbook](docs/ops/backup-restore.md) alone.**

Mirrors the `infra/auto-deploy` templated-unit pattern (per-FLAVOR systemd timer, `flock` single-flight, call-back-into-`make`), so backups are operated exactly like auto-deploy.

### `infra/backup/`
- **`backup.sh`** — `pg_dump -Fc` of the instance DB into `backups/<project>/` (deliberately **outside** the postgres data volume), then prune + optional off-host copy.
- **`prune.sh`** — grandfather-father-son retention: keep **N dailies + one dump per week for M weeks** (defaults 7 + 4). Pure filesystem, portable bash (no `mapfile`/assoc arrays → runs on Linux hosts *and* macOS bash 3.2), GNU `date -d` with a safe "keep newest N+M" fallback.
- **`restore.sh`** — drop + recreate the live DB and `pg_restore` a chosen dump (the recovery path).
- **`verify.sh`** — restore the **latest** dump into a **throwaway scratch DB**, assert schema version + not-dirty + ≥20 seeded categories, then drop it. Never touches the live DB. *An unrestored backup is not a backup.*
- **`offhost.sh`** — opt-in off-host copy seam (rclone/restic via `BACKUP_REMOTE`); no-op default. **Owner supplies the target + credentials — never fabricated** (human-gated slice per the harness guardrail).
- **`run.sh`** — nightly entrypoint (backup → verify) with a notifier-on-failure **seam** (`BACKUP_NOTIFY_CMD`) for the M13 notifier (#360, not yet merged).
- **`offbook-backup@.{service,timer}`** + `install.sh`/`uninstall.sh` — user-level nightly timer per FLAVOR (02:30, jittered, `Persistent=true`).
- **`lib.sh`** — the compose invocation is passed in via `$OFFBOOK_COMPOSE`, so the scripts are convention-agnostic and testable against any postgres project.

### Makefile
`backup` / `restore BACKUP=<file>` (typed-confirm, `FORCE=1` to skip) / `backup-verify` / `backup-list` / `backup-install` / `backup-uninstall`. The #358 `pre-deploy-backup` hook now takes a real backup before every data-bearing deploy, and skips cleanly on first boot (postgres not up yet).

### Docs & config
`docs/ops/backup-restore.md` runbook (take/schedule/retention/restore/**lost-volume recovery**/off-host/notifications/future PITR+HA), `infra/backup/README.md`, `.env.example` (`BACKUP_KEEP_*`, `BACKUP_REMOTE`, `BACKUP_NOTIFY_CMD`), `.gitignore` (`backups/`).

## Acceptance criteria
- [x] Nightly `pg_dump` per instance via a per-FLAVOR user systemd timer (mirrors `infra/auto-deploy`).
- [x] Retention: N dailies + M weeklies, configurable, sane defaults.
- [x] `make backup` and `make restore BACKUP=<file>`.
- [x] Scripted restore verification into a scratch DB (schema version + row-count sanity) on the nightly schedule.
- [x] Optional off-host copy seam (rclone/restic), opt-in via env.
- [x] Backup failure notification **seam** for when the M13 notifier (#360) lands.
- [x] Runbook in `docs/ops/`.

## Verification
Exercised end-to-end against a throwaway postgres project:
- `backup.sh` → dump written; `restore.sh` after `DROP TABLE categories CASCADE` fully recovered the DB (20 system categories + 78 plaid mappings back).
- `verify.sh` restored the latest dump into a scratch DB and passed (schema version 26); scratch DB cleaned up.
- `prune.sh` verified on both the GNU-date weekly-bucket path (via `gdate`) and the macOS fallback (deletes correctly).
- `command make verify` green (contract-check, `-race -p 1` tests, lint, schema-check, migration round-trip, frontend lint+build).

## Notes / human-gated remainder
- **Off-host target** and **notifier endpoint** need owner-only secrets, so they ship as documented seams with working no-op defaults (a commented step is on the issue).
- No new migration, so `docs/db/schema.md` is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)