### PR TITLE
feat #359: in-app job runner — schedule household-purge daily

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log"
 	"net/http"
 	"os"
@@ -14,6 +15,8 @@ import (
 	"github.com/gregwym/offbook/backend/internal/db"
 	"github.com/gregwym/offbook/backend/internal/repository"
 	"github.com/gregwym/offbook/backend/internal/router"
+	"github.com/gregwym/offbook/backend/internal/service/household"
+	"github.com/gregwym/offbook/backend/internal/service/jobs"
 	"github.com/gregwym/offbook/backend/internal/service/prices"
 )
 
@@ -42,13 +45,18 @@ func main() {
 
 	r := router.New(cfg, gormDB)
 
-	// Scheduled price refresh (#338 Phase 3): daily background pass over
-	// users who opted in via Settings (ADR-0014 §3 — background egress
-	// needs stored consent). Stops with the server context below.
+	// Background job runner (#359, ADR-0020). One in-app scheduler owns every
+	// periodic maintenance task; each job logs its outcome and alerts the
+	// Notifier on failure. Stops with the server context below. The M13 notifier
+	// (#360) will replace jobs.LogNotifier here — nothing else changes.
 	schedulerCtx, stopScheduler := context.WithCancel(context.Background())
 	defer stopScheduler()
+	runner := jobs.NewRunner(log.Printf, jobs.LogNotifier{})
+
+	// price-refresh (#338 Phase 3): daily background pass over users who opted
+	// in via Settings (ADR-0014 §3 — background egress needs stored consent).
 	settingsRepo := repository.NewUserSettingsRepository(gormDB)
-	prices.NewScheduler(
+	priceScheduler := prices.NewScheduler(
 		prices.NewService(
 			repository.NewUserRepository(gormDB),
 			repository.NewPositionRepository(gormDB),
@@ -57,7 +65,39 @@ func main() {
 			prices.NewCoinGecko(), prices.NewFrankfurter(),
 		),
 		settingsRepo.ListAutoRefreshUserIDs,
-	).Start(schedulerCtx)
+	)
+	runner.Register(jobs.Job{
+		Name:         "price-refresh",
+		Interval:     24 * time.Hour,
+		InitialDelay: time.Minute, // let boot settle before upstream calls
+		Run: func(ctx context.Context) (string, error) {
+			// RunOnce logs per-user detail and never aborts the pass on one
+			// user's provider failure; the pass itself has no fatal error.
+			priceScheduler.RunOnce(ctx)
+			return "refresh pass complete", nil
+		},
+	})
+
+	// household-purge (#359): grace-period purge is a privacy promise
+	// (ADR-0007) — it must run without the owner remembering the CLI.
+	runner.Register(jobs.Job{
+		Name:         "household-purge",
+		Interval:     24 * time.Hour,
+		InitialDelay: time.Minute,
+		Run: func(ctx context.Context) (string, error) {
+			res, err := household.RunPurge(ctx, gormDB, time.Now())
+			if err != nil {
+				return "", err
+			}
+			if res.MembersPurged == 0 && res.SharesDeleted == 0 {
+				return "nothing to purge", nil
+			}
+			return fmt.Sprintf("purged %d members, removed %d account_shares",
+				res.MembersPurged, res.SharesDeleted), nil
+		},
+	})
+
+	runner.Start(schedulerCtx)
 
 	srv := &http.Server{
 		Addr:              ":" + cfg.Port,

--- a/backend/internal/service/jobs/runner.go
+++ b/backend/internal/service/jobs/runner.go
@@ -1,0 +1,154 @@
+// Package jobs is a small in-app scheduler for periodic background maintenance
+// tasks — grace-period household purge (#359), ingestion-jobs purge (#337), the
+// price refresh (#338), and future periodic needs.
+//
+// It generalizes the pattern the price scheduler established (ADR-0020): the
+// server is one long-lived process per instance that already holds a DB handle
+// and config, so an in-app runner is simpler to operate than per-FLAVOR systemd
+// timers for the self-hosted deployment model. A Job is just a name + interval +
+// func; the Runner tickers each one on its own goroutine, logs every outcome,
+// recovers panics, and forwards failures to a Notifier (the seam the M13
+// notifier #360 plugs into).
+package jobs
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"runtime/debug"
+	"time"
+)
+
+// Notifier is alerted when a job run fails. It is the injection seam for the
+// M13 notifier (#360); until that lands, main wires LogNotifier.
+type Notifier interface {
+	// Notify delivers a failure alert. Implementations should return promptly
+	// and must not panic — a notifier failure must never take down the runner
+	// (the Runner also guards the call).
+	Notify(ctx context.Context, subject, detail string)
+}
+
+// Job is a named periodic task.
+type Job struct {
+	// Name identifies the job in logs and alerts. Keep it short and stable.
+	Name string
+	// Interval between runs. Must be > 0 for a repeating job.
+	Interval time.Duration
+	// InitialDelay before the first run, so boot work (migrations, first
+	// requests) isn't competing with the job. Zero runs almost immediately.
+	InitialDelay time.Duration
+	// Run does the work and returns a short human-readable outcome
+	// ("purged 3 members, removed 5 shares") plus an error. A returned error —
+	// or a panic, which the Runner recovers — is logged and sent to the Notifier.
+	Run func(ctx context.Context) (string, error)
+}
+
+// Runner owns a set of jobs, each ticking on its own goroutine.
+type Runner struct {
+	jobs     []Job
+	logf     func(format string, args ...any)
+	notifier Notifier
+}
+
+// NewRunner builds a runner. logf defaults to log.Printf when nil; a nil
+// notifier means failures are logged but not alerted (still safe).
+func NewRunner(logf func(format string, args ...any), notifier Notifier) *Runner {
+	if logf == nil {
+		logf = log.Printf
+	}
+	return &Runner{logf: logf, notifier: notifier}
+}
+
+// Register adds a job. Call before Start.
+func (r *Runner) Register(j Job) { r.jobs = append(r.jobs, j) }
+
+// Start launches every registered job in its own goroutine and returns
+// immediately. All jobs stop when ctx is canceled.
+func (r *Runner) Start(ctx context.Context) {
+	for _, j := range r.jobs {
+		go r.loop(ctx, j)
+	}
+}
+
+// loop runs one job after its initial delay, then on its interval, until ctx
+// is canceled.
+func (r *Runner) loop(ctx context.Context, j Job) {
+	if j.InitialDelay > 0 {
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(j.InitialDelay):
+		}
+	}
+	r.runOnce(ctx, j)
+
+	if j.Interval <= 0 {
+		return // defensively: a repeating job needs a positive interval
+	}
+	ticker := time.NewTicker(j.Interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			r.runOnce(ctx, j)
+		}
+	}
+}
+
+// runOnce executes a single run, guarding against panics so one bad job can
+// neither crash the server nor starve its siblings. Failures are logged and
+// forwarded to the Notifier; successes are logged with their outcome + duration.
+func (r *Runner) runOnce(ctx context.Context, j Job) {
+	start := time.Now()
+	outcome, err := r.safeRun(ctx, j)
+	elapsed := time.Since(start).Round(time.Millisecond)
+	if err != nil {
+		r.logf("[job] %s: FAILED after %s: %v", j.Name, elapsed, err)
+		r.notify(ctx, j.Name, err)
+		return
+	}
+	r.logf("[job] %s: ok in %s — %s", j.Name, elapsed, outcome)
+}
+
+// safeRun invokes the job func, converting a panic into an error so it is
+// treated like any other failure (logged + alerted) rather than crashing.
+func (r *Runner) safeRun(ctx context.Context, j Job) (outcome string, err error) {
+	defer func() {
+		if p := recover(); p != nil {
+			err = fmt.Errorf("panic: %v\n%s", p, debug.Stack())
+		}
+	}()
+	return j.Run(ctx)
+}
+
+// notify forwards a failure to the Notifier, guarding the notifier itself so an
+// alerting failure never kills the job loop.
+func (r *Runner) notify(ctx context.Context, name string, err error) {
+	if r.notifier == nil {
+		return
+	}
+	defer func() {
+		if p := recover(); p != nil {
+			r.logf("[job] %s: notifier panicked: %v", name, p)
+		}
+	}()
+	r.notifier.Notify(ctx, "offbook job failed: "+name, err.Error())
+}
+
+// LogNotifier is the default Notifier: it logs the alert with a distinct,
+// greppable prefix. The M13 notifier (#360) replaces it with real delivery
+// (ntfy / webhook / email) — main injects the replacement, nothing else changes.
+type LogNotifier struct {
+	Logf func(format string, args ...any)
+}
+
+// Notify logs the alert at a prominent, greppable prefix.
+func (n LogNotifier) Notify(_ context.Context, subject, detail string) {
+	logf := n.Logf
+	if logf == nil {
+		logf = log.Printf
+	}
+	logf("[job][ALERT] %s: %s", subject, detail)
+}

