### PR TITLE
feat #363: scheduled background Plaid transaction sync (polling, jittered)

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/gregwym/offbook/backend/internal/config"
+	"github.com/gregwym/offbook/backend/internal/crypto"
 	"github.com/gregwym/offbook/backend/internal/db"
 	"github.com/gregwym/offbook/backend/internal/logging"
 	"github.com/gregwym/offbook/backend/internal/repository"
@@ -21,6 +22,7 @@ import (
 	"github.com/gregwym/offbook/backend/internal/service/household"
 	"github.com/gregwym/offbook/backend/internal/service/jobs"
 	"github.com/gregwym/offbook/backend/internal/service/notify"
+	plaidsvc "github.com/gregwym/offbook/backend/internal/service/plaid"
 	"github.com/gregwym/offbook/backend/internal/service/prices"
 )
 
@@ -122,6 +124,58 @@ func main() {
 			return fmt.Sprintf("purged %d stale AI-staging job(s)", res.JobsPurged), nil
 		},
 	})
+
+	// plaid-transaction-sync (#363, docs/ADR/0021): daily jittered polling
+	// pass over every active plaid_item, since a Tailscale-private host
+	// can't receive Plaid webhooks (ADR-0016). Builds its own plaid.Service
+	// instance — the same construction router.go's newPlaidService and
+	// cmd/plaid-resync already duplicate — so the job runner doesn't share
+	// mutable state with the HTTP-facing service. No-op when Plaid isn't
+	// configured on this instance.
+	if cfg.PlaidConfigured() {
+		plaidClient, err := plaidsvc.NewSDKClient(plaidsvc.Config{
+			ClientID: cfg.PlaidClientID,
+			Secret:   cfg.PlaidSecret,
+			Env:      cfg.PlaidEnv,
+		})
+		if err != nil {
+			log.Fatalf("plaid: sdk client: %v", err)
+		}
+		plaidBox, err := crypto.NewSecretBox(cfg.PlaidTokenKey)
+		if err != nil {
+			log.Fatalf("plaid: secretbox: %v", err)
+		}
+		plaidMapper, err := plaidsvc.NewCategoryMapper(context.Background(), repository.NewPlaidCategoryMapRepository(gormDB))
+		if err != nil {
+			log.Fatalf("plaid: load category map: %v", err)
+		}
+		plaidAccountRepo := repository.NewAccountRepository(gormDB)
+		plaidAssetRepo := repository.NewAssetRepository(gormDB)
+		plaidPositionRepo := repository.NewPositionRepository(gormDB)
+		plaidPiiSvc := service.NewPIIService(
+			repository.NewPIIRepository(gormDB),
+			service.NewAccountService(gormDB, plaidAccountRepo, plaidAssetRepo, plaidPositionRepo),
+		)
+		plaidItemRepo := repository.NewPlaidItemRepository(gormDB)
+		plaidSyncSvc := plaidsvc.NewService(
+			plaidClient, plaidBox, plaidItemRepo, plaidAccountRepo,
+			repository.NewTransactionRepository(gormDB),
+			repository.NewPlaidSyncErrorRepository(gormDB),
+			plaidAssetRepo, plaidPositionRepo, plaidPiiSvc, plaidMapper, gormDB,
+		).WithRuleRepo(repository.NewCategorizationRuleRepository(gormDB)).
+			WithNotifier(notify.Build(cfg, log.Printf))
+
+		plaidScheduler := plaidsvc.NewSyncScheduler(plaidSyncSvc, plaidItemRepo)
+		runner.Register(jobs.Job{
+			Name:         "plaid-transaction-sync",
+			Interval:     24 * time.Hour,
+			InitialDelay: 3 * time.Minute,
+			Run: func(ctx context.Context) (string, error) {
+				res := plaidScheduler.RunOnce(ctx)
+				return fmt.Sprintf("synced %d, skipped %d, failed %d", res.Synced, res.Skipped, res.Failed), nil
+			},
+		})
+	}
 
 	// disk-space-check (#360): a full data volume degrades silently otherwise
 	// (Postgres refuses writes, backups fail) — alert well before that.

