### PR TITLE
chore #397: local launchd headless driver for the autonomous delivery loop

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .DEFAULT_GOAL := help
 
-.PHONY: help verify acceptance qa-smoke qa-suite require-env ensure-env pre-deploy-backup deploy deployed-sha down teardown auto-deploy-install auto-deploy-uninstall backup restore backup-verify backup-list backup-install backup-uninstall
+.PHONY: help verify acceptance qa-smoke qa-suite require-env ensure-env pre-deploy-backup deploy deployed-sha down teardown auto-deploy-install auto-deploy-uninstall backup restore backup-verify backup-list backup-install backup-uninstall delivery-install delivery-uninstall
 
 # ─── Deploy configuration (ADR-0016) ─────────────────────────────────────────
 # Near-zero config by convention. The common case — one instance, behind
@@ -80,6 +80,8 @@ help:
 	@printf '%s\n' '  command make backup-list                 List the dumps on hand for this instance.'
 	@printf '%s\n' '  command make backup-install              Install the user-level nightly backup timer.'
 	@printf '%s\n' '  command make backup-uninstall            Remove the nightly backup timer.'
+	@printf '%s\n' '  command make delivery-install            Install the launchd autonomous-delivery loop (macOS).'
+	@printf '%s\n' '  command make delivery-uninstall          Remove the delivery-loop LaunchAgent.'
 	@printf '%s\n' ''
 	@printf '%s\n' 'Backend-only targets live in backend/Makefile; run them from backend/ with command make <target>.'
 
@@ -241,6 +243,15 @@ backup-install:
 
 backup-uninstall:
 	@OFFBOOK_FLAVOR="$(FLAVOR)" infra/backup/uninstall.sh
+
+# delivery-install / -uninstall: manage the user-level launchd agent that runs
+# the autonomous delivery loop headless on the owner's Mac. See
+# infra/delivery-loop/README.md and docs/dev/autonomous-delivery.md § Durability.
+delivery-install:
+	@infra/delivery-loop/install.sh
+
+delivery-uninstall:
+	@infra/delivery-loop/uninstall.sh
 
 acceptance:
 	@./scripts/qa-assert-role.sh

--- a/docs/dev/autonomous-delivery.md
+++ b/docs/dev/autonomous-delivery.md
@@ -33,8 +33,9 @@ it is Sonnet or Opus, never Fable.
 
 ## The loop (one iteration = one shipped PR)
 
-The durable driver is a cloud cron routine (see **Durability** below), not the
-local `/loop` skill — but each firing runs the same iteration. Each iteration:
+The durable driver is a local launchd timer running headless `claude -p` (see
+**Durability** below), not the interactive `/loop` skill — but each firing runs
+the same iteration. Each iteration:
 
 1. **Pick** the next unchecked issue from the active epic in dependency order
    (below). Skip issues whose prerequisites are unmerged.
@@ -52,24 +53,29 @@ local `/loop` skill — but each firing runs the same iteration. Each iteration:
 Pacing: the loop is quota-bound, not time-bound. Use a long fallback wake
 (1200s+) only as a heartbeat; the real signal is subagent completion.
 
-## Durability — the engine is a cloud cron routine, not the local session
+## Durability — the engine is a local launchd timer, not a live session
 
-**The failure this section fixes:** an interactive Claude session driving the
-loop dies when the 5-hour quota cap is hit (or the laptop sleeps, or the REPL is
-closed). `ScheduleWakeup` and `CronCreate` both re-invoke *this* session and only
-fire while the local REPL is alive — so neither survives quota exhaustion. If the
-loop depends on them alone, it silently stops and never resumes.
+**The failures this section fixes.** (1) An interactive Claude session driving
+the loop dies when the 5-hour quota cap is hit (or the REPL is closed) —
+`ScheduleWakeup`/`CronCreate` only fire while that session is alive, so the loop
+silently stops. (2) The claude.ai **cloud-routine** experiment (July 2026) fixed
+the survival problem and did ship five issues, but each firing pushed
+interactive permission approvals to the owner's phone (not autonomous) and its
+sessions were unobservable in the Claude app.
 