--- a/backend/internal/service/jobs/runner_test.go
+++ b/backend/internal/service/jobs/runner_test.go
@@ -1,0 +1,202 @@
+package jobs
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// captureLog is a logf that records formatted lines for assertions.
+type captureLog struct {
+	mu    sync.Mutex
+	lines []string
+}
+
+func (c *captureLog) logf(format string, args ...any) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.lines = append(c.lines, fmt.Sprintf(format, args...))
+}
+
+func (c *captureLog) joined() string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return strings.Join(c.lines, "\n")
+}
+
+// fakeNotifier records every alert it receives.
+type fakeNotifier struct {
+	mu    sync.Mutex
+	calls []string
+	// panicOnCall lets a test prove the runner survives a broken notifier.
+	panicOnCall bool
+}
+
+func (f *fakeNotifier) Notify(_ context.Context, subject, detail string) {
+	f.mu.Lock()
+	f.calls = append(f.calls, subject+"|"+detail)
+	f.mu.Unlock()
+	if f.panicOnCall {
+		panic("notifier boom")
+	}
+}
+
+func (f *fakeNotifier) count() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.calls)
+}
+
+func TestRunner_runOnce(t *testing.T) {
+	tests := []struct {
+		name         string
+		run          func(ctx context.Context) (string, error)
+		wantNotify   int
+		wantLogParts []string
+	}{
+		{
+			name:         "success logs outcome, no alert",
+			run:          func(context.Context) (string, error) { return "did 3 things", nil },
+			wantNotify:   0,
+			wantLogParts: []string{"[job] demo: ok", "did 3 things"},
+		},
+		{
+			name:         "error logs failure and alerts",
+			run:          func(context.Context) (string, error) { return "", errors.New("boom") },
+			wantNotify:   1,
+			wantLogParts: []string{"[job] demo: FAILED", "boom"},
+		},
+		{
+			name:         "panic is recovered, logged as failure, and alerts",
+			run:          func(context.Context) (string, error) { panic("kaboom") },
+			wantNotify:   1,
+			wantLogParts: []string{"[job] demo: FAILED", "panic: kaboom"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			log := &captureLog{}
+			notif := &fakeNotifier{}
+			r := NewRunner(log.logf, notif)
+
+			r.runOnce(context.Background(), Job{Name: "demo", Run: tt.run})
+
+			if got := notif.count(); got != tt.wantNotify {
+				t.Fatalf("notify count = %d, want %d", got, tt.wantNotify)
+			}
+			out := log.joined()
+			for _, part := range tt.wantLogParts {
+				if !strings.Contains(out, part) {
+					t.Fatalf("log missing %q; got:\n%s", part, out)
+				}
+			}
+		})
+	}
+}
+
+// A panicking notifier must not take down the runner.
+func TestRunner_runOnce_survivesNotifierPanic(t *testing.T) {
+	log := &captureLog{}
+	notif := &fakeNotifier{panicOnCall: true}
+	r := NewRunner(log.logf, notif)
+
+	// Must not panic out of runOnce.
+	r.runOnce(context.Background(), Job{
+		Name: "demo",
+		Run:  func(context.Context) (string, error) { return "", errors.New("boom") },
+	})
+
+	if notif.count() != 1 {
+		t.Fatalf("notifier should have been called once, got %d", notif.count())
+	}
+	if !strings.Contains(log.joined(), "notifier panicked") {
+		t.Fatalf("expected a 'notifier panicked' log line; got:\n%s", log.joined())
+	}
+}
+
+// A nil notifier is safe: failures are logged, nothing is alerted, no panic.
+func TestRunner_runOnce_nilNotifier(t *testing.T) {
+	log := &captureLog{}
+	r := NewRunner(log.logf, nil)
+	r.runOnce(context.Background(), Job{
+		Name: "demo",
+		Run:  func(context.Context) (string, error) { return "", errors.New("boom") },
+	})
+	if !strings.Contains(log.joined(), "FAILED") {
+		t.Fatalf("expected FAILED log; got:\n%s", log.joined())
+	}
+}
+
+// Start runs a job repeatedly on its interval and stops cleanly on ctx cancel.
+func TestRunner_Start_runsThenStopsOnCancel(t *testing.T) {
+	var mu sync.Mutex
+	runs := 0
+	r := NewRunner(func(string, ...any) {}, nil)
+	r.Register(Job{
+		Name:     "tick",
+		Interval: 10 * time.Millisecond,
+		Run: func(context.Context) (string, error) {
+			mu.Lock()
+			runs++
+			mu.Unlock()
+			return "ok", nil
+		},
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	r.Start(ctx)
+
+	// Let it tick several times.
+	time.Sleep(55 * time.Millisecond)
+	cancel()
+
+	mu.Lock()
+	atCancel := runs
+	mu.Unlock()
+	if atCancel < 2 {
+		t.Fatalf("expected >=2 runs before cancel, got %d", atCancel)
+	}
+
+	// After cancel it must stop; allow at most one in-flight tick.
+	time.Sleep(40 * time.Millisecond)
+	mu.Lock()
+	afterCancel := runs
+	mu.Unlock()
+	if afterCancel > atCancel+1 {
+		t.Fatalf("job kept running after cancel: %d -> %d", atCancel, afterCancel)
+	}
+}
+
+// InitialDelay is honored: a job with a delay longer than the observation
+// window doesn't run, and cancel during the delay is clean.
+func TestRunner_Start_initialDelayAndCancel(t *testing.T) {
+	var mu sync.Mutex
+	ran := false
+	r := NewRunner(func(string, ...any) {}, nil)
+	r.Register(Job{
+		Name:         "delayed",
+		Interval:     10 * time.Millisecond,
+		InitialDelay: time.Hour, // far beyond the window
+		Run: func(context.Context) (string, error) {
+			mu.Lock()
+			ran = true
+			mu.Unlock()
+			return "ok", nil
+		},
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	r.Start(ctx)
+	time.Sleep(30 * time.Millisecond)
+	cancel()
+
+	mu.Lock()
+	defer mu.Unlock()
+	if ran {
+		t.Fatal("job ran before its InitialDelay elapsed")
+	}
+}

--- a/docs/ADR/0020-in-app-job-runner.md
+++ b/docs/ADR/0020-in-app-job-runner.md
@@ -1,0 +1,75 @@
+# ADR-0020: In-app job runner for periodic maintenance
+
+Status: Accepted (M13 / #359)
+
+## Context
+
+Offbook has periodic background work that must run without the instance owner
+remembering a CLI:
+
+- **Grace-period household purge** (`cmd/household-purge`, ADR-0007). Purging a
+  former member's data links after their grace window is a *privacy promise*.
+  The runner existed but nothing invoked it — a quiet contract violation.
+- **Ingestion-jobs purge** (#337) — stale, uncommitted AI-import staging jobs.
+- **Price refresh** (#338 Phase 3) — already ran in-app via a bespoke
+  `prices.Scheduler` goroutine, the only scheduled job on the instance.
+
+Each new periodic need was becoming ad hoc (gap E3 in
+`docs/PRODUCTION-READINESS.md`). We need one mechanism.
+
+Two options (from #359):
+
+1. **Generalize the in-app scheduler** into a small job runner: a job is a
+   name + interval + func; one runner tickers them all, logs outcomes, and
+   alerts on failure.
+2. **Per-FLAVOR systemd timers**, mirroring `infra/auto-deploy` and
+   `infra/backup` — one unit per job, surviving app crashes.
+
+## Decision
+
+**Generalize the in-app scheduler** (option 1). New package
+`internal/service/jobs`: `Runner` + `Job{Name, Interval, InitialDelay, Run}` +
+a `Notifier` seam. `cmd/server/main.go` builds one runner and registers
+`price-refresh` and `household-purge` (both daily); #337 registers its purge the
+same way when it lands.
+
+Rationale:
+
+- The server is one long-lived process per instance that **already holds the DB
+  handle and config** (`config.Load`). An in-app job reuses them directly; a
+  systemd timer would re-open the DB and re-resolve config per run.
+- It **matches the existing pattern** (`prices.Scheduler`) rather than
+  introducing a second operational surface. The tech note in #359 explicitly
+  biases to in-app for self-host simplicity.
+- **One place to look**: every job logs with a `[job]` prefix and alerts through
+  one `Notifier`. Systemd timers would scatter status across N units.
+
+Accepted trade-off: **in-app jobs don't run when the process is down.** For
+these tasks that's fine — purge is idempotent and time-based (a missed daily run
+is caught by the next one; the aggregator already filters expired members lazily
+on read, so correctness never depends on the purge having run *on time*). Work
+whose *durability across crashes* matters (backups) stays on systemd timers
+(`infra/backup`), where survival of an app crash is the whole point.
+
+## Consequences
+
+- `jobs.Runner` runs each job on its own goroutine: `InitialDelay`, then every
+  `Interval`, until the server context is canceled (clean shutdown).
+- **Panics are recovered** per run — one bad job can neither crash the server nor
+  starve its siblings; a panic is treated as a failure (logged + alerted).
+- **Failure alerting is a seam.** `jobs.Notifier` is injected; today main wires
+  `jobs.LogNotifier` (logs `[job][ALERT] …`). The M13 notifier (#360) replaces
+  that one injection with real delivery (ntfy/webhook/email) — no other change.
+- **Observability** is the structured `[job]` log line per run (outcome +
+  duration). See `docs/ops/scheduled-jobs.md` for how to read it. A durable
+  `job_runs` table/endpoint is deliberately out of scope (not a job-queue system).
+- `prices.Scheduler` keeps its `RunOnce` (still unit-tested); its `Start` loop is
+  superseded by the runner and left as a thin, unused helper.
+
+## Alternatives considered
+
+- **Systemd timers per job** — better crash durability, but a second operational
+  surface and per-run DB/config setup for tasks that don't need either. Reserved
+  for durability-critical work (backups).
+- **A real job queue** (River, asynq, etc.) — overkill for daily idempotent
+  maintenance on a single-process self-hosted instance; explicitly out of scope.

--- a/docs/ops/scheduled-jobs.md
+++ b/docs/ops/scheduled-jobs.md
@@ -1,0 +1,72 @@
+# Scheduled Jobs
+
+Offbook runs periodic maintenance in-app via a single job runner
+(`internal/service/jobs`, [ADR-0020](../ADR/0020-in-app-job-runner.md)). This is
+separate from the **backup** timer (systemd, `infra/backup`) and the
+**auto-deploy** timer (systemd, `infra/auto-deploy`), which are host-level and
+must survive an app crash.
+
+## Jobs that run in-app
+
+| Job | Interval | What it does |
+|---|---|---|
+| `household-purge` | daily | Seals in-grace member rows whose grace window elapsed and removes their `account_shares` (privacy promise, ADR-0007). Idempotent. |
+| `price-refresh` | daily | Refreshes prices/FX for users who opted in via Settings (ADR-0014 §3). |
+| `ingestion-jobs purge` | daily *(lands with #337)* | Purges stale, uncommitted AI-import staging jobs. |
+
+Each runs ~1 minute after boot, then every 24h, and stops on clean shutdown.
+
+## How to see when a job last ran
+
+Every run logs one line with a `[job]` prefix — outcome and duration on success,
+`FAILED` with the error on failure:
+
+```
+[job] household-purge: ok in 12ms — purged 2 members, removed 3 account_shares
+[job] household-purge: ok in 8ms — nothing to purge
+[job] price-refresh: ok in 1.4s — refresh pass complete
+[job] household-purge: FAILED after 40ms: purge: <error>
+```
+
+A failure also emits a distinct alert line (and, once the M13 notifier #360 is
+wired, a real notification):
+
+```
+[job][ALERT] offbook job failed: household-purge: purge: <error>
+```
+
+### Reading the logs
+
+- **Docker / compose deploy** (dev or prod flavor):
+
+  ```sh
+  docker compose -p offbook      logs backend | grep '\[job\]'   # dev
+  docker compose -p offbook-prod logs backend | grep '\[job\]'   # prod
+  # follow live:
+  docker compose -p offbook-prod logs -f backend | grep --line-buffered '\[job\]'
+  ```
+
+- **Just the failures/alerts:**
+
+  ```sh
+  docker compose -p offbook-prod logs backend | grep '\[job\]\[ALERT\]'
+  ```
+
+- **Running the server directly** (`make dev`): the same lines go to
+  `/tmp/offbook-server.log` (`command make logs`).
+
+## Running a job manually
+
+`household-purge` also has a standalone CLI for an out-of-band run (the in-app
+job doesn't replace it):
+
+```sh
+cd backend && go run ./cmd/household-purge
+```
+
+## Failure handling
+
+A job failure is logged, alerted through the `Notifier` seam, and — because
+panics are recovered per run — never crashes the server or the other jobs. Wire
+real alerting by injecting the M13 notifier (#360) in place of
+`jobs.LogNotifier` in `cmd/server/main.go`.


### PR DESCRIPTION
Closes #359

## What
Grace-period household purge is a **privacy promise** (ADR-0007), but `cmd/household-purge` was never invoked — a silent contract violation (gap O4). This generalizes the bespoke `prices.Scheduler` into one small **in-app job runner** and schedules the purge on it.

### `internal/service/jobs` (new)
- `Runner` + `Job{Name, Interval, InitialDelay, Run}` + a `Notifier` seam.
- Each job tickers on its own goroutine (`InitialDelay`, then every `Interval`), **logs every outcome** with a `[job]` prefix (outcome + duration), **recovers panics** so one bad job can't crash the server or starve siblings, and **alerts the `Notifier` on failure**.

### `cmd/server/main.go`
- One runner replaces the standalone price-scheduler goroutine and registers:
  - **`price-refresh`** (#338, migrated) — daily.
  - **`household-purge`** (#359) — daily; logs `purged N members, removed M account_shares` / `nothing to purge`.
  - #337's ingestion-jobs purge registers the same way when it lands.
- `Notifier` is injected; the default `jobs.LogNotifier` logs `[job][ALERT] …`. The **M13 notifier (#360)** swaps in real delivery at that one call site — nothing else changes.

### Decision & docs
- **[ADR-0020](docs/ADR/0020-in-app-job-runner.md)** records the choice — in-app runner over per-FLAVOR systemd timers: the server already holds the DB + config, it matches the existing pattern, and purge is idempotent + time-based (a missed daily run self-heals; the aggregator already filters expired members lazily on read). Durability-critical work (backups) stays on systemd timers.
- **[docs/ops/scheduled-jobs.md](docs/ops/scheduled-jobs.md)** — what runs and **how to see when each job last ran** (grep `[job]` in the backend logs).

## Acceptance criteria
- [x] A general scheduling mechanism — the in-app `jobs.Runner` (name + interval + func); choice recorded in ADR-0020.
- [x] `household-purge` runs daily; #337's ingestion-jobs purge slots in the same way.
- [x] Every run logged with outcome (rows purged / nothing to do / error).
- [x] A failed run triggers the notifier (seam wired; default `LogNotifier`, real delivery arrives with #360).
- [x] Docs: how to see when jobs last ran.

## Tests
`runner_test.go`: success/error/panic outcomes, notifier-on-failure, survives a *panicking* notifier, nil-notifier safety, and `Start` ticking repeatedly + stopping cleanly on ctx cancel + `InitialDelay` honored.

## Verification
`command make verify` green (contract-check, `-race -p 1` tests incl. the new suite, lint, schema-check, migration round-trip, frontend lint+build). No new migration → `docs/db/schema.md` unchanged.

## Note
`#360` (notifier) is not yet merged, so failure alerting ships as the injected `Notifier` seam with a working `LogNotifier` default — consistent with the harness guardrail for not-yet-available dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)