### PR TITLE
feat #337: purge stale uncommitted AI-import staging jobs

### DIFF
--- a/backend/cmd/ingestion-jobs-purge/main.go
+++ b/backend/cmd/ingestion-jobs-purge/main.go
@@ -1,0 +1,66 @@
+// Ingestion-jobs-purge CLI. Reclaims abandoned AI-import staging rows: an
+// ingestion_jobs row that sat at status='extracted' with its staged `extraction`
+// JSONB past the retention window (ADR-0019 §7, #337) has its payload nulled and
+// the row moved to a terminal 'failed' state. The audit row itself survives —
+// ingestion_jobs is append-only.
+//
+//	go run ./cmd/ingestion-jobs-purge                       # dry run (default)
+//	go run ./cmd/ingestion-jobs-purge --apply               # actually purge
+//	go run ./cmd/ingestion-jobs-purge --retention-days 14   # override window
+//
+// Idempotent — re-running is a no-op once nothing is stale. The in-app job
+// runner (#359) runs this same purge daily; this CLI is for an out-of-band run.
+// Uses config.Load() for DB selection.
+package main
+
+import (
+	"context"
+	"flag"
+	"log"
+	"time"
+
+	"github.com/gregwym/offbook/backend/internal/config"
+	"github.com/gregwym/offbook/backend/internal/db"
+	"github.com/gregwym/offbook/backend/internal/service"
+)
+
+func main() {
+	apply := flag.Bool("apply", false, "actually purge (default is dry-run)")
+	retentionDays := flag.Int("retention-days", 7, "purge extracted stages older than this many days")
+	flag.Parse()
+
+	if *retentionDays < 0 {
+		log.Fatal("--retention-days must be >= 0")
+	}
+	retention := time.Duration(*retentionDays) * 24 * time.Hour
+
+	cfg := config.MustLoad()
+	if cfg.DatabaseURL == "" {
+		log.Fatal("DATABASE_URL is empty")
+	}
+	g, err := db.Open(cfg.DatabaseURL)
+	if err != nil {
+		log.Fatalf("db.Open: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	now := time.Now()
+	if !*apply {
+		n, err := service.CountStaleAIStaging(ctx, g, now, retention)
+		if err != nil {
+			log.Fatalf("count: %v", err)
+		}
+		log.Printf("ingestion-jobs-purge: DRY RUN — %d stale AI-staging job(s) older than %d day(s) would be purged. Re-run with --apply to execute.",
+			n, *retentionDays)
+		return
+	}
+
+	res, err := service.PurgeStaleAIStaging(ctx, g, now, retention)
+	if err != nil {
+		log.Fatalf("purge: %v", err)
+	}
+	log.Printf("ingestion-jobs-purge: purged %d stale AI-staging job(s) older than %d day(s)",
+		res.JobsPurged, *retentionDays)
+}

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/gregwym/offbook/backend/internal/db"
 	"github.com/gregwym/offbook/backend/internal/repository"
 	"github.com/gregwym/offbook/backend/internal/router"
+	"github.com/gregwym/offbook/backend/internal/service"
 	"github.com/gregwym/offbook/backend/internal/service/household"
 	"github.com/gregwym/offbook/backend/internal/service/jobs"
 	"github.com/gregwym/offbook/backend/internal/service/prices"
@@ -94,6 +95,24 @@ func main() {
 			}
 			return fmt.Sprintf("purged %d members, removed %d account_shares",
 				res.MembersPurged, res.SharesDeleted), nil
+		},
+	})
+
+	// ingestion-jobs-purge (#337): reclaim abandoned AI-import staging payloads
+	// (status='extracted' past retention) so their JSONB doesn't accumulate.
+	runner.Register(jobs.Job{
+		Name:         "ingestion-jobs-purge",
+		Interval:     24 * time.Hour,
+		InitialDelay: time.Minute,
+		Run: func(ctx context.Context) (string, error) {
+			res, err := service.PurgeStaleAIStaging(ctx, gormDB, time.Now(), service.DefaultAIStagingRetention)
+			if err != nil {
+				return "", err
+			}
+			if res.JobsPurged == 0 {
+				return "nothing to purge", nil
+			}
+			return fmt.Sprintf("purged %d stale AI-staging job(s)", res.JobsPurged), nil
 		},
 	})
 