-**The fix:** the durable driver is a **claude.ai cloud routine** (managed via the
-`RemoteTrigger` tool / the `/schedule` skill), created on the **bridge
-environment** so it executes against this repo's working tree with the local git
-+ `gh` credentials and the local Docker/Colima Postgres that `make verify` needs.
-The cloud scheduler fires it on a wall-clock cron **independently of any local
-session**. When quota is exhausted a firing no-ops (or fails cheaply) and the
-*next* scheduled firing — after the window resets — picks up exactly where the
-last left off. That is the self-healing property the local loop lacked.
+**The engine:** a user-level **macOS LaunchAgent** (`com.offbook.delivery`,
+managed by `command make delivery-install` / `delivery-uninstall`; implementation
+in [`infra/delivery-loop/`](../../infra/delivery-loop/README.md)). Every ~3 h it
+runs one headless iteration — `claude -p` with the prompt in
+`infra/delivery-loop/iteration-prompt.md`, Sonnet, `--dangerously-skip-permissions`
+so nothing ever waits on a human — inside a dedicated delivery clone
+(`~/src/offbook-delivery`), never the owner's working checkout. Logs land in
+`~/Library/Logs/offbook-delivery/`. A quota-capped firing fails cheaply and the
+next firing — after the window resets — picks up exactly where the last left
+off. That is the self-healing property: wall-clock scheduling outside any Claude
+session, on the machine where git/gh/Docker are already warm.
 
