### PR TITLE
Deploy/rollback runbook: post-deploy SHA smoke + GIT_REF rollback

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,6 +70,7 @@ help:
 	@printf '%s\n' '  command make verify              Run the backend CI mirror from backend/'
 	@printf '%s\n' '  command make deploy [FLAVOR=prod]        Deploy/update an instance (default dev). First boot only:'
 	@printf '%s\n' '                                           add TS_AUTHKEY=tskey-... TS_HOSTNAME=<name> to register the sidecar.'
+	@printf '%s\n' '  command make deploy GIT_REF=<sha>        Pin/roll back to a prior commit (see docs/ops/deploy-rollback.md).'
 	@printf '%s\n' '  command make down [FLAVOR=prod]          Stop an instance (data preserved).'
 	@printf '%s\n' '  command make teardown [FLAVOR=prod]      Destroy an instance: containers + volumes (DB + tailnet identity).'
 	@printf '%s\n' '  command make auto-deploy-install         Install the user-level systemd poll-and-redeploy timer.'
@@ -117,10 +118,11 @@ ensure-env:
 		echo "Generated a SESSION_SECRET into $(ENV_FILE)"; \
 	fi
 
-# deploy is the single command for an instance — first boot AND updates. It
-# stamps the build with the current short SHA (surfaced at GET /health and
-# Settings → About, #310), then prunes dangling images (so repeated deploys
-# don't fill the disk — matters on the Pi's SD card) and reports /health.
+# deploy is the single command for an instance — first boot, updates, AND
+# rollback/pin. It stamps the build with the current short SHA (surfaced at
+# GET /health and Settings → About, #310), then prunes dangling images (so
+# repeated deploys don't fill the disk — matters on the Pi's SD card) and
+# runs a post-deploy smoke check (#361, see below).
 #
 # It auto-detects the Tailscale sidecar:
 #   • Sidecar already up  -> app-only update: recreate ONLY backend+frontend
@@ -128,6 +130,15 @@ ensure-env:
 #   • Sidecar not up (first boot) -> bring up the FULL stack. This needs the
 #     Tailscale identity ONCE to register the node; pass it on the command line
 #     and don't store it:  make deploy TS_AUTHKEY=tskey-... TS_HOSTNAME=offbook
+#
+# GIT_REF pins/rolls back the deploy to a specific commit/tag instead of
+# whatever HEAD currently is (#361; see docs/ops/deploy-rollback.md). Compose
+# builds from the working tree, so "deploy an older build" is just "check out
+# an older commit, then deploy" — scripted here rather than inventing an
+# image registry. Refuses if the checkout has uncommitted changes (would
+# silently fold them into the "rollback"). This does NOT touch the database —
+# see the runbook for when a restore is needed instead.
+#   command make deploy GIT_REF=<sha-or-tag> [FLAVOR=prod]
 #
 # FLAVOR picks the instance:
 #   command make deploy                                          # dev
@@ -148,6 +159,19 @@ pre-deploy-backup:
 	fi
 
 deploy: ensure-env pre-deploy-backup
+	@if [ -n "$(GIT_REF)" ]; then \
+		git fetch --quiet origin >/dev/null 2>&1 || true; \
+		git rev-parse --verify --quiet "$(GIT_REF)^{commit}" >/dev/null 2>&1 || { \
+			echo "GIT_REF '$(GIT_REF)' is not a known commit/tag in this checkout (try 'git fetch origin' first)." >&2; exit 2; \
+		}; \
+		if ! git diff --quiet HEAD --; then \
+			echo "This deploy checkout has uncommitted changes — commit or stash before pinning/rolling back." >&2; exit 2; \
+		fi; \
+		echo "Pinning $(OFFBOOK_PROJECT) to $(GIT_REF)."; \
+		echo "If the auto-deploy timer is active for this flavor, pause it first — it will fast-forward back to origin/main on its next tick:"; \
+		echo "    systemctl --user disable --now offbook-deploy@$(FLAVOR).timer"; \
+		git checkout --quiet "$(GIT_REF)"; \
+	fi
 	@SHA="$$(git rev-parse --short HEAD)"; \
 	if [ -n "$$($(COMPOSE) ps -q tailscale 2>/dev/null)" ]; then \
 		echo "Deploying $(OFFBOOK_PROJECT) @ $$SHA from $(ENV_FILE) (app update; sidecar up)…"; \
@@ -168,9 +192,10 @@ deploy: ensure-env pre-deploy-backup
 		TS_AUTHKEY="$(TS_AUTHKEY)" TS_HOSTNAME="$(TS_HOSTNAME)" GIT_SHA="$$SHA" $(COMPOSE) up -d --build; \
 	fi
 	@printf 'Pruning dangling images… '; docker image prune -f | tail -1