--- a/backend/internal/repository/plaid_item_repo.go
+++ b/backend/internal/repository/plaid_item_repo.go
@@ -31,6 +31,23 @@ type PlaidItemRepository interface {
 	// the rest of the sync, so there's no separate UpdateSyncStatus('ok').
 	UpdateSyncStatus(ctx context.Context, userID, id int64, status string, syncError *string) error
 	SoftDelete(ctx context.Context, userID, id int64) error
+	// ListAllActive returns every non-deleted, status='active' plaid_item
+	// across all users, ordered by id. It exists for the scheduled background
+	// sync job (#363) — the one caller expected to iterate cross-user, the
+	// same pattern UserSettingsRepository.ListAutoRefreshUserIDs and
+	// household.RunPurge already use for their own periodic jobs. Every other
+	// read on this repository stays scoped to a single session's user_id.
+	ListAllActive(ctx context.Context) ([]model.PlaidItem, error)
+	// TryStartSync atomically flips last_sync_status to 'syncing' unless it
+	// is already 'syncing' or 'error' ('error' is skipped until #364's
+	// re-auth flow lands — retrying it blind would just retry-storm a
+	// broken item). Returns false (no error) when the CAS didn't apply,
+	// meaning the caller should skip this item this pass. The scheduled
+	// sync job (#363) uses this to avoid racing a concurrent manual resync
+	// of the same item; SyncTransactions itself still calls
+	// UpdateSyncStatus("syncing", ...) right after, which is a harmless
+	// idempotent overwrite.
+	TryStartSync(ctx context.Context, userID, id int64) (bool, error)
 }
 
 type plaidItemRepo struct {
@@ -137,6 +154,28 @@ func (r *plaidItemRepo) UpdateSyncStatus(ctx context.Context, userID, id int64, 
 		return ErrNotFound
 	}
 	return nil
+}
+
+func (r *plaidItemRepo) ListAllActive(ctx context.Context) ([]model.PlaidItem, error) {
+	var items []model.PlaidItem
+	if err := r.db.WithContext(ctx).
+		Where("status = ?", "active").
+		Order("id").
+		Find(&items).Error; err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+func (r *plaidItemRepo) TryStartSync(ctx context.Context, userID, id int64) (bool, error) {
+	res := r.db.WithContext(ctx).
+		Model(&model.PlaidItem{}).
+		Where("user_id = ? AND id = ? AND last_sync_status NOT IN (?, ?)", userID, id, "syncing", "error").
+		Updates(map[string]any{"last_sync_status": "syncing"})
+	if res.Error != nil {
+		return false, res.Error
+	}
+	return res.RowsAffected > 0, nil
 }
 
 func (r *plaidItemRepo) SoftDelete(ctx context.Context, userID, id int64) error {

--- a/backend/internal/service/plaid/scheduler.go
+++ b/backend/internal/service/plaid/scheduler.go
@@ -1,0 +1,118 @@
+package plaid
+
+import (
+	"context"
+	"log"
+	"math/rand"
+	"time"
+
+	"github.com/gregwym/offbook/backend/internal/repository"
+)
+
+// SyncScheduler runs the daily background transaction sync (#363). A
+// Tailscale-private host (ADR-0016) can't receive Plaid webhooks, so
+// freshness comes from polling: once a day, every active plaid_item across
+// every user gets a SyncTransactions pass. See
+// docs/ADR/0021-plaid-polling-sync.md for the polling-not-webhooks
+// rationale, cadence, and jitter design.
+type SyncScheduler struct {
+	svc      *Service
+	itemRepo repository.PlaidItemRepository
+	// jitter randomizes each run's start within this window so a
+	// self-hosted instance doesn't call Plaid at the exact same wall-clock
+	// moment every day.
+	jitter time.Duration
+	// pause between items keeps a multi-item instance inside Plaid's
+	// per-key rate limits — same rationale as prices.Scheduler.pause.
+	pause time.Duration
+	logf  func(format string, args ...any)
+}
+
+// NewSyncScheduler wires a daily-pass scheduler over every active plaid_item
+// (across every user) that itemRepo reports via ListAllActive.
+func NewSyncScheduler(svc *Service, itemRepo repository.PlaidItemRepository) *SyncScheduler {
+	return &SyncScheduler{
+		svc:      svc,
+		itemRepo: itemRepo,
+		jitter:   30 * time.Minute,
+		pause:    5 * time.Second,
+		logf:     log.Printf,
+	}
+}
+
+// WithJitter overrides the pre-run randomized delay (tests).
+func (s *SyncScheduler) WithJitter(d time.Duration) *SyncScheduler {
+	s.jitter = d
+	return s
+}
+
+// WithPause overrides the between-items pause (tests).
+func (s *SyncScheduler) WithPause(d time.Duration) *SyncScheduler {
+	s.pause = d
+	return s
+}
+
+// SyncScheduleResult summarizes one scheduled pass across every active item.
+type SyncScheduleResult struct {
+	Synced  int
+	Skipped int
+	Failed  int
+}
+
+// RunOnce sleeps a random jitter, then drains every active plaid_item across
+// every user. Per-item isolation: one item's failure (network blip, revoked
+// consent) is logged and counted, never aborting the pass for the rest —
+// same rationale as prices.Scheduler.RunOnce. TryStartSync is the
+// concurrency guard: an item already mid-sync (manual resync in flight) or
+// sitting in 'error' (needs #364's re-auth flow first) is atomically skipped
+// rather than raced or retry-stormed.
+func (s *SyncScheduler) RunOnce(ctx context.Context) SyncScheduleResult {
+	var res SyncScheduleResult
+	if s.jitter > 0 {
+		select {
+		case <-ctx.Done():
+			return res
+		case <-time.After(time.Duration(rand.Int63n(int64(s.jitter)))):
+		}
+	}
+
+	items, err := s.itemRepo.ListAllActive(ctx)
+	if err != nil {
+		s.logf("plaid sync scheduler: list items: %v", err)
+		return res
+	}
+
+	for i, item := range items {
+		if i > 0 && s.pause > 0 {
+			select {
+			case <-ctx.Done():
+				return res
+			case <-time.After(s.pause):
+			}
+		}
+
+		started, err := s.itemRepo.TryStartSync(ctx, item.UserID, item.ID)
+		if err != nil {
+			s.logf("plaid sync scheduler: item %s (user %d): try-start: %v", item.PlaidItemID, item.UserID, err)
+			res.Failed++
+			continue
+		}
+		if !started {
+			res.Skipped++
+			continue
+		}
+
+		result, err := s.svc.SyncTransactions(ctx, item.UserID, item.PlaidItemID)
+		if err != nil {
+			s.logf("plaid sync scheduler: item %s (user %d): %v", item.PlaidItemID, item.UserID, err)
+			res.Failed++
+			continue
+		}
+		res.Synced++
+		if result.Inserted > 0 || result.Modified > 0 || result.Removed > 0 || result.Failed > 0 {
+			s.logf("plaid sync scheduler: item %s (user %d): %d inserted, %d modified, %d removed, %d failed",
+				item.PlaidItemID, item.UserID, result.Inserted, result.Modified, result.Removed, result.Failed)
+		}
+	}
+	return res
+}

--- a/backend/internal/service/plaid/scheduler_integration_test.go
+++ b/backend/internal/service/plaid/scheduler_integration_test.go
@@ -1,0 +1,306 @@
+package plaid_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gregwym/offbook/backend/internal/crypto"
+	"github.com/gregwym/offbook/backend/internal/model"
+	"github.com/gregwym/offbook/backend/internal/repository"
+	"github.com/gregwym/offbook/backend/internal/service"
+	plaidsvc "github.com/gregwym/offbook/backend/internal/service/plaid"
+)
+
+// keyedAccountID is the Plaid-side account_id a given access token's fake
+// transaction is reported against — "pacct-<token>" so every token maps to
+// its own globally-unique local account row (accounts.plaid_account_id has
+// a global, not per-user, unique index).
+func keyedAccountID(token string) string { return "pacct-" + token }
+
+// keyedTxnsSyncServer returns one canned transaction per distinct
+// access_token on its first call, empty on subsequent calls, and 500s for
+// any access_token in failFor — letting scheduler tests exercise multiple
+// items behind a single fake Plaid host (the real Plaid API routes by
+// access_token, not URL, so one Service/client serves every item).
+func keyedTxnsSyncServer(t *testing.T, failFor map[string]bool) (*httptest.Server, map[string]int) {
+	t.Helper()
+	var mu sync.Mutex
+	calls := map[string]int{}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/transactions/sync", func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		token, _ := body["access_token"].(string)
+
+		mu.Lock()
+		calls[token]++
+		n := calls[token]
+		mu.Unlock()
+
+		w.Header().Set("Content-Type", "application/json")
+		if failFor[token] {
+			w.WriteHeader(http.StatusInternalServerError)
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"error_type": "API_ERROR",
+				"error_code": "INTERNAL_SERVER_ERROR",
+				"request_id": "req-fail",
+			})
+			return
+		}
+		if n == 1 {
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"added": []map[string]any{
+					{
+						"transaction_id":    "ptx-" + token,
+						"account_id":        keyedAccountID(token),
+						"amount":            9.99,
+						"iso_currency_code": "USD",
+						"name":              "Scheduler Test Txn",
+						"date":              "2026-06-01",
+						"pending":           false,
+					},
+				},
+				"modified":    []any{},
+				"removed":     []any{},
+				"next_cursor": "cursor-" + token,
+				"has_more":    false,
+				"request_id":  "req-" + token,
+			})
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"added":       []any{},
+			"modified":    []any{},
+			"removed":     []any{},
+			"next_cursor": "cursor-" + token,
+			"has_more":    false,
+			"request_id":  "req-empty-" + token,
+		})
+	})
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		t.Errorf("unexpected Plaid call: %s %s", r.Method, r.URL.Path)
+		http.Error(w, "unexpected", 500)
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv, calls
+}
+
+func TestSyncScheduler_RunOnce_SyncsMultipleItemsAcrossUsers(t *testing.T) {
+	g := openPlaidTestDB(t)
+	userA := seedPlaidTestUser(t, g)
+	userB := seedPlaidTestUser(t, g)
+
+	acctA := &model.Account{UserID: userA, Name: "A Checking", InstitutionSlug: "ins_test", AccountType: "checking", Currency: "USD", PlaidAccountID: strp(keyedAccountID("access-token-a")), IsActive: true}
+	acctB := &model.Account{UserID: userB, Name: "B Checking", InstitutionSlug: "ins_test", AccountType: "checking", Currency: "USD", PlaidAccountID: strp(keyedAccountID("access-token-b")), IsActive: true}
+	if err := g.Create(acctA).Error; err != nil {
+		t.Fatalf("seed account A: %v", err)
+	}
+	if err := g.Create(acctB).Error; err != nil {
+		t.Fatalf("seed account B: %v", err)
+	}
+	t.Cleanup(func() {
+		g.Unscoped().Where("user_id IN ?", []int64{userA, userB}).Delete(&model.Transaction{})
+		g.Unscoped().Delete(&model.Account{}, acctA.ID)
+		g.Unscoped().Delete(&model.Account{}, acctB.ID)
+	})
+
+	srv, calls := keyedTxnsSyncServer(t, nil)
+	client, _ := plaidsvc.NewSDKClient(plaidsvc.Config{ClientID: "cid", Secret: "csec", Env: srv.URL})
+	box, _ := crypto.NewSecretBox(newTestKey())
+	itemRepo := repository.NewPlaidItemRepository(g)
+	acctRepo := repository.NewAccountRepository(g)
+	txRepo := repository.NewTransactionRepository(g)
+	piiSvc := service.NewPIIService(repository.NewPIIRepository(g), service.NewAccountService(g, acctRepo, repository.NewAssetRepository(g), repository.NewPositionRepository(g)))
+
+	encA, _ := box.Encrypt([]byte("access-token-a"))
+	encB, _ := box.Encrypt([]byte("access-token-b"))
+	itemA := &model.PlaidItem{UserID: userA, PlaidItemID: "item-sched-a", AccessTokenEnc: encA, Status: "active"}
+	itemB := &model.PlaidItem{UserID: userB, PlaidItemID: "item-sched-b", AccessTokenEnc: encB, Status: "active"}
+	if err := itemRepo.Create(context.Background(), itemA); err != nil {
+		t.Fatalf("seed item A: %v", err)
+	}
+	if err := itemRepo.Create(context.Background(), itemB); err != nil {
+		t.Fatalf("seed item B: %v", err)
+	}
+
+	svc := plaidsvc.NewService(client, box, itemRepo, acctRepo, txRepo, repository.NewPlaidSyncErrorRepository(g), repository.NewAssetRepository(g), repository.NewPositionRepository(g), piiSvc, nil, g)
+	scheduler := plaidsvc.NewSyncScheduler(svc, itemRepo).WithJitter(0).WithPause(0)
+
+	res := scheduler.RunOnce(context.Background())
+	if res.Synced != 2 || res.Skipped != 0 || res.Failed != 0 {
+		t.Fatalf("RunOnce = %+v, want {Synced:2 Skipped:0 Failed:0}", res)
+	}
+	if calls["access-token-a"] != 1 || calls["access-token-b"] != 1 {
+		t.Errorf("calls = %+v, want exactly 1 call per item", calls)
+	}
+
+	for _, tc := range []struct {
+		userID int64
+		itemID string
+	}{{userA, "item-sched-a"}, {userB, "item-sched-b"}} {
+		persisted, err := itemRepo.GetByPlaidItemID(context.Background(), tc.userID, tc.itemID)
+		if err != nil {
+			t.Fatalf("re-fetch %s: %v", tc.itemID, err)
+		}
+		if persisted.LastSyncStatus != "ok" {
+			t.Errorf("%s last_sync_status = %q, want ok", tc.itemID, persisted.LastSyncStatus)
+		}
+		var count int64
+		g.Model(&model.Transaction{}).Where("user_id = ?", tc.userID).Count(&count)
+		if count != 1 {
+			t.Errorf("user %d has %d transactions, want 1 (per-user isolation)", tc.userID, count)
+		}
+	}
+}
+
+func TestSyncScheduler_RunOnce_SkipsSyncingAndErrorItems(t *testing.T) {
+	g := openPlaidTestDB(t)
+	userOK := seedPlaidTestUser(t, g)
+	userSyncing := seedPlaidTestUser(t, g)
+	userError := seedPlaidTestUser(t, g)
+
+	tokensByUser := map[int64]string{
+		userOK:      "access-token-ok",
+		userSyncing: "access-token-syncing",
+		userError:   "access-token-error",
+	}
+	for _, uid := range []int64{userOK, userSyncing, userError} {
+		acct := &model.Account{UserID: uid, Name: "Checking", InstitutionSlug: "ins_test", AccountType: "checking", Currency: "USD", PlaidAccountID: strp(keyedAccountID(tokensByUser[uid])), IsActive: true}
+		if err := g.Create(acct).Error; err != nil {
+			t.Fatalf("seed account for user %d: %v", uid, err)
+		}
+		t.Cleanup(func(id int64) func() {
+			return func() {
+				g.Unscoped().Where("user_id = ?", id).Delete(&model.Transaction{})
+				g.Unscoped().Where("user_id = ?", id).Delete(&model.Account{})
+			}
+		}(uid))
+	}
+
+	srv, calls := keyedTxnsSyncServer(t, nil)
+	client, _ := plaidsvc.NewSDKClient(plaidsvc.Config{ClientID: "cid", Secret: "csec", Env: srv.URL})
+	box, _ := crypto.NewSecretBox(newTestKey())
+	itemRepo := repository.NewPlaidItemRepository(g)
+	acctRepo := repository.NewAccountRepository(g)
+	txRepo := repository.NewTransactionRepository(g)
+	piiSvc := service.NewPIIService(repository.NewPIIRepository(g), service.NewAccountService(g, acctRepo, repository.NewAssetRepository(g), repository.NewPositionRepository(g)))
+
+	encOK, _ := box.Encrypt([]byte("access-token-ok"))
+	encSyncing, _ := box.Encrypt([]byte("access-token-syncing"))
+	encError, _ := box.Encrypt([]byte("access-token-error"))
+	itemOK := &model.PlaidItem{UserID: userOK, PlaidItemID: "item-ok", AccessTokenEnc: encOK, Status: "active"}
+	itemSyncing := &model.PlaidItem{UserID: userSyncing, PlaidItemID: "item-syncing", AccessTokenEnc: encSyncing, Status: "active", LastSyncStatus: "syncing"}
+	itemError := &model.PlaidItem{UserID: userError, PlaidItemID: "item-error", AccessTokenEnc: encError, Status: "active", LastSyncStatus: "error"}
+	for _, it := range []*model.PlaidItem{itemOK, itemSyncing, itemError} {
+		if err := itemRepo.Create(context.Background(), it); err != nil {
+			t.Fatalf("seed item %s: %v", it.PlaidItemID, err)
+		}
+	}
+
+	svc := plaidsvc.NewService(client, box, itemRepo, acctRepo, txRepo, repository.NewPlaidSyncErrorRepository(g), repository.NewAssetRepository(g), repository.NewPositionRepository(g), piiSvc, nil, g)
+	scheduler := plaidsvc.NewSyncScheduler(svc, itemRepo).WithJitter(0).WithPause(0)
+
+	res := scheduler.RunOnce(context.Background())
+	if res.Synced != 1 || res.Skipped != 2 || res.Failed != 0 {
+		t.Fatalf("RunOnce = %+v, want {Synced:1 Skipped:2 Failed:0}", res)
+	}
+	if calls["access-token-syncing"] != 0 || calls["access-token-error"] != 0 {
+		t.Errorf("calls = %+v, want the syncing/error items never to reach Plaid", calls)
+	}
+	if calls["access-token-ok"] != 1 {
+		t.Errorf("calls[ok] = %d, want 1", calls["access-token-ok"])
+	}
+}
+
+func TestSyncScheduler_RunOnce_IsolatesPerItemFailure(t *testing.T) {
+	g := openPlaidTestDB(t)
+	userOK := seedPlaidTestUser(t, g)
+	userFail := seedPlaidTestUser(t, g)
+
+	acctOK := &model.Account{UserID: userOK, Name: "Checking", InstitutionSlug: "ins_test", AccountType: "checking", Currency: "USD", PlaidAccountID: strp(keyedAccountID("access-token-good")), IsActive: true}
+	acctFail := &model.Account{UserID: userFail, Name: "Checking", InstitutionSlug: "ins_test", AccountType: "checking", Currency: "USD", PlaidAccountID: strp(keyedAccountID("access-token-fail")), IsActive: true}
+	if err := g.Create(acctOK).Error; err != nil {
+		t.Fatalf("seed account OK: %v", err)
+	}
+	if err := g.Create(acctFail).Error; err != nil {
+		t.Fatalf("seed account fail: %v", err)
+	}
+	t.Cleanup(func() {
+		g.Unscoped().Where("user_id IN ?", []int64{userOK, userFail}).Delete(&model.Transaction{})
+		g.Unscoped().Delete(&model.Account{}, acctOK.ID)
+		g.Unscoped().Delete(&model.Account{}, acctFail.ID)
+	})
+
+	srv, calls := keyedTxnsSyncServer(t, map[string]bool{"access-token-fail": true})
+	client, _ := plaidsvc.NewSDKClient(plaidsvc.Config{ClientID: "cid", Secret: "csec", Env: srv.URL})
+	box, _ := crypto.NewSecretBox(newTestKey())
+	itemRepo := repository.NewPlaidItemRepository(g)
+	acctRepo := repository.NewAccountRepository(g)
+	txRepo := repository.NewTransactionRepository(g)
+	piiSvc := service.NewPIIService(repository.NewPIIRepository(g), service.NewAccountService(g, acctRepo, repository.NewAssetRepository(g), repository.NewPositionRepository(g)))
+
+	encOK, _ := box.Encrypt([]byte("access-token-good"))
+	encFail, _ := box.Encrypt([]byte("access-token-fail"))
+	itemOK := &model.PlaidItem{UserID: userOK, PlaidItemID: "item-fail-ok", AccessTokenEnc: encOK, Status: "active"}
+	itemFail := &model.PlaidItem{UserID: userFail, PlaidItemID: "item-fail-bad", AccessTokenEnc: encFail, Status: "active"}
+	if err := itemRepo.Create(context.Background(), itemOK); err != nil {
+		t.Fatalf("seed item OK: %v", err)
+	}
+	if err := itemRepo.Create(context.Background(), itemFail); err != nil {
+		t.Fatalf("seed item fail: %v", err)
+	}
+
+	svc := plaidsvc.NewService(client, box, itemRepo, acctRepo, txRepo, repository.NewPlaidSyncErrorRepository(g), repository.NewAssetRepository(g), repository.NewPositionRepository(g), piiSvc, nil, g)
+	scheduler := plaidsvc.NewSyncScheduler(svc, itemRepo).WithJitter(0).WithPause(0)
+
+	res := scheduler.RunOnce(context.Background())
+	if res.Synced != 1 || res.Failed != 1 || res.Skipped != 0 {
+		t.Fatalf("RunOnce = %+v, want {Synced:1 Skipped:0 Failed:1}", res)
+	}
+	if calls["access-token-good"] != 1 || calls["access-token-fail"] != 1 {
+		t.Errorf("calls = %+v, want exactly one attempt per item regardless of outcome", calls)
+	}
+
+	okItem, err := itemRepo.GetByPlaidItemID(context.Background(), userOK, "item-fail-ok")
+	if err != nil {
+		t.Fatalf("re-fetch ok item: %v", err)
+	}
+	if okItem.LastSyncStatus != "ok" {
+		t.Errorf("ok item last_sync_status = %q, want ok", okItem.LastSyncStatus)
+	}
+	failItem, err := itemRepo.GetByPlaidItemID(context.Background(), userFail, "item-fail-bad")
+	if err != nil {
+		t.Fatalf("re-fetch fail item: %v", err)
+	}
+	if failItem.LastSyncStatus != "error" {
+		t.Errorf("fail item last_sync_status = %q, want error (isolated, doesn't block item-fail-ok)", failItem.LastSyncStatus)
+	}
+}
+
+func TestSyncScheduler_RunOnce_JitterRespectsContextCancellation(t *testing.T) {
+	g := openPlaidTestDB(t)
+	itemRepo := repository.NewPlaidItemRepository(g)
+	svc := plaidsvc.NewService(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	scheduler := plaidsvc.NewSyncScheduler(svc, itemRepo).WithJitter(time.Hour)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	start := time.Now()
+	res := scheduler.RunOnce(ctx)
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Errorf("RunOnce blocked %s past a canceled context, want near-instant return", elapsed)
+	}
+	if res.Synced != 0 || res.Skipped != 0 || res.Failed != 0 {
+		t.Errorf("RunOnce on canceled context = %+v, want zero value", res)
+	}
+}
+
+func strp(s string) *string { return &s }