-Routine invariants (encoded in the routine's prompt):
+Iteration invariants (encoded in the iteration prompt):
 
 - **One iteration per firing.** Each firing ships *at most one* PR, then exits.
   This bounds per-firing cost and lets quota back-pressure throttle naturally —
@@ -82,20 +88,21 @@ Routine invariants (encoded in the routine's prompt):
 - **State lives in GitHub, not the session.** The epic checklists (#383/#384/#385)
   plus merged PRs are the source of truth for "what's done." A cold firing
   reconstructs position from them + this file — never from prior session memory.
-- **Cadence** ≈ every 2h so each rolling 5-hour window gets ≥2 attempts; a capped
-  firing simply retries next window. Recurring routines auto-expire after 7 days —
-  re-arm (or bump the schedule) to continue a multi-week run.
-- **Model:** the routine runs as Sonnet (the workhorse tier). Issues flagged
+- **Cadence** ≈ every 3h (tunable at install: `OFFBOOK_DELIVERY_INTERVAL`); a
+  capped firing simply retries next window. launchd persists across reboots —
+  no expiry, no re-arming.
+- **Model:** the iteration runs as Sonnet (the workhorse tier). Issues flagged
   Opus-design in the delivery order get their ADR/design slice written first, then
   implemented; money/valuation correctness is never downgraded to Fable.
 - **Human-gated stops** (#362 and any owner-secret step) are done to their
-  agent-completable slice, then the routine comments on the issue and advances —
+  agent-completable slice, then the iteration comments on the issue and advances —
   never blocks the loop.
 
 An interactive session may still hand-drive iterations (e.g. to burn a live quota
-window faster), but it must not run concurrently with the routine on the *same*
-issue — the idempotency guard above is the tie-breaker. The routine is the thing
-that guarantees the plan keeps moving when no one is watching.
+window faster), but it must not run concurrently with the timer on the *same*
+issue — the idempotency guard above is the tie-breaker. The launchd timer is the
+thing that guarantees the plan keeps moving when no one is watching. (The retired
+cloud routine `trig_01BGrffWSrKTmYrMoTETRkgD` is kept disabled as a fallback.)
 
 ## Delivery scope — everything up to Milestone B
 

--- a/infra/delivery-loop/README.md
+++ b/infra/delivery-loop/README.md
@@ -1,0 +1,70 @@
+# Autonomous Delivery Loop — local launchd driver
+
+Runs the production-readiness delivery loop
+([docs/dev/autonomous-delivery.md](../../docs/dev/autonomous-delivery.md))
+**headless on the owner's Mac**: a user-level LaunchAgent fires
+`run-iteration.sh` on an interval; each firing runs one `claude -p` iteration
+(Sonnet, permissions bypassed) that ships **at most one PR** and exits.
+
+## Why local, not a cloud routine
+
+The claude.ai cloud-routine experiment (July 2026) *did* deliver — five issues
+merged overnight — but each firing pushed interactive permission approvals to
+the owner's phone (not autonomous) and its sessions were not observable in the
+Claude iOS app. Running locally fixes both: `--dangerously-skip-permissions`
+means zero approval prompts, and every iteration writes a plain log file you
+can `tail`. The env is also already warm — local git + `gh` credentials,
+Colima/Docker Postgres for `make verify` — no cold-start cost.
+
+## Install / manage
+
+```sh
+command make delivery-install      # from the repo root
+command make delivery-uninstall
+```
+
+Install creates a **dedicated clone** at `~/src/offbook-delivery` (the loop
+never touches your working checkout — no branch/index fights with an active
+dev session), renders `com.offbook.delivery.plist`, and bootstraps it into
+launchd. Idempotent; re-run to refresh.
+
+| Knob (env var at install time) | Default | Meaning |
+|---|---|---|
+| `OFFBOOK_DELIVERY_INTERVAL` | `10800` (3 h) | Seconds between firings |
+| `OFFBOOK_DELIVERY_DIR` | `~/src/offbook-delivery` | Delivery clone location |
+| `OFFBOOK_DELIVERY_MODEL` | `claude-sonnet-5` | Model for the iteration (runner env) |
+| `OFFBOOK_DELIVERY_MAX_SECONDS` | `10800` | Watchdog kills a runaway iteration (runner env) |
+
+Ad-hoc control:
+
+```sh
+launchctl kickstart gui/$(id -u)/com.offbook.delivery   # fire one iteration now
+launchctl bootout   gui/$(id -u)/com.offbook.delivery   # pause (uninstall re-arms)
+tail -f ~/Library/Logs/offbook-delivery/iteration-*.log # watch a run
+```
+
+## Behavior & safety
+
+- **One iteration = one PR max.** The prompt (`iteration-prompt.md`) enforces
+  idempotent pick (existing PR → finish it, never duplicate), CI gating before
+  merge, and stop-on-blocker. `main` stays PR-only protected.
+- **Quota is the governor.** A firing that hits the plan's usage cap fails
+  cheaply; the next firing (after the window resets) resumes from GitHub
+  state. Nothing to babysit. To leave more daytime quota for interactive use,
+  reinstall with a longer interval (e.g. `OFFBOOK_DELIVERY_INTERVAL=21600`).
+- **Overlap-safe.** launchd never double-starts the label, a stale-aware lock
+  guards manual runs, and a wall-clock watchdog kills a hung iteration.
+- **Permissions are bypassed** (`--dangerously-skip-permissions`) — that is
+  the point, and it is why this runs only on the owner's own machine, scoped
+  by the prompt to this repo + its toolchain. Do not reuse this harness on a
+  shared host.
+- Logs older than 14 days are pruned automatically.
+
+## Files
+
+| File | Role |
+|---|---|
+| `iteration-prompt.md` | The self-contained prompt each firing executes |
+| `run-iteration.sh` | Lock → refresh clone → `claude -p` → watchdog → log |
+| `com.offbook.delivery.plist.template` | LaunchAgent, rendered by install.sh |
+| `install.sh` / `uninstall.sh` | Manage the LaunchAgent + delivery clone |

--- a/infra/delivery-loop/com.offbook.delivery.plist.template
+++ b/infra/delivery-loop/com.offbook.delivery.plist.template
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.offbook.delivery</string>
+
+    <!-- Login shell so brew/go/node/claude land on PATH exactly as in the
+         owner's terminal — launchd's default env is nearly empty. -->
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/zsh</string>
+        <string>-l</string>
+        <string>-c</string>
+        <string>exec "__RUNNER__"</string>
+    </array>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>OFFBOOK_DELIVERY_DIR</key>
+        <string>__DELIVERY_DIR__</string>
+    </dict>
+
+    <!-- Fire every __INTERVAL__ seconds. launchd never double-starts a label,
+         so a long iteration simply absorbs the next tick. -->
+    <key>StartInterval</key>
+    <integer>__INTERVAL__</integer>
+    <key>RunAtLoad</key>
+    <false/>
+
+    <!-- The runner redirects its own output to a per-iteration log; these
+         catch launchd-level failures (e.g. zsh itself failing to start). -->
+    <key>StandardOutPath</key>
+    <string>__LOG_DIR__/launchd.log</string>
+    <key>StandardErrorPath</key>
+    <string>__LOG_DIR__/launchd.log</string>
+
+    <key>ProcessType</key>
+    <string>Background</string>
+</dict>
+</plist>

--- a/infra/delivery-loop/install.sh
+++ b/infra/delivery-loop/install.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+# Install the Offbook autonomous-delivery LaunchAgent (macOS, user-level).
+#
+#   command make delivery-install                # from the repo root
+#   OFFBOOK_DELIVERY_INTERVAL=21600 install.sh   # custom cadence (seconds)
+#
+# What it does:
+#   1. Creates/refreshes a DEDICATED delivery clone (default
+#      ~/src/offbook-delivery) so the loop never touches your working checkout.
+#   2. Renders com.offbook.delivery.plist and bootstraps it into launchd.
+# Idempotent — re-running updates the clone, plist, and schedule in place.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+DELIVERY_DIR="${OFFBOOK_DELIVERY_DIR:-$HOME/src/offbook-delivery}"
+INTERVAL="${OFFBOOK_DELIVERY_INTERVAL:-10800}"   # 3h default
+LOG_DIR="$HOME/Library/Logs/offbook-delivery"
+PLIST_DST="$HOME/Library/LaunchAgents/com.offbook.delivery.plist"
+LABEL="com.offbook.delivery"
+
+echo "== Offbook delivery loop install =="
+
+# ── Preflight ────────────────────────────────────────────────────────────────
+for bin in claude git gh; do
+  command -v "$bin" >/dev/null || { echo "FATAL: '$bin' not on PATH" >&2; exit 1; }
+done
+gh auth status >/dev/null 2>&1 || { echo "FATAL: gh is not authenticated (run 'gh auth login')" >&2; exit 1; }
+
+# ── Delivery clone ───────────────────────────────────────────────────────────
+ORIGIN_URL="$(git -C "$REPO_ROOT" remote get-url origin)"
+if [ ! -d "$DELIVERY_DIR/.git" ]; then
+  echo "Cloning $ORIGIN_URL -> $DELIVERY_DIR"
+  git clone "$ORIGIN_URL" "$DELIVERY_DIR"
+else
+  echo "Refreshing existing delivery clone at $DELIVERY_DIR"
+  git -C "$DELIVERY_DIR" fetch origin
+  git -C "$DELIVERY_DIR" checkout -q main
+  git -C "$DELIVERY_DIR" pull --ff-only -q
+fi
+
+# ── Render + load the LaunchAgent ────────────────────────────────────────────
+mkdir -p "$LOG_DIR" "$HOME/Library/LaunchAgents"
+RUNNER="$DELIVERY_DIR/infra/delivery-loop/run-iteration.sh"
+chmod +x "$RUNNER" "$SCRIPT_DIR/run-iteration.sh"
+
+sed -e "s|__RUNNER__|$RUNNER|g" \
+    -e "s|__DELIVERY_DIR__|$DELIVERY_DIR|g" \
+    -e "s|__LOG_DIR__|$LOG_DIR|g" \
+    -e "s|__INTERVAL__|$INTERVAL|g" \
+    "$SCRIPT_DIR/com.offbook.delivery.plist.template" > "$PLIST_DST"
+
+UID_NUM="$(id -u)"
+launchctl bootout "gui/$UID_NUM/$LABEL" 2>/dev/null || true
+launchctl bootstrap "gui/$UID_NUM" "$PLIST_DST"
+
+echo
+echo "Installed. The loop fires every $((INTERVAL / 60)) minutes."
+echo "  runner:   $RUNNER"
+echo "  logs:     $LOG_DIR/iteration-*.log"
+echo "  run now:  launchctl kickstart gui/$UID_NUM/$LABEL"
+echo "  pause:    launchctl bootout gui/$UID_NUM/$LABEL"
+echo "  remove:   command make delivery-uninstall"

--- a/infra/delivery-loop/iteration-prompt.md
+++ b/infra/delivery-loop/iteration-prompt.md
@@ -1,0 +1,30 @@
+You are the autonomous delivery worker for Offbook's production-readiness program, running headless on the owner's machine with permissions bypassed. Restrict yourself to this repository, `gh`, `git`, `docker`/`colima`, and the Go/Node toolchains — touch nothing else on the machine. This is a scheduled firing with a fresh, cold session. Do EXACTLY ONE iteration (ship at most one PR), then STOP. Do not loop. The next scheduled firing continues where you leave off. If the API reports quota/usage-limit exhaustion at any point, stop immediately — the next firing retries after the window resets.
+
+STEP 1 — Load context (source of truth, in this order):
+- Read AGENTS.md (repo conventions, git discipline, `command make` requirement).
+- Read docs/dev/autonomous-delivery.md — the delivery harness: model tiering, the loop, the Durability section, and the dependency-sequenced delivery order (Phase 0 M13 -> Phase 1 M14 -> Phase 2 M15, up to and including Milestone B). Follow it exactly.
+- Reconstruct progress from GitHub, never from memory: `gh issue view 383`, `gh issue view 384`, `gh issue view 385` (the epics; checked boxes = merged), and `gh pr list --state open`.
+
+STEP 2 — Idempotent pick (avoid colliding with a prior firing):
+- First run `gh pr list --state open` and `git branch -a`. If an open PR already exists for the next issue in order: if its CI is green and it is mergeable, squash-merge it (`gh pr merge <n> --squash --delete-branch`), tick the epic checkbox, and STOP (that is this firing's one iteration). If it is red, fix it forward on its branch, get CI green, merge, tick, STOP. Never open a duplicate PR/branch for an issue that already has one.
+- Otherwise pick the next UNCHECKED issue in the documented delivery order whose prerequisites are already merged.
+
+STEP 3 — Implement one issue:
+- `git fetch origin main` and branch `feature/{issue}-{slug}` off latest `origin/main`.
+- Read the issue with `gh issue view <n>`. Implement to its acceptance criteria AND its Product Goal. Add/extend tests. Respect all repo rules: money uses shopspring/decimal + NUMERIC(30,18) (never float); PII stays in pii_store; the household aggregator and AI layer never import pii_repo; schema changes go through golang-migrate and then `cd backend && command make schema`.
+- Verify like CI: ensure the Docker daemon is up (if `docker ps` fails, run `colima start` and wait), then from backend/ run `command make verify` and `command make schema-check`. All must be green before you push. Use `command make` (a zsh stub shadows raw make). Run each shell command in its own step; do not `&&`-chain a `cd`.
+
+STEP 4 — Ship (main is PROTECTED — PR only):
+- Commit (end the message with `Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>`). NEVER `git commit --amend`, `git reset --hard`, or force-push — fix forward with new commits.
+- `git push -u origin <branch>`; `gh pr create --body "Closes #<n>" ...` and end the PR body with `🤖 Generated with [Claude Code](https://claude.com/claude-code)`.
+- Wait for CI: `gh pr checks <n> --watch`. When all green and mergeable: `gh pr merge <n> --squash --delete-branch`.
+- Tick the issue's checkbox on its epic (#383/#384/#385) with `gh issue edit`.
+
+STEP 5 — Stop. Report in your final message: which issue you shipped (PR#), or why you no-opped (e.g. quota, blocked prereq, nothing left).
+
+GUARDRAILS:
+- Human-gated issues (#362 Plaid production application, and any step needing an owner-only secret such as an off-host backup target or a notifier endpoint URL): do only the agent-completable slice (ADR/checklist/config seam with a working default), comment the remaining human step on the issue, tick nothing that isn't truly done, and treat that as your one iteration.
+- If CI cannot be made green within reason, or you are blocked, leave the PR open with a comment describing the blocker and STOP — the next firing or a human picks it up. Do not thrash.
+- Do not fix unrelated problems; file `gh issue create --label backlog` and move on.
+- Never QA-certify your own work; that is a separate manually-triggered role.
+- Scope ends at Milestone B (end of Phase 2 / M15 epic #385). If everything up to B is merged, no-op and report that the program is complete up to B.

--- a/infra/delivery-loop/run-iteration.sh
+++ b/infra/delivery-loop/run-iteration.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+# One firing of the Offbook autonomous delivery loop.
+#
+# Invoked by the com.offbook.delivery LaunchAgent (see install.sh) on a
+# StartInterval cadence. Runs headless `claude -p` with permissions bypassed
+# in a DEDICATED delivery clone — never the owner's working checkout — so an
+# active dev session and the loop can't fight over branches or the index.
+#
+# Design (mirrors docs/dev/autonomous-delivery.md § Durability):
+#   * one iteration = at most one shipped PR, then exit
+#   * a quota-capped firing fails cheaply; the next firing retries
+#   * overlap-safe: launchd never double-starts a label, plus a stale-aware lock
+set -u
+
+LABEL="offbook-delivery"
+DELIVERY_DIR="${OFFBOOK_DELIVERY_DIR:-$HOME/src/offbook-delivery}"
+LOG_DIR="${OFFBOOK_DELIVERY_LOG_DIR:-$HOME/Library/Logs/offbook-delivery}"
+LOCK_DIR="${TMPDIR:-/tmp}/${LABEL}.lock"
+# Kill a runaway iteration after this many seconds (default 3h — one interval).
+MAX_SECONDS="${OFFBOOK_DELIVERY_MAX_SECONDS:-10800}"
+MODEL="${OFFBOOK_DELIVERY_MODEL:-claude-sonnet-5}"
+PROMPT_FILE="$DELIVERY_DIR/infra/delivery-loop/iteration-prompt.md"
+
+mkdir -p "$LOG_DIR"
+LOG_FILE="$LOG_DIR/iteration-$(date +%Y%m%d-%H%M%S).log"
+exec >>"$LOG_FILE" 2>&1
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*"; }
+
+# ── Overlap guard ────────────────────────────────────────────────────────────
+# launchd already refuses to double-start the label; the lock additionally
+# protects against a manual run racing a scheduled one. Steal locks older
+# than MAX_SECONDS — their owner is dead or about to be killed anyway.
+if ! mkdir "$LOCK_DIR" 2>/dev/null; then
+  age=$(( $(date +%s) - $(stat -f %m "$LOCK_DIR" 2>/dev/null || echo 0) ))
+  if [ "$age" -lt "$MAX_SECONDS" ]; then
+    log "another iteration holds the lock (age ${age}s) — skipping this firing"
+    exit 0
+  fi
+  log "stealing stale lock (age ${age}s)"
+  rm -rf "$LOCK_DIR"
+  mkdir "$LOCK_DIR" || exit 1
+fi
+trap 'rm -rf "$LOCK_DIR"' EXIT
+
+# ── Preflight ────────────────────────────────────────────────────────────────
+for bin in claude git gh; do
+  command -v "$bin" >/dev/null || { log "FATAL: '$bin' not on PATH"; exit 1; }
+done
+[ -d "$DELIVERY_DIR/.git" ] || { log "FATAL: delivery clone missing at $DELIVERY_DIR — run install.sh"; exit 1; }
+
+cd "$DELIVERY_DIR" || exit 1
+log "refreshing delivery clone at $DELIVERY_DIR"
+git fetch origin || { log "FATAL: git fetch failed"; exit 1; }
+git checkout -q main || { log "FATAL: cannot checkout main"; exit 1; }
+git pull --ff-only -q || { log "FATAL: ff-only pull failed"; exit 1; }
+[ -f "$PROMPT_FILE" ] || { log "FATAL: prompt file missing at $PROMPT_FILE"; exit 1; }
+
+# ── Run one iteration, with a wall-clock watchdog ────────────────────────────
+log "starting iteration: model=$MODEL max=${MAX_SECONDS}s"
+claude -p "$(cat "$PROMPT_FILE")" \
+  --model "$MODEL" \
+  --dangerously-skip-permissions \
+  --output-format text &
+CLAUDE_PID=$!
+( sleep "$MAX_SECONDS"; kill "$CLAUDE_PID" 2>/dev/null && echo "WATCHDOG: killed iteration after ${MAX_SECONDS}s" ) &
+WATCHDOG_PID=$!
+wait "$CLAUDE_PID"
+STATUS=$?
+kill "$WATCHDOG_PID" 2>/dev/null
+wait "$WATCHDOG_PID" 2>/dev/null
+
+log "iteration finished with exit status $STATUS"
+
+# Keep two weeks of logs.
+find "$LOG_DIR" -name 'iteration-*.log' -mtime +14 -delete 2>/dev/null
+
+exit "$STATUS"

--- a/infra/delivery-loop/uninstall.sh
+++ b/infra/delivery-loop/uninstall.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# Remove the Offbook autonomous-delivery LaunchAgent.
+# Keeps the delivery clone and logs — delete those by hand if wanted:
+#   rm -rf ~/src/offbook-delivery ~/Library/Logs/offbook-delivery
+set -euo pipefail
+
+LABEL="com.offbook.delivery"
+PLIST="$HOME/Library/LaunchAgents/$LABEL.plist"
+
+launchctl bootout "gui/$(id -u)/$LABEL" 2>/dev/null || true
+rm -f "$PLIST"
+echo "Removed $LABEL. Delivery clone and logs left in place."


### PR DESCRIPTION
Closes #397

## What
Replaces the claude.ai cloud routine as the durable engine for the production-readiness delivery loop with a **user-level macOS LaunchAgent** running headless `claude -p` on the owner's Mac.

## Why
The cloud routine **did deliver** — #392–#396 shipped issues #352, #358, #357, #359, #337 overnight — but it failed the owner's autonomy requirements: every firing pushed interactive permission approvals to the phone (not auto mode), and its sessions were unobservable in the Claude iOS app. Owner direction: run the harness locally where the env is warm.

## How
- `infra/delivery-loop/iteration-prompt.md` — the proven one-iteration prompt (idempotent pick, one PR max, CI-gated merge, stop-on-blocker), now with local-machine scoping + quota-exhaustion early exit.
- `infra/delivery-loop/run-iteration.sh` — stale-aware lock → refresh a **dedicated delivery clone** (`~/src/offbook-delivery`, never the working checkout) → `claude -p` (Sonnet, permissions bypassed) with a wall-clock watchdog → per-iteration log under `~/Library/Logs/offbook-delivery/` (14-day retention).
- `com.offbook.delivery.plist.template` + `install.sh`/`uninstall.sh` — rendered + bootstrapped via `launchctl`; `StartInterval` 3h default (tunable), login-shell wrapper so brew PATH resolves under launchd.
- Root `make delivery-install` / `delivery-uninstall` (mirrors `auto-deploy-*`/`backup-*`).
- `docs/dev/autonomous-delivery.md` § Durability rewritten for the launchd engine; cloud routine retired (kept disabled as fallback).

## Verification
- `bash -n` clean on all three scripts; rendered plist passes `plutil -lint`.
- `/bin/zsh -lc` (the launchd exec context) resolves `claude`/`gh`/`git`/`docker`; headless `claude -p` smoke returns correctly.
- No backend/frontend code touched — infra + docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)