-	@printf 'Deployed $(OFFBOOK_PROJECT) → '; \
-		$(COMPOSE) exec -T backend wget -qO- http://localhost:8000/api/v1/health 2>/dev/null && echo \
-		|| echo '(backend still starting — check /health shortly)'
+	@SHA="$$(git rev-parse --short HEAD)"; \
+		OFFBOOK_COMPOSE='$(COMPOSE)' OFFBOOK_PROJECT='$(OFFBOOK_PROJECT)' \
+		infra/deploy/post-deploy-smoke.sh "$$SHA"
+	@echo "Deployed $(OFFBOOK_PROJECT) @ $$(git rev-parse --short HEAD)."
 
 # deployed-sha: the build SHA the running backend reports at /health (#310), via
 # a container exec so it works whether or not host ports are published (prod

--- a/docs/ops/deploy-rollback.md
+++ b/docs/ops/deploy-rollback.md
@@ -1,0 +1,156 @@
+# Deploy & Rollback Runbook
+
+Every Offbook deploy is `command make deploy` — first boot, routine updates, and
+rollback all go through one target (ADR-0016). This page covers the operational
+side: what a normal deploy does, how to tell a deploy failed, how to roll back
+to a known-good build, and how rollback interacts with backups and migrations.
+See [`infra/auto-deploy/README.md`](../../infra/auto-deploy/README.md) for the
+poll-and-redeploy timer this all sits under, and
+[`docs/ops/backup-restore.md`](backup-restore.md) for the backup half.
+
+## What a normal deploy does
+
+```sh
+command make deploy               # dev instance
+command make deploy FLAVOR=prod   # prod instance
+```
+
+In order:
+
+1. **`ensure-env`** — creates the instance's env file from its `.example` on
+   first boot; generates `SESSION_SECRET` if missing (never rotates an
+   existing one).
+2. **`pre-deploy-backup`** — if Postgres is already running (i.e. this isn't
+   first boot), takes a backup *before* touching anything (migration safety,
+   [AGENTS.md § Migration Safety](../../AGENTS.md)). A backup failure aborts
+   the deploy — don't migrate what you can't restore.
+3. **Build + bring up** — `docker compose up -d --build`, stamping the image
+   with `GIT_SHA=$(git rev-parse --short HEAD)` (surfaced at `GET /health` and
+   Settings → About, #310). If the Tailscale sidecar is already up this only
+   recreates `backend`+`frontend` (`--no-deps`); first boot brings up the full
+   stack and needs `TS_AUTHKEY`/`TS_HOSTNAME` once.
+4. **Prune** dangling images (keeps the disk from filling on repeated deploys).
+5. **Post-deploy smoke** (#361) — polls `/health` *inside* the backend
+   container (a container exec, so it works even when no host ports are
+   published, i.e. prod) up to 10 times, 3s apart. Passes only when the
+   response is `{"data":{"status":"ok","version":"<the SHA just deployed>"}}`.
+   On failure: prints what it saw, fires a notifier event via
+   `infra/notify/notify.sh` (the #360 ntfy/webhook seam — a no-op if neither
+   is configured), and **`make deploy` exits non-zero**.
+
+A deploy that only brings the containers up but never passes the smoke check
+is not considered successful — the command fails loudly instead of leaving a
+crash-looping or stale backend running silently.
+
+## Triage: a deploy failed
+
+**`make deploy` itself failed (non-zero exit).** Read the last thing it
+printed — the recipe stops at the first failing step, so the message tells you
+which stage failed:
+
+- *Backup step failed* — Postgres came up but `pg_dump` errored. Check disk
+  space (`df -h`) and `docker compose ... logs postgres`. The deploy did not
+  proceed; nothing changed.
+- *Build/compose step failed* — a Docker build error or a container that
+  exited immediately. `docker compose -p <project> logs backend` /
+  `... logs frontend` for the stack trace. Nothing was pruned or smoke-tested;
+  the previous containers are still whatever they were before this attempt
+  (compose leaves the prior container running until the new one is healthy
+  enough to replace it, but an outright build failure means no new container
+  was even created).
+- *Post-deploy smoke failed* — containers came up but `/health` never reported
+  the new SHA within ~30s. Most common causes: a migration panicked on boot
+  (`docker compose ... logs backend` — look for a migration error before the
+  HTTP server starts), the backend is crash-looping, or a config value is
+  missing/wrong for this environment. This is the case to roll back from (see
+  below) if triage doesn't turn up a quick fix.
+
+**Auto-deploy timer fired and failed.** It notifies
+(`infra/notify/notify.sh`) with the same detail and leaves the previous
+build running — the timer is self-healing by design (see
+[`infra/auto-deploy/README.md`](../../infra/auto-deploy/README.md) § Notes):
+a failed build doesn't advance "what's deployed," so the next tick just
+retries the same commit. If a bad commit landed on `main`, retrying won't
+help; fix forward on `main` or roll back the *instance* to the last good SHA
+(below) while `main` is fixed.
+
+## Rollback: pin to a known-good commit
+
+Compose builds from the working tree, so "run an older build" is "check out an
+older commit, then deploy" — `command make deploy` supports this directly via
+`GIT_REF`:
+
+```sh
+command make deploy GIT_REF=<sha-or-tag> [FLAVOR=prod]
+```
+
+This:
+
+- Fetches `origin` and verifies `GIT_REF` resolves to a known commit (fails
+  loudly if it's an unfetched remote-only ref — run `git fetch origin` by hand
+  if needed).
+- Refuses if the deploy checkout has uncommitted changes (a rollback should
+  never silently fold in local edits).
+- Prints a reminder to pause the auto-deploy timer, then checks out `GIT_REF`
+  and runs the normal deploy sequence above (backup → build → smoke) against
+  that commit.
+
+**Pause auto-deploy first if it's installed for this flavor**, or the timer's
+next tick will see `origin/main` has moved past `GIT_REF` and fast-forward
+right back:
+
+```sh
+systemctl --user disable --now offbook-deploy@<flavor>.timer   # dev or prod
+```
+
+Re-enable it once `main` is fixed and you're ready to track it again:
+
+```sh
+systemctl --user enable --now offbook-deploy@<flavor>.timer
+```
+
+**Returning to latest** after the incident is resolved: check out `main` again
+and deploy normally.
+
+```sh
+git checkout main && git pull --ff-only && command make deploy [FLAVOR=prod]
+```
+
+### Rollback vs. restore
+
+Rolling back (`GIT_REF=`) only changes **which code** is running — it never
+touches the database. That's exactly what you want when the code is broken but
+the schema is fine (the common case: a bad handler, a broken build, a bug in
+business logic).
+
+It is **not** enough when the failed deploy ran a migration that the older
+code can't work against — an older binary querying a column the new migration
+dropped will itself error. In that case:
+
+1. Roll back the code (`GIT_REF=` to the commit *before* the migration).
+2. If the migration already changed data in a way the old code can't tolerate,
+   restore the pre-migration backup instead — every deploy takes one
+   automatically right before migrating (step 2 above). See
+   [`docs/ops/backup-restore.md`](backup-restore.md) § Restoring.
+
+This is the same expand→migrate→contract discipline from
+[AGENTS.md § Migration Safety](../../AGENTS.md): a migration is designed to be
+safe for the *currently deployed* code, so a same-stage rollback (code only,
+no schema change in flight) should never need a restore. Reach for restore
+only when a contract-stage migration already dropped something the rolled-back
+code still reads.
+
+## Manual smoke check
+
+To re-run just the post-deploy check (e.g. after fixing something by hand
+without a full redeploy):
+
+```sh
+OFFBOOK_COMPOSE="docker compose --env-file .env -p offbook -f docker-compose.yml -f docker-compose.tailscale.yml" \
+  OFFBOOK_PROJECT=offbook \
+  infra/deploy/post-deploy-smoke.sh "$(git rev-parse --short HEAD)"
+```
+
+(Match `OFFBOOK_COMPOSE`/`OFFBOOK_PROJECT` to the flavor — swap in the prod
+compose files/project for a prod check. Easiest in practice: just rerun
+`command make deploy [FLAVOR=prod]`, which is idempotent.)

--- a/infra/auto-deploy/README.md
+++ b/infra/auto-deploy/README.md
@@ -3,6 +3,13 @@
 Auto-redeploys an Offbook instance on a self-hosted host (e.g. a Raspberry Pi)
 whenever `origin/main` moves — **no GitHub Actions, no inbound webhook.**
 
+Every `make deploy` (this timer or a manual run) ends with a post-deploy smoke
+check and supports pinning/rolling back to a prior commit via
+`GIT_REF=<sha>`. User-facing runbook — normal deploy, failed-deploy triage,
+rollback, and the interaction with pre-migration backups — lives in
+**[docs/ops/deploy-rollback.md](../../docs/ops/deploy-rollback.md)**. This file
+covers the auto-deploy timer specifically.
+
 A user-level systemd timer polls `origin/main` every ~2 minutes. When the
 running build's SHA (reported by `GET /health`, see
 [ADR-0016](../../docs/ADR/0016-tailscale-per-instance-deployment.md) and `#310`)

--- a/infra/deploy/post-deploy-smoke.sh
+++ b/infra/deploy/post-deploy-smoke.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Post-deploy smoke check (#361): after `make deploy` brings up/updates
+# containers, poll /health inside the backend container and assert it
+# reports status=ok AND the SHA that was just deployed. A container exec
+# (not a host curl) so it works whether or not host ports are published —
+# same trick as `make deployed-sha` (#310), which prod relies on since it
+# binds none.
+#
+# A deploy that "succeeds" at `docker compose up` but leaves the backend
+# crash-looping or serving a stale binary is exactly the silent failure this
+# guards against. Non-zero exit + a notifier event on failure so a bad deploy
+# announces itself instead of quietly serving errors.
+#
+# Usage: post-deploy-smoke.sh <expected-sha>
+# Env:
+#   OFFBOOK_COMPOSE   compose invocation (word-split), required — set by the
+#                     Makefile the same way infra/backup/*.sh consume it.
+#   OFFBOOK_PROJECT   project name, for messages (required)
+#   SMOKE_RETRIES     poll attempts (default 10)
+#   SMOKE_DELAY       seconds between attempts (default 3)
+set -uo pipefail
+
+expected_sha="${1:?usage: post-deploy-smoke.sh <expected-sha>}"
+retries="${SMOKE_RETRIES:-10}"
+delay="${SMOKE_DELAY:-3}"
+
+# shellcheck disable=SC2206
+compose=(${OFFBOOK_COMPOSE:?OFFBOOK_COMPOSE not set})
+project="${OFFBOOK_PROJECT:?OFFBOOK_PROJECT not set}"
+
+status=""
+version=""
+attempt=1
+while [ "$attempt" -le "$retries" ]; do
+	body="$("${compose[@]}" exec -T backend wget -qO- http://localhost:8000/api/v1/health 2>/dev/null)"
+	status="$(printf '%s' "$body" | grep -oE '"status":"[^"]+"' | cut -d'"' -f4)"
+	version="$(printf '%s' "$body" | grep -oE '"version":"[^"]+"' | cut -d'"' -f4)"
+
+	if [ "$status" = "ok" ] && [ "$version" = "$expected_sha" ]; then
+		echo "post-deploy smoke[$project]: OK (status=ok version=$version)"
+		exit 0
+	fi
+
+	attempt=$((attempt + 1))
+	[ "$attempt" -le "$retries" ] && sleep "$delay"
+done
+
+msg="post-deploy smoke failed for $project: expected version=$expected_sha, got status='${status:-<none>}' version='${version:-<none>}' after $retries attempts (~$((retries * delay))s)"
+echo "$msg" >&2
+
+repo_root="$(cd "$(dirname "$0")/../.." && pwd)"
+"$repo_root/infra/notify/notify.sh" "offbook deploy smoke failed ($project)" "$msg" \
+	|| echo "post-deploy-smoke: notifier command failed" >&2
+
+exit 1


### PR DESCRIPTION
Closes #361

## Summary
- `make deploy` now runs a post-deploy smoke check (`infra/deploy/post-deploy-smoke.sh`): polls `/health` inside the backend container (works even with no published host ports, i.e. prod), asserting `status=ok` and `version` equals the SHA just deployed. On failure it fires a notifier event via `infra/notify/notify.sh` (the #360 seam) and `make deploy` exits non-zero — a broken deploy now announces itself instead of silently serving errors.
- Scripted rollback: `make deploy GIT_REF=<sha-or-tag> [FLAVOR=prod]` fetches origin, verifies the ref, refuses if the deploy checkout has uncommitted changes, then checks it out and redeploys through the normal backup → build → smoke sequence. Never touches the database. Prints a reminder to pause the auto-deploy timer first (otherwise its next poll fast-forwards back to `origin/main`).
- New runbook `docs/ops/deploy-rollback.md`: normal deploy walkthrough, failed-deploy triage (backup step / build step / smoke step), rollback usage, and rollback-vs-restore guidance for when a contract-stage migration means a code-only rollback isn't enough.
- `infra/auto-deploy/README.md` cross-links the new runbook.

## Test plan
- [x] `command make verify` green (contract-check, vet, lint, test, schema-check, migrate-roundtrip, frontend lint/test/build)
- [x] `infra/deploy/post-deploy-smoke.sh` exercised directly against a fake compose stub for three scenarios: version match (exit 0), version mismatch (exit 1), backend unreachable (exit 1)
- [x] `make -n deploy` dry-run to confirm the new `GIT_REF` recipe block and Makefile variable substitution are syntactically correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)