--- a/backend/internal/service/ingestion_purge.go
+++ b/backend/internal/service/ingestion_purge.go
@@ -1,0 +1,84 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"gorm.io/gorm"
+)
+
+// DefaultAIStagingRetention is how long an uncommitted AI-import stage lives
+// before the purge reclaims it (#337). Seven days: long enough that a user who
+// previewed an import can come back the following week and commit, short enough
+// that abandoned `extraction` payloads don't accumulate indefinitely.
+const DefaultAIStagingRetention = 7 * 24 * time.Hour
+
+// staleStagingWhere selects abandoned AI-import staging rows: still awaiting the
+// user's commit (status='extracted'), still carrying a staged payload
+// (extraction IS NOT NULL), and older than the retention cutoff. The single `?`
+// binds the cutoff timestamp. Kept as one const so the dry-run count and the
+// apply update can never drift apart.
+const staleStagingWhere = "status = 'extracted' AND extraction IS NOT NULL AND created_at < ?"
+
+// StagingPurgeResult reports how many stale staging rows the purge reclaimed.
+type StagingPurgeResult struct {
+	JobsPurged int
+}
+
+// CountStaleAIStaging returns how many rows PurgeStaleAIStaging would reclaim at
+// `now` for the given retention — the dry-run counterpart to the purge.
+func CountStaleAIStaging(ctx context.Context, db *gorm.DB, now time.Time, retention time.Duration) (int64, error) {
+	if db == nil {
+		return 0, errors.New("service: CountStaleAIStaging requires a non-nil *gorm.DB")
+	}
+	var n int64
+	if err := db.WithContext(ctx).
+		Table("ingestion_jobs").
+		Where(staleStagingWhere, now.Add(-retention)).
+		Count(&n).Error; err != nil {
+		return 0, fmt.Errorf("count stale AI-staging jobs: %w", err)
+	}
+	return n, nil
+}
+
+// PurgeStaleAIStaging reclaims abandoned AI-import staging rows: for every
+// ingestion_jobs row that has sat at status='extracted' with a staged
+// `extraction` payload past the retention window, it nulls the payload (freeing
+// the potentially large JSONB) and moves the row to a terminal 'failed' state
+// with an explanatory error_message.
+//
+// It deliberately does NOT delete the row: ingestion_jobs is an append-only
+// audit trail (see docs/ARCHITECTURE.md), so the import attempt stays on record
+// — only the heavy, no-longer-committable staged payload is discarded. Flipping
+// out of 'extracted' also removes the ghost job from the "awaiting commit" UI so
+// it can't be committed against an emptied stage.
+//
+// Idempotent: a second run reclaims nothing (the WHERE no longer matches a row
+// whose extraction is already NULL / status already 'failed'). `now` is injected
+// so callers (and the regression test) can pin a deterministic clock.
+func PurgeStaleAIStaging(ctx context.Context, db *gorm.DB, now time.Time, retention time.Duration) (StagingPurgeResult, error) {
+	var res StagingPurgeResult
+	if db == nil {
+		return res, errors.New("service: PurgeStaleAIStaging requires a non-nil *gorm.DB")
+	}
+
+	cutoff := now.Add(-retention)
+	// Single set-based UPDATE — raw Exec bypasses GORM hooks, so updated_at is
+	// set explicitly alongside completed_at.
+	r := db.WithContext(ctx).Exec(`
+		UPDATE ingestion_jobs
+		SET extraction    = NULL,
+		    status        = 'failed',
+		    error_message = 'expired: AI-staged import was not committed within the retention window; staged payload discarded',
+		    completed_at  = ?,
+		    updated_at    = ?
+		WHERE `+staleStagingWhere,
+		now, now, cutoff)
+	if r.Error != nil {
+		return res, fmt.Errorf("purge stale AI-staging jobs: %w", r.Error)
+	}
+	res.JobsPurged = int(r.RowsAffected)
+	return res, nil
+}

