### PR TITLE
fix #397: don't kill iteration background tasks at 600s; warn on untrusted clone

### DIFF
--- a/infra/delivery-loop/README.md
+++ b/infra/delivery-loop/README.md
@@ -61,6 +61,10 @@ tail -f ~/Library/Logs/offbook-delivery/iteration-*.log # watch a run
   is deliberately NOT used). A denied call means the iteration adapts or stops
   cleanly; it never waits on a phone prompt. Still: run this only on the
   owner's own machine.
+- **Trust the delivery clone once** (owner action; install.sh warns if
+  missing): `cd ~/src/offbook-delivery && claude`, accept the trust dialog,
+  exit. Untrusted workspaces ignore the repo's `permissions.allow` list, which
+  starves auto mode of its pre-approvals.
 - Logs older than 14 days are pruned automatically.
 
 ## Files

--- a/infra/delivery-loop/install.sh
+++ b/infra/delivery-loop/install.sh
@@ -54,6 +54,19 @@ UID_NUM="$(id -u)"
 launchctl bootout "gui/$UID_NUM/$LABEL" 2>/dev/null || true
 launchctl bootstrap "gui/$UID_NUM" "$PLIST_DST"
 
+# Claude Code ignores the repo's permissions.allow list in an untrusted
+# workspace, which starves the auto-mode iteration of its pre-approvals.
+# Trust is the owner's to grant — detect and instruct, never self-modify.
+if command -v jq >/dev/null && [ -f "$HOME/.claude.json" ]; then
+  trusted="$(jq -r --arg d "$DELIVERY_DIR" '.projects[$d].hasTrustDialogAccepted // false' "$HOME/.claude.json")"
+  if [ "$trusted" != "true" ]; then
+    echo
+    echo "⚠️  $DELIVERY_DIR is not a trusted Claude workspace — the repo allowlist"
+    echo "   will be ignored. Trust it once (owner action):"
+    echo "     cd $DELIVERY_DIR && claude   # accept the trust dialog, then exit"
+  fi
+fi
+
 echo
 echo "Installed. The loop fires every $((INTERVAL / 60)) minutes."
 echo "  runner:   $RUNNER"

--- a/infra/delivery-loop/run-iteration.sh
+++ b/infra/delivery-loop/run-iteration.sh
@@ -58,6 +58,10 @@ git pull --ff-only -q || { log "FATAL: ff-only pull failed"; exit 1; }
 [ -f "$PROMPT_FILE" ] || { log "FATAL: prompt file missing at $PROMPT_FILE"; exit 1; }
 
 # ── Run one iteration, with a wall-clock watchdog ────────────────────────────
+# Headless print mode kills lingering background tasks (subagents, `--watch`es)
+# after 600s by default — that aborted a real iteration mid-implementation.
+# Wait indefinitely instead; OUR watchdog below is the runaway bound.
+export CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS=0
 log "starting iteration: model=$MODEL max=${MAX_SECONDS}s"
 claude -p "$(cat "$PROMPT_FILE")" \
   --model "$MODEL" \


### PR DESCRIPTION
Refs #397 (follow-up to #398/#399)

Two defects found watching the first real firings:

1. **600s background-task ceiling aborted an iteration.** The 05:01 PT firing logged `Background tasks still running after 600s; terminating` and exited without shipping. Headless print mode kills lingering background tasks (subagents, watches) after 10 minutes by default — far too short for implement→verify→CI. `run-iteration.sh` now sets `CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS=0`; the runner's own wall-clock watchdog (default 3h) remains the runaway bound.

2. **Untrusted delivery clone starves auto mode.** Firings logged `Ignoring 28 permissions.allow entries … workspace has not been trusted`. Trust is the owner's to grant, so `install.sh` now detects it and prints the one-time action (`cd ~/src/offbook-delivery && claude`, accept dialog); README documents it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)