### PR TITLE
docs #362: Plaid production access prep (OAuth redirect strategy + BYO-keys guide)

### DIFF
--- a/.env.prod.example
+++ b/.env.prod.example
@@ -29,7 +29,9 @@ SESSION_SECRET=
 FRONTEND_URL=https://offbook-prod.<your-tailnet>.ts.net
 
 # ─── Plaid (disabled in prod for now — leave unset) ───────────────────────────
+# See docs/ops/plaid-production.md for how to bring your own Plaid production
+# keys and the OAuth redirect URI strategy for Tailscale-private hosts.
 # PLAID_CLIENT_ID=
 # PLAID_SECRET=
-# PLAID_ENV=sandbox
+# PLAID_ENV=production
 # PLAID_TOKEN_KEY=

--- a/backend/internal/config/config_test.go
+++ b/backend/internal/config/config_test.go
@@ -181,3 +181,49 @@ func TestLoad_ProdRequiresExplicitDatabaseURL(t *testing.T) {
 		t.Fatal("want error when APP_ENV=prod and DATABASE_URL is empty; got nil")
 	}
 }
+
+// TestLoad_PlaidProductionEnv smoke-tests the PLAID_ENV=production config
+// path (#362): a self-hoster's own production credentials load the same way
+// sandbox credentials do, and PlaidConfigured()/PlaidEnv reflect production
+// once the required trio (client ID, secret, token key) is present.
+func TestLoad_PlaidProductionEnv(t *testing.T) {
+	t.Setenv("APP_ENV", AppEnvProd)
+	t.Setenv("DATABASE_URL", "postgres://prod:prod@db.internal/offbook?sslmode=require")
+	t.Setenv("SESSION_SECRET", "a-real-generated-secret")
+	t.Setenv("PLAID_CLIENT_ID", "prod-client-id")
+	t.Setenv("PLAID_SECRET", "prod-secret")
+	t.Setenv("PLAID_ENV", "production")
+	t.Setenv("PLAID_TOKEN_KEY", strings.Repeat("ab", 32)) // 32 bytes hex-encoded
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.PlaidEnv != "production" {
+		t.Errorf("PlaidEnv = %q, want %q", cfg.PlaidEnv, "production")
+	}
+	if !cfg.PlaidConfigured() {
+		t.Error("PlaidConfigured() = false, want true with client ID + secret + 32-byte token key set")
+	}
+	if len(cfg.PlaidTokenKey) != 32 {
+		t.Errorf("PlaidTokenKey length = %d, want 32", len(cfg.PlaidTokenKey))
+	}
+}
+
+// TestLoad_PlaidProductionEnvRequiresTokenKey mirrors the sandbox-path
+// validation but for production: an operator can't accidentally run
+// production Plaid without the encryption key any more than they can in
+// sandbox (ADR-0010 applies uniformly across PLAID_ENV values).
+func TestLoad_PlaidProductionEnvRequiresTokenKey(t *testing.T) {
+	t.Setenv("APP_ENV", AppEnvProd)
+	t.Setenv("DATABASE_URL", "postgres://prod:prod@db.internal/offbook?sslmode=require")
+	t.Setenv("SESSION_SECRET", "a-real-generated-secret")
+	t.Setenv("PLAID_CLIENT_ID", "prod-client-id")
+	t.Setenv("PLAID_SECRET", "prod-secret")
+	t.Setenv("PLAID_ENV", "production")
+	t.Setenv("PLAID_TOKEN_KEY", "")
+
+	if _, err := Load(); err == nil || !strings.Contains(err.Error(), "PLAID_TOKEN_KEY") {
+		t.Fatalf("Load error = %v, want PLAID_TOKEN_KEY error", err)
+	}
+}