--- a/backend/internal/service/ingestion_purge_test.go
+++ b/backend/internal/service/ingestion_purge_test.go
@@ -1,0 +1,143 @@
+package service_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"gorm.io/gorm"
+
+	"github.com/gregwym/offbook/backend/internal/model"
+	"github.com/gregwym/offbook/backend/internal/service"
+)
+
+// seedIngestionJob inserts an ingestion_jobs row and back-dates created_at to
+// ageDays ago (UpdateColumn bypasses GORM's autoCreateTime). Cleanup is
+// registered since seedTestUser's cascade doesn't cover ingestion_jobs.
+func seedIngestionJob(t *testing.T, g *gorm.DB, userID int64, status string, extraction json.RawMessage, ageDays int) int64 {
+	t.Helper()
+	job := &model.IngestionJob{
+		UserID:     userID,
+		Source:     "pdf",
+		Status:     status,
+		Extraction: extraction,
+	}
+	if err := g.Create(job).Error; err != nil {
+		t.Fatalf("seed ingestion job: %v", err)
+	}
+	created := time.Now().Add(-time.Duration(ageDays) * 24 * time.Hour)
+	if err := g.Model(&model.IngestionJob{}).Where("id = ?", job.ID).
+		UpdateColumn("created_at", created).Error; err != nil {
+		t.Fatalf("backdate created_at: %v", err)
+	}
+	t.Cleanup(func() { g.Unscoped().Delete(&model.IngestionJob{}, job.ID) })
+	return job.ID
+}
+
+func reload(t *testing.T, g *gorm.DB, id int64) model.IngestionJob {
+	t.Helper()
+	var j model.IngestionJob
+	if err := g.First(&j, id).Error; err != nil {
+		t.Fatalf("reload job %d: %v", id, err)
+	}
+	return j
+}
+
+// TestPurgeStaleAIStaging_PurgesOldExtractedOnly: an old, uncommitted
+// 'extracted' stage is reclaimed (payload nulled, moved to 'failed'); a recent
+// stage, a 'completed' job, and an already-emptied stage are all preserved.
+func TestPurgeStaleAIStaging_PurgesOldExtractedOnly(t *testing.T) {
+	g := openTestDB(t)
+	ctx := context.Background()
+	userID := seedTestUser(t, g)
+
+	payload := json.RawMessage(`{"rows":[{"amount":"1.00"}]}`)
+	now := time.Now()
+
+	oldStale := seedIngestionJob(t, g, userID, "extracted", payload, 10)  // > 7d → purge
+	recent := seedIngestionJob(t, g, userID, "extracted", payload, 1)     // < 7d → keep
+	completed := seedIngestionJob(t, g, userID, "completed", payload, 30) // not extracted → keep
+	emptied := seedIngestionJob(t, g, userID, "extracted", nil, 30)       // no payload → keep (idempotent)
+
+	// Dry-run count sees exactly the one purgeable row.
+	n, err := service.CountStaleAIStaging(ctx, g, now, service.DefaultAIStagingRetention)
+	if err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("CountStaleAIStaging = %d, want 1", n)
+	}
+
+	res, err := service.PurgeStaleAIStaging(ctx, g, now, service.DefaultAIStagingRetention)
+	if err != nil {
+		t.Fatalf("purge: %v", err)
+	}
+	if res.JobsPurged != 1 {
+		t.Fatalf("JobsPurged = %d, want 1", res.JobsPurged)
+	}
+
+	// The old stale row: payload gone, moved to terminal 'failed' with a reason.
+	got := reload(t, g, oldStale)
+	if got.Status != "failed" {
+		t.Errorf("oldStale status = %q, want failed", got.Status)
+	}
+	if got.Extraction != nil {
+		t.Errorf("oldStale extraction should be nil, got %s", got.Extraction)
+	}
+	if got.ErrorMessage == nil || *got.ErrorMessage == "" {
+		t.Error("oldStale should have an explanatory error_message")
+	}
+	if got.CompletedAt == nil {
+		t.Error("oldStale should have completed_at set")
+	}
+
+	// Recent stage untouched — still committable.
+	if r := reload(t, g, recent); r.Status != "extracted" || r.Extraction == nil {
+		t.Errorf("recent stage altered: status=%q extraction=%v", r.Status, r.Extraction)
+	}
+	// Completed job untouched.
+	if c := reload(t, g, completed); c.Status != "completed" || c.Extraction == nil {
+		t.Errorf("completed job altered: status=%q extraction=%v", c.Status, c.Extraction)
+	}
+	// Already-emptied 'extracted' row is not matched (extraction IS NULL).
+	if e := reload(t, g, emptied); e.Status != "extracted" {
+		t.Errorf("emptied stage altered: status=%q", e.Status)
+	}
+
+	// Idempotent: a second pass reclaims nothing.
+	res2, err := service.PurgeStaleAIStaging(ctx, g, now, service.DefaultAIStagingRetention)
+	if err != nil {
+		t.Fatalf("purge (2nd): %v", err)
+	}
+	if res2.JobsPurged != 0 {
+		t.Errorf("second purge JobsPurged = %d, want 0", res2.JobsPurged)
+	}
+}
+
+// TestPurgeStaleAIStaging_RetentionBoundary: retention is honored — a stage just
+// inside the window is kept, one just outside is purged.
+func TestPurgeStaleAIStaging_RetentionBoundary(t *testing.T) {
+	g := openTestDB(t)
+	ctx := context.Background()
+	userID := seedTestUser(t, g)
+	payload := json.RawMessage(`{"rows":[]}`)
+	now := time.Now()
+
+	inside := seedIngestionJob(t, g, userID, "extracted", payload, 5)  // 5d < 7d → keep
+	outside := seedIngestionJob(t, g, userID, "extracted", payload, 9) // 9d > 7d → purge
+
+	res, err := service.PurgeStaleAIStaging(ctx, g, now, service.DefaultAIStagingRetention)
+	if err != nil {
+		t.Fatalf("purge: %v", err)
+	}
+	if res.JobsPurged != 1 {
+		t.Fatalf("JobsPurged = %d, want 1", res.JobsPurged)
+	}
+	if r := reload(t, g, inside); r.Status != "extracted" {
+		t.Errorf("inside-window stage was purged: status=%q", r.Status)
+	}
+	if r := reload(t, g, outside); r.Status != "failed" {
+		t.Errorf("outside-window stage not purged: status=%q", r.Status)
+	}
+}

