### PR TITLE
ci #272: gate acceptance baseline smoke on every PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,3 +174,66 @@ jobs:
         run: pnpm lint
       - name: Build
         run: pnpm build
+
+  qa-smoke:
+    name: QA acceptance baseline smoke
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: acceptance/pnpm-lock.yaml
+      # Ephemeral QA secrets for this run only — never committed, never reused
+      # across runs. qa-preflight.sh refuses placeholder SESSION_SECRET values,
+      # so these must be real random ones even in CI.
+      - name: Generate QA env
+        run: |
+          cp .env.qa.example .env.qa
+          {
+            echo "SESSION_SECRET=$(openssl rand -hex 32)"
+            echo "QA_SECRET=$(openssl rand -hex 32)"
+          } >> .env.qa
+      - name: Boot QA stack
+        run: docker compose -p offbook-qa -f docker-compose.yml -f docker-compose.qa.yml up -d --build
+      - name: Wait for backend health
+        run: |
+          for i in $(seq 1 60); do
+            if curl -sf http://localhost:18000/api/v1/health >/dev/null; then
+              echo "backend healthy"
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "backend did not become healthy in time" >&2
+          docker compose -p offbook-qa -f docker-compose.yml -f docker-compose.qa.yml logs --no-color
+          exit 1
+      - name: Install acceptance deps
+        working-directory: acceptance
+        run: pnpm install --frozen-lockfile
+      # PLAYWRIGHT_BROWSERS_PATH must match what `make qa-smoke` uses
+      # (Makefile default: acceptance/.cache/ms-playwright) or the test run
+      # can't find the browser it just installed.
+      - name: Install Playwright Chromium
+        working-directory: acceptance
+        env:
+          PLAYWRIGHT_BROWSERS_PATH: .cache/ms-playwright
+        run: pnpm exec playwright install --with-deps chromium
+      - name: Bootstrap QA personas
+        env:
+          OFFBOOK_ROLE: qa
+        run: node acceptance/fixtures/bootstrap.mjs
+      - name: Run baseline smoke
+        env:
+          OFFBOOK_ROLE: qa
+        run: make qa-smoke
+      - name: QA stack logs
+        if: failure()
+        run: docker compose -p offbook-qa -f docker-compose.yml -f docker-compose.qa.yml logs --no-color
+      - name: Tear down QA stack
+        if: always()
+        run: docker compose -p offbook-qa -f docker-compose.yml -f docker-compose.qa.yml down -v

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,7 +49,7 @@ pacing so an autonomous session can resume the program across quota windows.
 - QA browser automation uses Playwright headless Chromium. Run from a `*-qa` worktree or set `OFFBOOK_ROLE=qa` so QA helper scripts can tell the role apart from development.
 - QA persona emails and credential derivation are defined in @docs/QA.md and are for the isolated QA stack only.
 - Follow @docs/QA.md for QA runs: use GitHub Discussion #199 as the QA Ledger, compare against the last QAed commit with `scripts/qa-last-reviewed.sh`, and include the "found at" commit when filing or commenting on bugs.
-- Acceptance tests live outside unit tests. They start as optional, manually run suites and are not merge-required until the owner explicitly promotes them.
+- Acceptance tests live outside unit tests. They start as optional, manually run suites and are not merge-required until the owner explicitly promotes them. **Exception:** `acceptance/smoke/baseline.spec.ts` is promoted — it runs as the required `QA acceptance baseline smoke` CI check on every PR (#272). Every other suite stays opt-in.
 
 ## Git Discipline
 - Auto-commit completed work without asking.

--- a/docs/QA.md
+++ b/docs/QA.md
@@ -271,6 +271,8 @@ Browser checks:
 
 Acceptance tests are separate from unit tests and from `make verify`. They exercise user-level product requirements through the running app and API. They start as optional, manually run checks and are not required for merging until the owner explicitly promotes them.
 
+**Exception — the baseline suite is promoted (#272).** `acceptance/smoke/baseline.spec.ts` runs as the required `QA acceptance baseline smoke` GitHub Actions check on every PR: it boots the isolated `docker-compose.qa.yml` stack, bootstraps QA personas, and visits the full public + authenticated + household route list, asserting no console errors, no runtime exceptions, and no API 4xx/5xx (the #266/#268 regression class). Every other suite (`auth/`, `plaid/`, household privacy/lifecycle, etc.) remains opt-in and manually triggered until the owner promotes it too.
+
 Location:
 
 - Browser/API acceptance tests: `acceptance/`.


### PR DESCRIPTION
Closes #272

## Summary
- Adds a new `QA acceptance baseline smoke` job to `.github/workflows/ci.yml` that boots the isolated `docker-compose.qa.yml` stack (project `offbook-qa`, ports 15173/18000/15432, same as manual QA), bootstraps the four QA personas via `acceptance/fixtures/bootstrap.mjs`, and runs `make qa-smoke` — the `acceptance/smoke/baseline.spec.ts` suite covering ~6 public routes + ~14 authenticated/household routes across desktop and mobile viewports.
- Ephemeral `SESSION_SECRET`/`QA_SECRET` are generated per CI run (never committed, never reused) — `qa-preflight.sh` refuses known placeholder secrets, so this was required to pass its guard.
- `docs/QA.md` and `AGENTS.md` updated to record the baseline suite as the one promoted, CI-required exception to "acceptance suites are opt-in until the owner promotes them" — every other suite (`auth/`, `plaid/`, household privacy/lifecycle, etc.) stays manually triggered.

## Notes
- Playwright's `PLAYWRIGHT_BROWSERS_PATH` in the install step is pinned to `acceptance/.cache/ms-playwright` to match what `make qa-smoke` expects (the Makefile default) — installing without it puts the browser in the wrong cache dir and the test run can't find it.
- Did not add branch-protection "required status check" enforcement via the GitHub API in this PR — that's a repo-wide setting affecting every existing check (contract-check, backend-test, etc., none of which are currently required either), which felt like a separate, owner-level call rather than something to fold into this issue silently. Flagging on the issue instead of ticking that box unilaterally.

## Test plan
- [x] Ran the full flow locally exactly as CI will: built + booted `docker compose -p offbook-qa -f docker-compose.yml -f docker-compose.qa.yml up -d --build`, waited for backend health, bootstrapped personas, ran `OFFBOOK_ROLE=qa make qa-smoke` — 40/40 passed.
- [x] `make verify` and `make schema-check` green (no backend/frontend code touched by this PR).
- [ ] CI run on this PR (first real run of the new job in GitHub Actions' environment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)