--- a/docs/ops/plaid-production.md
+++ b/docs/ops/plaid-production.md
@@ -1,0 +1,89 @@
+# Plaid Production Access
+
+Tracks issue #362 — the process-dependency half of "link a real bank, not just
+sandbox." Sandbox stays the default everywhere in dev/QA/CI (see
+`AGENTS.md` § Plaid Sandbox); this page is only about the production path.
+
+## Status
+
+| Acceptance criterion (#362) | Status |
+|---|---|
+| Plaid production (or limited-production) application submitted | **Owner action — not started.** Plaid's production application is a per-company/per-Plaid-account process (business details, use-case description, security questionnaire) that only the instance owner's Plaid account can submit. Tracked in comments on #362. |
+| OAuth redirect URI strategy decided for Tailscale-private hosts | **Decided — see below.** |
+| Production credentials live only in `.env.prod`; `PLAID_ENV=production` path smoke-tested | **Done.** `.env.prod.example` documents the keys (commented out, unset by default); `config.Load()` validates `PLAID_ENV ∈ {sandbox, development, production}` and requires `PLAID_TOKEN_KEY`/`PLAID_SECRET` alongside `PLAID_CLIENT_ID` regardless of env — see `backend/internal/config/config_test.go::TestLoad_PlaidProductionEnv`. |
+| Docs: how a self-hoster brings their own Plaid production keys | **Done — see below.** |
+| Sandbox remains the default everywhere in dev/QA/CI | **Already true** — `PLAID_ENV` defaults to `sandbox` when unset (`config.go`), and no dev/QA/CI env file sets it otherwise. |
+
+The remaining item — actually filing the application — needs the owner's
+Plaid account and business details. Everything an agent can prepare ahead of
+that approval is done; this doc plus the config validation is the
+agent-completable slice. See the comment on #362 for the day-one status.
+
+## OAuth redirect URI strategy for Tailscale-private hosts
+
+Plaid's OAuth-based institutions (most large US banks in **production** —
+sandbox mostly doesn't require this) send the user back to a `redirect_uri`
+that must be:
+
+1. Registered in the Plaid dashboard ahead of time (allowlisted, exact match).
+2. Reachable by the user's browser at the moment Plaid redirects back.
+
+**Decision: use the instance's own Tailscale MagicDNS URL, not a third-party
+redirect page.** Each Offbook instance already has a stable, HTTPS, per-instance
+hostname from [ADR-0016](../ADR/0016-tailscale-per-instance-deployment.md) —
+`https://<hostname>.<tailnet>.ts.net` — reachable by any device on the owner's
+tailnet, including mobile. That satisfies both constraints without opening any
+public ingress (which the "no webhooks" decision in the M14 sync ADR rules out
+for the same reason).
+
+Concretely: `redirect_uri` = `${FRONTEND_URL}/plaid/oauth-return` (a fixed SPA
+route). This route does not exist yet — wiring `receivedRedirectUri` into
+`usePlaidLink` and adding the `/plaid/oauth-return` route is Link-integration
+work that belongs with the Link-token changes in **#364** (Plaid re-auth /
+update-mode flow), not this tracking issue, since both touch the same
+`CreateLinkToken` call path. This doc records the decision so #364 doesn't have
+to re-derive it: reuse `FRONTEND_URL` (already required config, already
+correct per-instance), don't introduce a second env var.
+
+Constraints this implies, worth re-checking when #364 lands:
+
+- `FRONTEND_URL` must be the tailnet MagicDNS URL, not `localhost` — already
+  the case in `.env.prod.example`.
+- The redirect URI must be registered **per institution** that requires OAuth
+  in the Plaid dashboard once production access is granted — an owner action
+  at that time, not a one-time setup step now.
+- Self-hosters running their own instance register their **own** MagicDNS
+  hostname as their own redirect URI under their own Plaid production
+  application (see below) — there's nothing shared or hardcoded to Offbook's
+  upstream repo.
+
+## Bringing your own Plaid production keys (self-hosters)
+
+Offbook never ships or proxies Plaid credentials — every self-hosted instance
+uses its own Plaid account, same as Tailscale requires its own auth key
+([ADR-0016](../ADR/0016-tailscale-per-instance-deployment.md)) and the same
+`.env.prod`-is-secrets-only convention.
+
+1. Create a Plaid account at https://dashboard.plaid.com if you don't have
+   one, and apply for production access from the dashboard. This is a real
+   review process with lead time — plan for weeks, not days.
+2. Once approved, generate a production `client_id` and `secret` from the
+   dashboard.
+3. Generate a token-encryption key: `openssl rand -hex 32` (this is
+   `PLAID_TOKEN_KEY`, unrelated to anything Plaid issues — see
+   [ADR-0010](../ADR/0010-plaid-token-encryption.md)).
+4. Set in `.env.prod` (never in `.env`, `.env.qa`, or any committed file):
+   ```
+   PLAID_CLIENT_ID=<your production client id>
+   PLAID_SECRET=<your production secret>
+   PLAID_ENV=production
+   PLAID_TOKEN_KEY=<output of openssl rand -hex 32>
+   ```
+5. Register your instance's redirect URI (`https://<your-hostname>.<your-tailnet>.ts.net/plaid/oauth-return`)
+   with Plaid for any OAuth institution you need, per the strategy above.
+6. `command make deploy FLAVOR=prod` picks these up automatically — no code
+   changes required. Dev, QA, and CI are unaffected; they never read
+   `.env.prod`.
+
+Sandbox development keys (`PLAID_ENV=sandbox`) remain free and require no
+application — see `AGENTS.md` § Plaid Sandbox for the dev-loop setup.


### PR DESCRIPTION
## Summary
- Prepares the agent-completable slice of #362 (Plaid production application, human-gated). Actually filing the Plaid production application remains an owner action and is **not** done by this PR — see Refs below.
- Documents the OAuth redirect URI strategy for Tailscale-private hosts: reuse the instance's existing `FRONTEND_URL` MagicDNS URL as the redirect target (`${FRONTEND_URL}/plaid/oauth-return`); defer the actual `receivedRedirectUri`/route wiring to #364 (Plaid re-auth/update-mode), which already touches the same Link-token call path.
- Documents how a self-hoster brings their own Plaid production keys into `.env.prod` (own Plaid account, own credentials, own redirect URI registration — nothing shared/hardcoded to the upstream repo).
- Adds `TestLoad_PlaidProductionEnv` / `TestLoad_PlaidProductionEnvRequiresTokenKey` in `backend/internal/config/config_test.go`, smoke-testing the `PLAID_ENV=production` config path (it validates identically to sandbox — client ID + secret + 32-byte token key required).
- Points `.env.prod.example`'s commented-out Plaid block at the new doc.

New file: `docs/ops/plaid-production.md`.

## Not done (owner action, tracked on #362)
- Submitting the actual Plaid production application (business details, use-case description, security questionnaire) — only doable from the owner's own Plaid account. **Issue #362 stays open** until that's done; this PR does not close it.

Refs #362

## Test plan
- [x] `command make verify` green (backend vet+test -race, migration round-trip, frontend lint/test/build)
- [x] `command make schema-check` — no schema drift (no migration in this PR)
- [x] New config tests pass: `go test ./internal/config/...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)