--- a/docs/ops/scheduled-jobs.md
+++ b/docs/ops/scheduled-jobs.md
@@ -12,7 +12,7 @@ must survive an app crash.
 |---|---|---|
 | `household-purge` | daily | Seals in-grace member rows whose grace window elapsed and removes their `account_shares` (privacy promise, ADR-0007). Idempotent. |
 | `price-refresh` | daily | Refreshes prices/FX for users who opted in via Settings (ADR-0014 §3). |
-| `ingestion-jobs purge` | daily *(lands with #337)* | Purges stale, uncommitted AI-import staging jobs. |
+| `ingestion-jobs-purge` | daily | Reclaims abandoned AI-import staging payloads: an `ingestion_jobs` row left at `status='extracted'` past the retention window (7 days) has its staged `extraction` JSONB nulled and moves to a terminal `failed` state. The audit row survives (append-only). |
 
 Each runs ~1 minute after boot, then every 24h, and stops on clean shutdown.
 
@@ -57,11 +57,16 @@ wired, a real notification):
 
 ## Running a job manually
 
-`household-purge` also has a standalone CLI for an out-of-band run (the in-app
-job doesn't replace it):
+Two jobs also have standalone CLIs for an out-of-band run (the in-app jobs don't
+replace them):
 
 ```sh
 cd backend && go run ./cmd/household-purge
+
+# AI-staging purge — dry-run by default; --apply to execute:
+cd backend && go run ./cmd/ingestion-jobs-purge                     # dry run
+cd backend && go run ./cmd/ingestion-jobs-purge --apply             # purge
+cd backend && go run ./cmd/ingestion-jobs-purge --retention-days 14 # custom window
 ```
 
 ## Failure handling


### PR DESCRIPTION
Closes #337

## What
Abandoned AI-import stages accumulate forever: when a user extracts a statement (ADR-0019 §7) but never commits, the `ingestion_jobs` row sits at `status='extracted'` with its staged `extraction` JSONB indefinitely. This reclaims them after a retention window (default **7 days**).

### Design note — null the payload, don't delete the row
`ingestion_jobs` is an **append-only audit trail** (`docs/ARCHITECTURE.md`, database rule), so the issue's "delete **or null the extraction payload**" is resolved toward nulling:

- `PurgeStaleAIStaging` nulls `extraction` (reclaims the large JSONB — the disk/privacy concern), moves the row to a terminal `failed` state with an explanatory `error_message`, and sets `completed_at`.
- The import attempt stays on the audit record; only the heavy, **no-longer-committable** payload is discarded. Flipping out of `extracted` also clears the ghost from the "awaiting commit" UI so it can't be committed against an emptied stage.

### Changes
- **`internal/service/ingestion_purge.go`** — `PurgeStaleAIStaging` (apply) + `CountStaleAIStaging` (dry-run), sharing one `WHERE` const so they can't drift. Idempotent; injected clock. `DefaultAIStagingRetention = 7d`.
- **`cmd/ingestion-jobs-purge`** — CLI mirroring `cmd/household-purge`: **dry-run by default**, `--apply` to execute, `--retention-days` to override, `config.Load()` for DB selection.
- **`cmd/server/main.go`** — registers the purge as a daily job on the **#359 in-app runner** (that issue's AC anticipated this landing on the same scheduler).
- **`docs/ops/scheduled-jobs.md`** — job now active; manual CLI documented.

## Acceptance criteria
- [x] Runner `cmd/ingestion-jobs-purge` mirroring `cmd/household-purge`; dry-run default, `--apply`, `config.Load()`.
- [x] Wired into the schedule — daily on the in-app job runner (#359 / ADR-0020), the chosen scheduling mechanism.
- [x] Retention default decided: 7 days (overridable).
- [x] Regression coverage: old `extracted` purged; recent + `completed` preserved.

## Tests
`internal/service/ingestion_purge_test.go` (real test DB): old `extracted` → purged (payload nulled, `status→failed`, `error_message` + `completed_at` set); recent stage, `completed` job, and already-emptied stage all preserved; dry-run count matches; second pass is a no-op; retention boundary (5d keep / 9d purge) honored.

## Verification
`command make verify` green — contract-check, `-race -p 1` tests incl. the new suite, lint, schema-check, migration round-trip, frontend lint+build. No new migration → `docs/db/schema.md` unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)