--- a/backend/internal/service/plaid/service_test.go
+++ b/backend/internal/service/plaid/service_test.go
@@ -93,6 +93,8 @@ func (r *fakeRepo) UpdateCursor(context.Context, int64, int64, string, time.Time
 func (r *fakeRepo) UpdateSyncStatus(context.Context, int64, int64, string, *string) error {
 	return nil
 }
+func (r *fakeRepo) ListAllActive(context.Context) ([]model.PlaidItem, error) { return nil, nil }
+func (r *fakeRepo) TryStartSync(context.Context, int64, int64) (bool, error) { return true, nil }
 
 // (fakeRepo implements PlaidItemRepository — the transaction-repo methods
 // added in #62 / #63 live on a separate interface and aren't exercised here.)

--- a/docs/ADR/0021-plaid-polling-sync.md
+++ b/docs/ADR/0021-plaid-polling-sync.md
@@ -1,0 +1,124 @@
+# ADR 0021: Scheduled Plaid Transaction Sync via Polling, Not Webhooks
+
+## Status
+Accepted (M14 / #363)
+
+## Context
+
+Through M13, Plaid transaction sync is entirely user-triggered: the initial
+Link connect flow and a manual per-institution resync button (#313). Nothing
+keeps data fresh between visits — the Product Goal for M14 (Milestone A) is
+"new transactions appear in Offbook every day without me opening the app,"
+which means Offbook needs to initiate sync on its own schedule.
+
+Plaid's usual answer for "tell me when new data is ready" is **webhooks**:
+Plaid POSTs to a URL Offbook registers when an item has new transactions.
+That doesn't fit this deployment model:
+
+- Per [ADR-0016](0016-tailscale-per-instance-deployment.md), a self-hosted
+  Offbook instance is reachable only over Tailscale (`*.ts.net`), by design —
+  there is no public inbound endpoint for Plaid's servers to reach. Standing
+  one up (a public reverse-proxy tunnel, a relay service) would reintroduce
+  exactly the attack surface the Tailscale-only model exists to avoid, for
+  every self-hoster, just to receive a "go sync now" ping.
+- Self-host simplicity is a recurring project value (see ADR-0020's job
+  runner decision): an operator running `docker compose up` on a home
+  server shouldn't also need port-forwarding, a public DNS name, or a
+  webhook-relay account.
+
+So freshness has to come from Offbook **asking** Plaid, on a schedule —
+polling — rather than Plaid telling Offbook.
+
+## Decision
+
+**Poll.** A new job, `plaid-transaction-sync`, registered on the ADR-0020
+job runner (`internal/service/jobs.Runner`, already wired in
+`cmd/server/main.go`), runs once a day and calls the existing
+`plaid.Service.SyncTransactions` for every active `plaid_item` across every
+user on the instance. No new sync logic — this is scheduling + iteration +
+error routing over the sync path #313 already built and #360 already wired
+for alerting.
+
+**Cadence and jitter:**
+- **Interval: 24 hours**, `InitialDelay: 3 minutes` (after boot work — DB
+  migrations, first HTTP requests — settles, matching the pattern the other
+  jobs in ADR-0020 already use).
+- **Jitter: a random 0–30 minute delay at the start of every run**
+  (`plaidsvc.SyncScheduler.jitter`, default 30m), not just once at process
+  boot. Rationale: an in-app job's *actual* daily fire time already varies
+  run to run purely from process restarts (deploys, host reboots), but a
+  long-lived instance that never restarts would otherwise sync at the exact
+  same wall-clock minute every day indefinitely. The jitter keeps that from
+  becoming a fixed, guessable pattern and spreads Plaid API load across the
+  window rather than a single instant — the same rationale
+  `prices.Scheduler` applies with its inter-user `pause`, one level up.
+- **Inter-item pause: 5 seconds** between items within one pass (mirrors
+  `prices.Scheduler.pause`) — keeps a multi-item instance inside Plaid's
+  per-key rate limits rather than firing every item's sync back-to-back.
+
+**Per-item isolation.** One user's Plaid failure — expired consent, a Plaid
+outage, a malformed row — must never block another user's sync. Each item's
+`SyncTransactions` call is independent; a failure is logged, counted, and the
+pass continues to the next item. This mirrors `prices.Scheduler.RunOnce`'s
+existing per-user isolation for the price-refresh job.
+
+**Concurrency guard.** `SyncTransactions` itself does not check whether an
+item is already mid-sync before flipping its status to `syncing` — historically
+safe because only one caller (the user clicking resync) could ever invoke it
+for a given item. The scheduled job breaks that assumption: a user could
+click "resync" at the same moment the daily job reaches their item. To avoid
+a race, `PlaidItemRepository.TryStartSync` does an atomic conditional update
+(`UPDATE ... WHERE last_sync_status NOT IN ('syncing','error')`) before the
+scheduler calls `SyncTransactions`; a failed CAS means "already being synced
+elsewhere" and the item is skipped this pass, not retried.
+
+**Errored items are skipped, not retried blind.** An item already sitting in
+`last_sync_status = 'error'` needs a human or a re-auth flow to fix (revoked
+consent, `ITEM_LOGIN_REQUIRED`) — retrying it daily would just retry-storm a
+broken item and re-fire the #360 notifier every day for a condition nothing
+is doing anything about. #364 (Plaid re-auth flow: Link update mode) is the
+follow-up that gives a broken item a real recovery path; until it lands, the
+scheduler leaves `error` items alone. This is an accepted, temporary gap:
+transient errors (a one-off network blip) also get stuck until #364 or a
+manual resync clears them. That trade-off is the smaller one — a stuck item
+is visible (Settings already shows `last_sync_status`/`last_sync_error`) and
+recoverable by a manual resync in the meantime; retry-storming a revoked
+item's DLQ and alert channel is worse.
+
+## Alternatives considered
+
+- **Webhooks with a public relay/tunnel** (ngrok-style, or a shared
+  Offbook-operated relay). Rejected: reintroduces a public attack surface
+  and an extra hosted dependency for every self-hoster, exactly what
+  ADR-0016 avoids. Also a second operational surface (relay uptime, relay
+  auth) for a problem polling solves with zero new infrastructure.
+- **User-configurable cadence.** Explicitly out of scope for #363 (see the
+  issue) — one fixed daily cadence is simpler to reason about and matches
+  how often a personal-finance app's data realistically changes. Revisit if
+  a real need for tighter freshness emerges.
+- **No jitter (fixed daily time).** Simpler, but produces a permanent
+  fixed-time pattern for a long-lived process and clusters load into a
+  single instant rather than spreading it. The jitter costs one `time.Duration`
+  field and a `select` — cheap enough to keep.
+
+## Consequences
+
+- New `internal/service/plaid.SyncScheduler` (mirrors
+  `prices.Scheduler`'s shape: `RunOnce`, `WithJitter`, `WithPause`) and
+  `PlaidItemRepository.ListAllActive` / `.TryStartSync` — the same
+  "one repo method exists for the periodic job to iterate cross-user"
+  pattern `UserSettingsRepository.ListAutoRefreshUserIDs` and
+  `household.RunPurge` already use. No other read path on
+  `PlaidItemRepository` crosses `user_id`.
+- `cmd/server/main.go` builds its own `plaid.Service` instance for the job —
+  the same construction `internal/router`'s `newPlaidService` and
+  `cmd/plaid-resync` already duplicate, kept separate so the job runner
+  doesn't share mutable state with the HTTP-facing service.
+- A failed item sync still routes through the existing `plaid.Notifier` seam
+  (#360) — no new alerting path, just a new caller of the existing one.
+- `last_synced_at` becomes visibly fresh in Settings/Accounts without the
+  user ever clicking resync — the existing UI already renders that field
+  (`SyncStatusPill`, Settings, Transactions); this job is what keeps it
+  current.
+- Out of scope here (per the issue): balance/holdings scheduled sync — M15
+  (#369) extends this same job to cover those; re-auth recovery — #364.

--- a/docs/ops/scheduled-jobs.md
+++ b/docs/ops/scheduled-jobs.md
@@ -13,9 +13,10 @@ must survive an app crash.
 | `household-purge` | daily | Seals in-grace member rows whose grace window elapsed and removes their `account_shares` (privacy promise, ADR-0007). Idempotent. |
 | `price-refresh` | daily | Refreshes prices/FX for users who opted in via Settings (ADR-0014 §3). |
 | `ingestion-jobs-purge` | daily | Reclaims abandoned AI-import staging payloads: an `ingestion_jobs` row left at `status='extracted'` past the retention window (7 days) has its staged `extraction` JSONB nulled and moves to a terminal `failed` state. The audit row survives (append-only). |
+| `plaid-transaction-sync` | daily, jittered 0–30min | Polls `/transactions/sync` for every active `plaid_item` across every user — a Tailscale-private host can't receive Plaid webhooks ([ADR-0021](../ADR/0021-plaid-polling-sync.md)). Per-item isolated; skips items already mid-sync or in `error` status (needs #364's re-auth flow first). No-op when Plaid isn't configured on this instance. |
 | `disk-space-check` | every 6h | Alerts when free disk space on `DISK_CHECK_PATH` (default `/`) drops below `LOW_DISK_THRESHOLD_PCT` (default 10%). |
 
-Each runs ~1 minute after boot, then every 24h, and stops on clean shutdown.
+Each runs ~1 to 3 minutes after boot, then on its interval, and stops on clean shutdown.
 
 ## How to see when a job last ran
 


### PR DESCRIPTION
Closes #363

## Summary
- Adds a `plaid-transaction-sync` job on the M13 job runner (ADR-0020): once a day, jittered 0–30min, drains every active `plaid_item` across every user via the existing `SyncTransactions` path — no new sync logic, just scheduling + iteration + error routing.
- A Tailscale-private host can't receive Plaid webhooks (ADR-0016), so freshness comes from polling instead. Full rationale, cadence, and jitter design in new [ADR-0021](docs/ADR/0021-plaid-polling-sync.md).
- Per-item isolation (mirrors `prices.Scheduler`): one item's failure never blocks another's, and failures still route through the existing #360 notifier seam via `SyncTransactions`'s own error path.
- New `PlaidItemRepository.TryStartSync` is an atomic CAS that skips an item already mid-sync (concurrent manual resync) or sitting in `error` status — retrying an errored item blind would retry-storm it daily until #364's re-auth flow lands.
- New `PlaidItemRepository.ListAllActive` is the one cross-user read this job needs, following the same pattern `UserSettingsRepository.ListAutoRefreshUserIDs` and `household.RunPurge` already use for their own periodic jobs.
- `docs/ops/scheduled-jobs.md` updated with the new job row.

## Test plan
- [x] New integration tests in `backend/internal/service/plaid/scheduler_integration_test.go`: multi-item/multi-user sync, skip-already-syncing/error items, per-item failure isolation, jitter respects context cancellation.
- [x] `command make verify` green from `backend/`: vet, lint, full test suite (incl. new scheduler tests), contract-check, schema-check, migration round-trip.
- [x] Frontend lint/test/build green (no frontend changes needed — `last_synced_at` is already rendered by `SyncStatusPill`/Settings/Transactions, so this job just keeps that value current).

🤖 Generated with [Claude Code](https://claude.com/claude-code)